### PR TITLE
InnoDI의 상태 소유권 원칙을 README에 문서화

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 
 A Swift Macro-based Dependency Injection library for clean, type-safe DI containers.
 
+## State Ownership
+
+InnoDI is a **static dependency graph and scope validation** framework.
+
+- Use `DIScope` to describe construction lifetime.
+- Use DAG validation and diagnostics to catch graph problems early.
+- Do not treat container resolution as a runtime state machine.
+
+Across the InnoSquad stack, runtime state transitions belong in `InnoFlow`,
+navigation transitions belong in `InnoRouter`, and transport/session lifecycle
+belongs in `InnoNetwork`.
+
 ## Features
 
 - **Compile-time safety**: Macro-based validation catches errors at build time


### PR DESCRIPTION
## 개요
- InnoDI가 런타임 상태머신 계층이 아니라 정적 dependency graph validator라는 점을 README에 명시했습니다.
- InnoSquad 프레임워크군에서 InnoDI가 소유해야 할 책임과 소유하지 않아야 할 책임을 문서로 정리했습니다.

## 주요 변경사항
- README에 `State Ownership` 섹션을 추가했습니다.
- scope/lifecycle semantics는 enum + graph validation으로 유지하고, container runtime state machine은 도입하지 않는 방향을 문서화했습니다.
- InnoFlow / InnoRouter / InnoNetwork와의 역할 경계를 명시했습니다.

## 기대 효과
- 프레임워크 간 상태 소유권 경계가 더 명확해집니다.
- DI 계층에 오토마타 추상화를 과도하게 끌어들이는 설계 혼선을 줄일 수 있습니다.

## 검증
- 문서 변경만 포함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * README에 새로운 "State Ownership" 섹션이 추가되었습니다. InnoDI의 정적 의존성 그래프 및 범위 검증 프레임워크와 런타임 상태 전환에 대한 가이드를 포함합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->