### PR TITLE
Run macro tests by default in local test workflow

### DIFF
--- a/.github/workflows/macro-tests.yml
+++ b/.github/workflows/macro-tests.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: macos-15
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
-      INNODI_RUN_MACRO_TESTS: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,8 @@
 
 ## Build, Test, and Development Commands
 - `swift build`: Build all targets (library, macros, CLI).
-- `swift test`: Run test suites (SwiftTesting); macro tests are CI-only.
-- `swift test --filter InnoDIMacrosTests`: Run macro tests when enabled in CI with `INNODI_RUN_MACRO_TESTS=1`.
+- `swift test`: Run all SwiftTesting suites, including macro tests.
+- `swift test --filter InnoDIMacrosTests`: Run only macro-focused tests.
 - `swift run InnoDI-DependencyGraph --root /path/to/project`: Generate dependency graph from DI containers.
 
 ## Coding Style & Naming Conventions

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -131,7 +131,7 @@ Run:
 swift test
 ```
 
-### 4) Macro Expansion Tests (CI-only by default)
+### 4) Macro Expansion Tests
 
 ```swift
 import SwiftSyntaxMacros
@@ -177,8 +177,8 @@ final class DIContainerMacroTests: XCTestCase {
 }
 ```
 
-Run (CI-style):
+Run:
 
 ```bash
-INNODI_RUN_MACRO_TESTS=1 swift test --filter InnoDIMacrosTests
+swift test --filter InnoDIMacrosTests
 ```

--- a/Tests/InnoDIMacrosTests/DIContainerMacroTests.swift
+++ b/Tests/InnoDIMacrosTests/DIContainerMacroTests.swift
@@ -1,4 +1,3 @@
-import Foundation
 import InnoDICore
 import SwiftParser
 import SwiftSyntax
@@ -7,7 +6,6 @@ import Testing
 
 @testable import InnoDIMacros
 
-@Suite(.enabled(if: ProcessInfo.processInfo.environment["INNODI_RUN_MACRO_TESTS"] == "1"))
 struct DIContainerMacroTests {
     @Test
     func parseProvideAttributes() throws {


### PR DESCRIPTION
## Summary
- remove environment gating from InnoDIMacrosTests so macro test suite runs in default swift test
- update repository guidance docs to reflect default local macro test execution
- simplify macro test CI workflow by removing obsolete INNODI_RUN_MACRO_TESTS env var

## Validation
- swift test

Closes #8