### PR TITLE
Prepare 3.0 OSS release

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -31,11 +31,13 @@ jobs:
           swift --version
 
       - name: Run Framework Comparison Benchmarks
-        run: Benchmarks/compare.sh --compile-iterations 5 --runtime-runs 5 --runtime-iterations 100000
+        run: Benchmarks/compare.sh --preset local --compile-iterations 5 --runtime-runs 5 --runtime-iterations 100000
 
       - name: Upload Benchmark Artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: innodi-benchmarks
-          path: Benchmarks/results/*.json
+          path: |
+            Benchmarks/results/*.json
+            Benchmarks/results/*.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,110 @@
+name: Release Gate
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release-gate:
+    runs-on: macos-26
+    timeout-minutes: 240
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: |
+          if [[ -d /Applications/Xcode_26.2.app/Contents/Developer ]]; then
+            DEVELOPER_DIR=/Applications/Xcode_26.2.app/Contents/Developer
+          elif [[ -d /Applications/Xcode_26.3.app/Contents/Developer ]]; then
+            DEVELOPER_DIR=/Applications/Xcode_26.3.app/Contents/Developer
+          elif [[ -d /Applications/Xcode_26.1.1.app/Contents/Developer ]]; then
+            DEVELOPER_DIR=/Applications/Xcode_26.1.1.app/Contents/Developer
+          else
+            echo "No supported Xcode 26.x installation found under /Applications."
+            ls -1 /Applications | grep '^Xcode' || true
+            exit 1
+          fi
+          sudo xcode-select -s "$DEVELOPER_DIR"
+          xcodebuild -version
+          swift --version
+
+      - name: Run Main Test Suite
+        run: swift test
+
+      - name: Test SwiftUI Example
+        run: |
+          cd Examples/SwiftUIExample
+          swift build
+          swift test
+
+      - name: Test Preview Injection Example
+        run: |
+          cd Examples/PreviewInjectionExample
+          swift build
+          swift test
+
+      - name: Validate Global DAG
+        run: swift run InnoDI-DependencyGraph --root . --validate-dag
+
+      - name: Run Validation Benchmark (CI preset)
+        run: Benchmarks/run-validation-bench.sh --preset ci
+
+      - name: Generate Validation Compare Artifacts (non-blocking)
+        continue-on-error: true
+        run: Benchmarks/compare.sh --preset ci --compile-iterations 1 --runtime-runs 1 --runtime-iterations 1000 --validation-runs 1 --sizes 10
+
+      - name: Generate DocC
+        run: Tools/generate-docc.sh
+
+      - name: Package DocC Artifact
+        run: |
+          mkdir -p .build/docc
+          tar -C .build/docc -czf .build/docc/innodi-docc.tar.gz InnoDI
+
+      - name: Upload Release Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: innodi-release-gate
+          path: |
+            Benchmarks/results/*.json
+            Benchmarks/results/*.md
+            .build/docc/innodi-docc.tar.gz
+
+  publish-release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: release-gate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download Release Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: innodi-release-gate
+          path: release-assets
+
+      - name: Prepare Release Notes
+        run: |
+          chmod +x Tools/extract-release-notes.sh
+          Tools/extract-release-notes.sh "${GITHUB_REF_NAME}" > release-notes.md
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          body_path: release-notes.md
+          fail_on_unmatched_files: false
+          files: |
+            release-assets/**/*.json
+            release-assets/**/*.md
+            release-assets/**/*.tar.gz

--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -2,30 +2,59 @@
 
 This directory contains performance benchmark scaffolding for InnoDI.
 
-## Scenarios
+## Presets
 
-- `10` dependencies
-- `50` dependencies
-- `100` dependencies
-- `250` dependencies
+- `local`: default exploratory runs with broader iteration counts
+- `ci`: lower-noise, lower-cost preset intended for regression gating in CI
 
 ## Run
 
 ```bash
 Benchmarks/run-compile-bench.sh
 Benchmarks/run-runtime-bench.sh
-Benchmarks/compare.sh
+Benchmarks/run-validation-bench.sh --preset ci
+Benchmarks/compare.sh --preset ci
 ```
 
-## Output
+Update the validation baseline only after an intentional performance change:
 
-Results are written as JSON:
+```bash
+Benchmarks/compare.sh --preset ci --update-validation-baseline
+```
+
+## Outputs
+
+Core benchmark outputs:
 
 - `Benchmarks/results/compile.json`
 - `Benchmarks/results/runtime.json`
+- `Benchmarks/results/validation.json`
 - `Benchmarks/results/compare.json`
+
+Validation regression outputs:
+
+- `Benchmarks/validation-performance-baseline.json`
+- `Benchmarks/results/validation-compare.json`
+- `Benchmarks/results/validation-compare.md`
+
+## Validation Benchmark Contract
+
+Validation benchmarks track:
+
+- graph scan wall time
+- coordinator cold-run wall time
+- coordinator warm cache-hit wall time
+- cache reason distribution summary
+
+`compare.sh` uses the validation baseline and threshold to decide pass/fail:
+
+- baseline within threshold: exit `0`
+- threshold exceeded: exit non-zero and list offending metrics
+- baseline update mode: refreshes the tracked validation baseline without gating
 
 ## Notes
 
 - InnoDI measurements are active.
 - Needle/SafeDI entries are scaffolded as non-blocking comparison slots and marked `skipped` until scenario generators are added.
+- Validation benchmarks split graph scan, coordinator cold run, coordinator warm cache hit, and cache invalidation scenarios.
+- Result and baseline JSON files are versioned schemas; update them intentionally and document schema changes in the release process.

--- a/Benchmarks/compare.sh
+++ b/Benchmarks/compare.sh
@@ -4,45 +4,109 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 COMPILE_RESULT="$ROOT_DIR/Benchmarks/results/compile.json"
 RUNTIME_RESULT="$ROOT_DIR/Benchmarks/results/runtime.json"
+VALIDATION_RESULT="$ROOT_DIR/Benchmarks/results/validation.json"
 COMPARE_RESULT="$ROOT_DIR/Benchmarks/results/compare.json"
+VALIDATION_COMPARE_RESULT="$ROOT_DIR/Benchmarks/results/validation-compare.json"
+VALIDATION_COMPARE_SUMMARY="$ROOT_DIR/Benchmarks/results/validation-compare.md"
+VALIDATION_BASELINE="$ROOT_DIR/Benchmarks/validation-performance-baseline.json"
 
+PRESET="local"
 COMPILE_ITERATIONS=5
 RUNTIME_RUNS=5
 RUNTIME_ITERATIONS=100000
+VALIDATION_RUNS=3
+VALIDATION_THRESHOLD_PERCENT=20
+UPDATE_VALIDATION_BASELINE=0
 SIZES_CSV=""
+
+COMPILE_ITERATIONS_EXPLICIT=0
+RUNTIME_RUNS_EXPLICIT=0
+RUNTIME_ITERATIONS_EXPLICIT=0
+VALIDATION_RUNS_EXPLICIT=0
+SIZES_EXPLICIT=0
 
 usage() {
   cat <<USAGE
 Usage: Benchmarks/compare.sh [options]
 
 Options:
-  --compile-iterations <N>   Compile benchmark iterations (default: 5)
-  --runtime-runs <N>         Runtime benchmark sample runs (default: 5)
-  --runtime-iterations <N>   Runtime resolve iterations per sample (default: 100000)
-  --sizes <CSV>              Comma-separated scenario sizes (default: 10,50,100,250)
-  --output <PATH>            Comparison output JSON (default: Benchmarks/results/compare.json)
+  --preset <local|ci>            Benchmark preset (default: local)
+  --compile-iterations <N>       Compile benchmark iterations
+  --runtime-runs <N>             Runtime benchmark sample runs
+  --runtime-iterations <N>       Runtime resolve iterations per sample
+  --validation-runs <N>          Validation benchmark sample runs
+  --validation-baseline <PATH>   Validation baseline JSON path
+  --validation-threshold <PCT>   Allowed validation regression percentage
+  --update-validation-baseline   Overwrite validation baseline with current run
+  --sizes <CSV>                  Comma-separated scenario sizes
+  --output <PATH>                Aggregate comparison output JSON
+  --help                         Show this help
 USAGE
+}
+
+require_option_value() {
+  local option="$1"
+  local value="${2:-}"
+  if [[ -z "$value" || "$value" == -* ]]; then
+    echo "Missing value for $option" >&2
+    usage
+    exit 1
+  fi
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --preset)
+      require_option_value "$1" "${2:-}"
+      PRESET="${2:-}"
+      shift 2
+      ;;
     --compile-iterations)
+      require_option_value "$1" "${2:-}"
       COMPILE_ITERATIONS="$2"
+      COMPILE_ITERATIONS_EXPLICIT=1
       shift 2
       ;;
     --runtime-runs)
+      require_option_value "$1" "${2:-}"
       RUNTIME_RUNS="$2"
+      RUNTIME_RUNS_EXPLICIT=1
       shift 2
       ;;
     --runtime-iterations)
+      require_option_value "$1" "${2:-}"
       RUNTIME_ITERATIONS="$2"
+      RUNTIME_ITERATIONS_EXPLICIT=1
       shift 2
       ;;
+    --validation-runs)
+      require_option_value "$1" "${2:-}"
+      VALIDATION_RUNS="$2"
+      VALIDATION_RUNS_EXPLICIT=1
+      shift 2
+      ;;
+    --validation-baseline)
+      require_option_value "$1" "${2:-}"
+      VALIDATION_BASELINE="$2"
+      shift 2
+      ;;
+    --validation-threshold)
+      require_option_value "$1" "${2:-}"
+      VALIDATION_THRESHOLD_PERCENT="$2"
+      shift 2
+      ;;
+    --update-validation-baseline)
+      UPDATE_VALIDATION_BASELINE=1
+      shift
+      ;;
     --sizes)
+      require_option_value "$1" "${2:-}"
       SIZES_CSV="$2"
+      SIZES_EXPLICIT=1
       shift 2
       ;;
     --output)
+      require_option_value "$1" "${2:-}"
       COMPARE_RESULT="$2"
       shift 2
       ;;
@@ -58,39 +122,286 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-mkdir -p "$(dirname "$COMPARE_RESULT")"
+case "$PRESET" in
+  local)
+    ;;
+  ci)
+    [[ "$COMPILE_ITERATIONS_EXPLICIT" -eq 0 ]] && COMPILE_ITERATIONS=2
+    [[ "$RUNTIME_RUNS_EXPLICIT" -eq 0 ]] && RUNTIME_RUNS=2
+    [[ "$RUNTIME_ITERATIONS_EXPLICIT" -eq 0 ]] && RUNTIME_ITERATIONS=10000
+    [[ "$VALIDATION_RUNS_EXPLICIT" -eq 0 ]] && VALIDATION_RUNS=1
+    [[ "$SIZES_EXPLICIT" -eq 0 ]] && SIZES_CSV="10,50"
+    ;;
+  *)
+    echo "--preset must be one of: local, ci" >&2
+    exit 1
+    ;;
+esac
+
+mkdir -p "$(dirname "$COMPARE_RESULT")" "$(dirname "$VALIDATION_BASELINE")"
 
 declare -a compile_args=(--iterations "$COMPILE_ITERATIONS" --output "$COMPILE_RESULT")
 declare -a runtime_args=(--runs "$RUNTIME_RUNS" --iterations "$RUNTIME_ITERATIONS" --output "$RUNTIME_RESULT")
+declare -a validation_args=(--preset "$PRESET" --runs "$VALIDATION_RUNS" --output "$VALIDATION_RESULT")
 if [[ -n "$SIZES_CSV" ]]; then
   compile_args+=(--sizes "$SIZES_CSV")
   runtime_args+=(--sizes "$SIZES_CSV")
+  validation_args+=(--sizes "$SIZES_CSV")
 fi
 
 "$ROOT_DIR/Benchmarks/run-compile-bench.sh" "${compile_args[@]}"
 "$ROOT_DIR/Benchmarks/run-runtime-bench.sh" "${runtime_args[@]}"
+"$ROOT_DIR/Benchmarks/run-validation-bench.sh" "${validation_args[@]}"
+
+set +e
+python3 - \
+  "$VALIDATION_RESULT" \
+  "$VALIDATION_BASELINE" \
+  "$VALIDATION_COMPARE_RESULT" \
+  "$VALIDATION_COMPARE_SUMMARY" \
+  "$VALIDATION_THRESHOLD_PERCENT" \
+  "$UPDATE_VALIDATION_BASELINE" \
+  <<'PY'
+import json
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+validation_path = Path(sys.argv[1])
+baseline_path = Path(sys.argv[2])
+compare_json_path = Path(sys.argv[3])
+compare_md_path = Path(sys.argv[4])
+threshold_percent = float(sys.argv[5])
+update_baseline = sys.argv[6] == "1"
+
+current = json.loads(validation_path.read_text())
+
+def now():
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+def mean_metric(entry, key):
+    return float(entry[key]["mean"])
+
+def scenario_key(entry):
+    return (entry["scenario"], int(entry["size"]))
+
+def reason_map(entry):
+    return dict(entry.get("warm_reason_frequencies", {}))
+
+def write_outputs(payload, markdown):
+    compare_json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    compare_md_path.write_text(markdown)
+
+def reason_label(reason):
+    labels = {
+        "cache-hit-metadata": "metadata cache hit",
+        "cache-hit-content-hash": "content-hash reuse",
+        "cache-miss-content-changed": "content changed",
+        "cache-miss-new-file": "new file detected",
+        "cache-miss-deleted-file": "file deleted",
+        "cache-miss-manifest-version": "manifest version changed",
+        "live-run-custom-init-failure": "custom init validation failed",
+        "live-run-dag-validation": "live DAG validation ran",
+    }
+    return labels.get(reason, reason)
+
+current_by_key = {scenario_key(entry): entry for entry in current["validation"]}
+
+if update_baseline or not baseline_path.exists():
+    shutil.copyfile(validation_path, baseline_path)
+    payload = {
+        "schema_version": 1,
+        "generated_at": now(),
+        "status": "baseline-updated",
+        "baseline_path": str(baseline_path.name),
+        "threshold_percent": threshold_percent,
+        "current_signature": {
+            "swift_version": current.get("swift_version", ""),
+            "preset": current.get("config", {}).get("preset", ""),
+        },
+        "offending_metrics": [],
+        "comparisons": [],
+        "reason_frequency_deltas": [],
+    }
+    markdown = """# Validation Benchmark Compare\n\n- Status: `baseline-updated`\n- Validation baseline was created or refreshed from the current benchmark run.\n- Re-run `Benchmarks/compare.sh` without `--update-validation-baseline` to enable regression gating.\n"""
+    write_outputs(payload, markdown)
+    sys.exit(0)
+
+baseline = json.loads(baseline_path.read_text())
+baseline_by_key = {scenario_key(entry): entry for entry in baseline["validation"]}
+
+comparisons = []
+offending_metrics = []
+reason_frequency_deltas = []
+
+for key in sorted(set(current_by_key) | set(baseline_by_key)):
+    current_entry = current_by_key.get(key)
+    baseline_entry = baseline_by_key.get(key)
+    scenario_name = key[0]
+    size = key[1]
+    if current_entry is None:
+      continue
+    if baseline_entry is None:
+      offending_metrics.append({
+          "scenario": scenario_name,
+          "size": size,
+          "metric": "scenario-presence",
+          "status": "new-scenario",
+      })
+      continue
+
+    for metric_key, metric_label in (
+        ("graph_scan", "graph-scan-ms"),
+        ("coordinator_cold", "coordinator-cold-ms"),
+        ("coordinator_warm", "coordinator-warm-ms"),
+    ):
+        current_mean = mean_metric(current_entry, metric_key)
+        baseline_mean = mean_metric(baseline_entry, metric_key)
+        delta = 0.0 if baseline_mean == 0 else ((current_mean - baseline_mean) / baseline_mean) * 100.0
+        status = "pass" if delta <= threshold_percent else "fail"
+        comparison = {
+            "scenario": scenario_name,
+            "size": size,
+            "metric": metric_label,
+            "current_mean_ms": round(current_mean, 3),
+            "baseline_mean_ms": round(baseline_mean, 3),
+            "delta_percent": round(delta, 2),
+            "status": status,
+        }
+        comparisons.append(comparison)
+        if status == "fail":
+            offending_metrics.append(comparison)
+
+    baseline_reasons = reason_map(baseline_entry)
+    current_reasons = reason_map(current_entry)
+    for reason in sorted(set(baseline_reasons) | set(current_reasons)):
+        reason_frequency_deltas.append({
+            "scenario": scenario_name,
+            "size": size,
+            "reason": reason,
+            "reason_label": reason_label(reason),
+            "baseline_count": int(baseline_reasons.get(reason, 0)),
+            "current_count": int(current_reasons.get(reason, 0)),
+        })
+
+for key in sorted(set(baseline_by_key) - set(current_by_key)):
+    offending_metrics.append({
+        "scenario": key[0],
+        "size": key[1],
+        "metric": "scenario-presence",
+        "status": "missing-from-current-run",
+    })
+
+status = "fail" if offending_metrics else "pass"
+payload = {
+    "schema_version": 1,
+    "generated_at": now(),
+    "status": status,
+    "baseline_path": baseline_path.name,
+    "threshold_percent": threshold_percent,
+    "current_signature": {
+        "swift_version": current.get("swift_version", ""),
+        "preset": current.get("config", {}).get("preset", ""),
+    },
+    "baseline_signature": {
+        "swift_version": baseline.get("swift_version", ""),
+        "preset": baseline.get("config", {}).get("preset", ""),
+    },
+    "offending_metrics": offending_metrics,
+    "comparisons": comparisons,
+    "reason_frequency_deltas": reason_frequency_deltas,
+}
+
+lines = [
+    "# Validation Benchmark Compare",
+    "",
+    f"- Status: `{status}`",
+    f"- Threshold: `{threshold_percent:.2f}%`",
+    f"- Current preset: `{current.get('config', {}).get('preset', '')}`",
+    f"- Baseline preset: `{baseline.get('config', {}).get('preset', '')}`",
+    f"- Current Swift: `{current.get('swift_version', '')}`",
+    f"- Baseline Swift: `{baseline.get('swift_version', '')}`",
+    "",
+    "## Timing Comparison",
+    "",
+    "| Scenario | Size | Metric | Baseline | Current | Delta | Status |",
+    "|---|---:|---|---:|---:|---:|---|",
+]
+for comparison in comparisons:
+    lines.append(
+        f"| `{comparison['scenario']}` | `{comparison['size']}` | `{comparison['metric']}` | "
+        f"`{comparison['baseline_mean_ms']:.3f} ms` | `{comparison['current_mean_ms']:.3f} ms` | "
+        f"`{comparison['delta_percent']:.2f}%` | `{comparison['status']}` |"
+    )
+
+lines.extend(["", "## Cache Reason Distribution", ""])
+if reason_frequency_deltas:
+    lines.extend([
+        "| Scenario | Size | Reason | Baseline | Current |",
+        "|---|---:|---|---:|---:|",
+    ])
+    for delta in reason_frequency_deltas:
+        lines.append(
+            f"| `{delta['scenario']}` | `{delta['size']}` | `{delta['reason_label']}` | "
+            f"`{delta['baseline_count']}` | `{delta['current_count']}` |"
+        )
+else:
+    lines.append("- none")
+
+lines.extend(["", "## Offending Metrics", ""])
+if offending_metrics:
+    for item in offending_metrics:
+        lines.append(
+            f"- `{item['scenario']}` size `{item['size']}` metric `{item['metric']}` status `{item['status']}`"
+        )
+else:
+    lines.append("- none")
+
+write_outputs(payload, "\n".join(lines) + "\n")
+sys.exit(1 if status == "fail" else 0)
+PY
+validation_compare_status=$?
+set -e
 
 generated_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
 if command -v jq >/dev/null 2>&1; then
   jq -n \
     --arg generated_at "$generated_at" \
+    --arg preset "$PRESET" \
+    --arg validation_baseline "$(basename "$VALIDATION_BASELINE")" \
     --slurpfile compile "$COMPILE_RESULT" \
     --slurpfile runtime "$RUNTIME_RESULT" \
+    --slurpfile validation "$VALIDATION_RESULT" \
+    --slurpfile validation_compare "$VALIDATION_COMPARE_RESULT" \
     '{
+      schema_version: 1,
       generated_at: $generated_at,
+      preset: $preset,
+      validation_baseline: $validation_baseline,
       compile: $compile[0],
-      runtime: $runtime[0]
+      runtime: $runtime[0],
+      validation: $validation[0],
+      validation_compare: $validation_compare[0]
     }' >"$COMPARE_RESULT"
 else
   cat >"$COMPARE_RESULT" <<JSON
 {
+  "schema_version": 1,
   "generated_at": "$generated_at",
+  "preset": "$PRESET",
+  "validation_baseline": "$(basename "$VALIDATION_BASELINE")",
   "compile_path": "$(basename "$COMPILE_RESULT")",
   "runtime_path": "$(basename "$RUNTIME_RESULT")",
+  "validation_path": "$(basename "$VALIDATION_RESULT")",
+  "validation_compare_path": "$(basename "$VALIDATION_COMPARE_RESULT")",
   "note": "Install jq for fully inlined compare output."
 }
 JSON
 fi
 
 echo "[bench-compare] Wrote $COMPARE_RESULT"
+echo "[bench-compare] Wrote $VALIDATION_COMPARE_RESULT"
+echo "[bench-compare] Wrote $VALIDATION_COMPARE_SUMMARY"
+exit "$validation_compare_status"

--- a/Benchmarks/run-validation-bench.sh
+++ b/Benchmarks/run-validation-bench.sh
@@ -1,0 +1,555 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+GENERATED_ROOT="$ROOT_DIR/.build/generated-benchmarks/validation"
+RESULT_PATH="$ROOT_DIR/Benchmarks/results/validation.json"
+SCHEMA_VERSION=1
+PRESET="local"
+RUNS=3
+SIZES=(10 50 100)
+SIZES_CSV=""
+RUNS_EXPLICIT=0
+SIZES_EXPLICIT=0
+
+usage() {
+  cat <<USAGE
+Usage: Benchmarks/run-validation-bench.sh [options]
+
+Options:
+  --preset <local|ci>  Benchmark preset (default: local)
+  --runs <N>          Number of measured runs per scenario (default: 3)
+  --sizes <CSV>       Comma-separated scenario sizes (default: 10,50,100)
+  --output <PATH>     Output JSON file (default: Benchmarks/results/validation.json)
+USAGE
+}
+
+require_option_value() {
+  local option="$1"
+  local value="${2:-}"
+  if [[ -z "$value" || "$value" == -* ]]; then
+    echo "Missing value for $option" >&2
+    usage
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --preset)
+      require_option_value "$1" "${2:-}"
+      PRESET="${2:-}"
+      shift 2
+      ;;
+    --runs)
+      require_option_value "$1" "${2:-}"
+      RUNS="${2:-}"
+      RUNS_EXPLICIT=1
+      shift 2
+      ;;
+    --sizes)
+      require_option_value "$1" "${2:-}"
+      SIZES_CSV="${2:-}"
+      SIZES_EXPLICIT=1
+      shift 2
+      ;;
+    --output)
+      require_option_value "$1" "${2:-}"
+      RESULT_PATH="${2:-}"
+      shift 2
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+case "$PRESET" in
+  local)
+    if [[ "$RUNS_EXPLICIT" -eq 0 ]]; then
+      RUNS=3
+    fi
+    if [[ "$SIZES_EXPLICIT" -eq 0 ]]; then
+      SIZES=(10 50 100)
+    fi
+    ;;
+  ci)
+    if [[ "$RUNS_EXPLICIT" -eq 0 ]]; then
+      RUNS=1
+    fi
+    if [[ "$SIZES_EXPLICIT" -eq 0 ]]; then
+      SIZES=(10 50)
+    fi
+    ;;
+  *)
+    echo "--preset must be one of: local, ci" >&2
+    exit 1
+    ;;
+esac
+
+if ! [[ "$RUNS" =~ ^[0-9]+$ ]] || [[ "$RUNS" -lt 1 ]]; then
+  echo "--runs must be a positive integer" >&2
+  exit 1
+fi
+
+if [[ -n "$SIZES_CSV" ]]; then
+  IFS=',' read -r -a raw_sizes <<<"$SIZES_CSV"
+  declare -a parsed_sizes=()
+  for size in "${raw_sizes[@]}"; do
+    size="${size//[[:space:]]/}"
+    if ! [[ "$size" =~ ^[0-9]+$ ]] || [[ "$size" -lt 1 ]]; then
+      echo "--sizes must be a comma-separated list of positive integers" >&2
+      exit 1
+    fi
+    parsed_sizes+=("$size")
+  done
+  SIZES=("${parsed_sizes[@]}")
+fi
+
+mkdir -p "$GENERATED_ROOT" "$(dirname "$RESULT_PATH")"
+TMP_RESULTS="$(mktemp)"
+trap 'rm -f "$TMP_RESULTS"' EXIT
+
+discover_executable() {
+  local name="$1"
+  local build_root="$ROOT_DIR/.build"
+  local candidates=(
+    "$build_root/debug/$name"
+    "$build_root/arm64-apple-macosx/debug/$name"
+    "$build_root/x86_64-apple-macosx/debug/$name"
+  )
+
+  for candidate in "${candidates[@]}"; do
+    if [[ -x "$candidate" ]]; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done
+
+  while IFS= read -r candidate; do
+    if [[ -x "$candidate" ]]; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done < <(find "$build_root" -path "*/debug/$name" -type f 2>/dev/null | sort)
+
+  echo "Failed to locate executable $name" >&2
+  exit 1
+}
+
+measure_ms() {
+  local started ended status
+  local stdout_file stderr_file
+  stdout_file="$(mktemp)"
+  stderr_file="$(mktemp)"
+  started="$(perl -MTime::HiRes=time -e 'printf "%.0f\n", time()*1000000000')"
+  set +e
+  "$@" >"$stdout_file" 2>"$stderr_file"
+  status=$?
+  set -e
+  ended="$(perl -MTime::HiRes=time -e 'printf "%.0f\n", time()*1000000000')"
+  rm -f "$stdout_file" "$stderr_file"
+  local elapsed
+  elapsed="$(awk -v s="$started" -v e="$ended" 'BEGIN { printf "%.3f", (e - s) / 1000000.0 }')"
+  printf '%s %s\n' "$elapsed" "$status"
+}
+
+write_common_models() {
+  local dir="$1"
+  cat >"$dir/Common.swift" <<'SWIFT'
+import InnoDI
+
+struct Config {
+    let seed: Int
+}
+
+struct LeafService {
+    let seed: Int
+}
+SWIFT
+}
+
+generate_nested_containers() {
+  local dir="$1"
+  local size="$2"
+  write_common_models "$dir"
+  {
+    cat <<'SWIFT'
+import InnoDI
+
+@DIContainer(root: true)
+struct AppContainer {
+    @Provide(.input)
+    var config: Config
+
+SWIFT
+    local i prev
+    for ((i = 1; i <= size; i++)); do
+      if [[ "$i" -eq 1 ]]; then
+        echo "    @Provide(.shared, factory: Feature1.Container(config: config), concrete: true)"
+      else
+        prev=$((i - 1))
+        echo "    @Provide(.shared, factory: Feature$i.Container(feature: feature$prev), concrete: true)"
+      fi
+      echo "    var feature$i: Feature$i.Container"
+      echo
+      cat <<SWIFT
+enum Feature$i {
+    @DIContainer
+    struct Container {
+SWIFT
+      if [[ "$i" -eq 1 ]]; then
+        echo "        @Provide(.input)"
+        echo "        var config: Config"
+        echo
+        echo "        @Provide(.shared, factory: LeafService(seed: config.seed), concrete: true)"
+        echo "        var leaf: LeafService"
+      else
+        prev=$((i - 1))
+        echo "        @Provide(.input)"
+        echo "        var feature: Feature$prev.Container"
+        echo
+        echo "        @Provide(.shared, factory: feature, concrete: true)"
+        echo "        var upstream: Feature$prev.Container"
+      fi
+      cat <<'SWIFT'
+    }
+}
+
+SWIFT
+    done
+    cat <<'SWIFT'
+}
+SWIFT
+  } >"$dir/NestedContainers.swift"
+}
+
+generate_typealias_heavy() {
+  local dir="$1"
+  local size="$2"
+  write_common_models "$dir"
+  {
+    cat <<'SWIFT'
+import InnoDI
+
+enum Namespace {
+    @DIContainer
+    struct LiveContainer {
+        @Provide(.input)
+        var config: Config
+    }
+
+    typealias ActiveContainer = LiveContainer
+}
+
+typealias RootAlias = Namespace.ActiveContainer
+
+@DIContainer(root: true)
+struct AppContainer {
+    @Provide(.input)
+    var config: Config
+
+SWIFT
+    local i
+    for ((i = 1; i <= size; i++)); do
+      echo "    @Provide(.shared, factory: RootAlias(config: config), concrete: true)"
+      echo "    var feature$i: Namespace.LiveContainer"
+      echo
+    done
+    cat <<'SWIFT'
+}
+SWIFT
+  } >"$dir/TypeAliasHeavy.swift"
+}
+
+generate_duplicate_display_names() {
+  local dir="$1"
+  write_common_models "$dir"
+  cat >"$dir/DuplicateDisplayNames.swift" <<'SWIFT'
+import InnoDI
+
+@DIContainer(root: true)
+struct AppContainer {
+    @Provide(.input)
+    var config: Config
+
+    @Provide(.shared, factory: FeatureContainer(config: config), concrete: true)
+    var feature: FeatureContainer
+}
+
+enum FeatureA {
+    @DIContainer
+    struct FeatureContainer {
+        @Provide(.input)
+        var config: Config
+    }
+}
+
+enum FeatureB {
+    @DIContainer
+    struct FeatureContainer {
+        @Provide(.input)
+        var config: Config
+    }
+}
+SWIFT
+}
+
+generate_unresolved_semantic() {
+  local dir="$1"
+  write_common_models "$dir"
+  cat >"$dir/UnresolvedSemantic.swift" <<'SWIFT'
+import InnoDI
+
+@DIContainer(root: true)
+struct AppContainer {
+    @Provide(.input)
+    var config: Config
+
+    @Provide(.shared, factory: MissingFeatureContainer(config: config), concrete: true)
+    var feature: MissingFeatureContainer
+}
+SWIFT
+}
+
+mutate_content_change() {
+  local dir="$1"
+  python3 - "$dir/NestedContainers.swift" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+text = path.read_text()
+path.write_text(text.replace("LeafService(seed: config.seed)", "LeafService(seed: config.seed + 1)", 1))
+PY
+}
+
+mutate_add_delete() {
+  local dir="$1"
+  cat >"$dir/AddedFile.swift" <<'SWIFT'
+struct AddedFileMarker {
+    let value = 1
+}
+SWIFT
+  rm -f "$dir/Common.swift"
+}
+
+record_json_line() {
+  local scenario="$1"
+  local size="$2"
+  local run="$3"
+  local graph_ms="$4"
+  local graph_exit="$5"
+  local cold_ms="$6"
+  local cold_exit="$7"
+  local warm_ms="$8"
+  local warm_exit="$9"
+  local mutation_kind="${10}"
+  local mutation_ms="${11}"
+  local mutation_exit="${12}"
+  local artifact_path="${13}"
+
+  python3 - "$scenario" "$size" "$run" "$graph_ms" "$graph_exit" "$cold_ms" "$cold_exit" "$warm_ms" "$warm_exit" "$mutation_kind" "$mutation_ms" "$mutation_exit" "$artifact_path" >>"$TMP_RESULTS" <<'PY'
+import json, sys
+from pathlib import Path
+
+scenario, size, run, graph_ms, graph_exit, cold_ms, cold_exit, warm_ms, warm_exit, mutation_kind, mutation_ms, mutation_exit, artifact_path = sys.argv[1:]
+artifact = {}
+path = Path(artifact_path)
+if path.exists():
+    artifact = json.loads(path.read_text())
+
+entry = {
+    "scenario": scenario,
+    "size": int(size),
+    "run": int(run),
+    "graph_scan_ms": float(graph_ms),
+    "graph_exit_code": int(graph_exit),
+    "coordinator_cold_ms": float(cold_ms),
+    "coordinator_cold_exit_code": int(cold_exit),
+    "coordinator_warm_ms": float(warm_ms),
+    "coordinator_warm_exit_code": int(warm_exit),
+    "warm_reason_codes": artifact.get("reasonCodes", []),
+    "warm_human_summary_source": artifact.get("humanSummarySource"),
+    "warm_file_changes": artifact.get("fileChanges", {}),
+}
+if mutation_kind != "none":
+    entry["mutation"] = {
+        "kind": mutation_kind,
+        "ms": float(mutation_ms),
+        "exit_code": int(mutation_exit),
+    }
+print(json.dumps(entry))
+PY
+}
+
+echo "[validation-bench] Building validation tools"
+(cd "$ROOT_DIR" && swift build --product InnoDI-DependencyGraph --product InnoDI-DAGValidationCoordinator >/dev/null)
+
+GRAPH_TOOL="$(discover_executable InnoDI-DependencyGraph)"
+COORDINATOR_TOOL="$(discover_executable InnoDI-DAGValidationCoordinator)"
+
+run_scenario() {
+  local scenario="$1"
+  local size="$2"
+  local run="$3"
+  local dir="$GENERATED_ROOT/$scenario-$size-run$run"
+  local state_dir="$dir/state"
+  local output_cold="$dir/output-cold"
+  local output_warm="$dir/output-warm"
+  local output_mutation="$dir/output-mutation"
+  rm -rf "$dir"
+  mkdir -p "$dir" "$state_dir" "$output_cold" "$output_warm" "$output_mutation"
+
+  case "$scenario" in
+    nested-containers)
+      generate_nested_containers "$dir" "$size"
+      ;;
+    typealias-heavy)
+      generate_typealias_heavy "$dir" "$size"
+      ;;
+    duplicate-display-names)
+      generate_duplicate_display_names "$dir"
+      ;;
+    unresolved-semantic)
+      generate_unresolved_semantic "$dir"
+      ;;
+    cache-content-change)
+      generate_nested_containers "$dir" "$size"
+      ;;
+    cache-add-delete)
+      generate_nested_containers "$dir" "$size"
+      ;;
+    *)
+      echo "Unknown scenario: $scenario" >&2
+      exit 1
+      ;;
+  esac
+
+  read -r graph_ms graph_exit < <(measure_ms "$GRAPH_TOOL" --root "$dir" --validate-dag)
+  read -r cold_ms cold_exit < <(measure_ms "$COORDINATOR_TOOL" --root "$dir" --tool "$GRAPH_TOOL" --state-dir "$state_dir" --output-dir "$output_cold")
+  read -r warm_ms warm_exit < <(measure_ms "$COORDINATOR_TOOL" --root "$dir" --tool "$GRAPH_TOOL" --state-dir "$state_dir" --output-dir "$output_warm")
+
+  local mutation_kind="none"
+  local mutation_ms="0.000"
+  local mutation_exit="0"
+  if [[ "$scenario" == "cache-content-change" ]]; then
+    mutate_content_change "$dir"
+    mutation_kind="content-change"
+    read -r mutation_ms mutation_exit < <(measure_ms "$COORDINATOR_TOOL" --root "$dir" --tool "$GRAPH_TOOL" --state-dir "$state_dir" --output-dir "$output_mutation")
+  elif [[ "$scenario" == "cache-add-delete" ]]; then
+    mutate_add_delete "$dir"
+    mutation_kind="add-delete"
+    read -r mutation_ms mutation_exit < <(measure_ms "$COORDINATOR_TOOL" --root "$dir" --tool "$GRAPH_TOOL" --state-dir "$state_dir" --output-dir "$output_mutation")
+  fi
+
+  record_json_line \
+    "$scenario" "$size" "$run" \
+    "$graph_ms" "$graph_exit" \
+    "$cold_ms" "$cold_exit" \
+    "$warm_ms" "$warm_exit" \
+    "$mutation_kind" "$mutation_ms" "$mutation_exit" \
+    "$output_warm/dag-validation-metrics.json"
+}
+
+SCENARIOS=(
+  "nested-containers"
+  "typealias-heavy"
+  "duplicate-display-names"
+  "unresolved-semantic"
+  "cache-content-change"
+  "cache-add-delete"
+)
+
+for size in "${SIZES[@]}"; do
+  for scenario in "${SCENARIOS[@]}"; do
+    for ((run = 1; run <= RUNS; run++)); do
+      echo "[validation-bench] scenario=$scenario size=$size run=$run"
+      run_scenario "$scenario" "$size" "$run"
+    done
+  done
+done
+
+python3 - "$TMP_RESULTS" "$RESULT_PATH" "$RUNS" "${SIZES[*]}" "$PRESET" <<'PY'
+import json, sys
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+import subprocess
+
+tmp_path, result_path, runs, sizes, preset = sys.argv[1:]
+rows = [json.loads(line) for line in Path(tmp_path).read_text().splitlines() if line.strip()]
+grouped = defaultdict(list)
+for row in rows:
+    grouped[(row["scenario"], row["size"])].append(row)
+
+def stats(values):
+    if not values:
+        return {"iterations": 0, "mean": 0, "min": 0, "max": 0, "samples": []}
+    return {
+        "iterations": len(values),
+        "mean": round(sum(values) / len(values), 3),
+        "min": round(min(values), 3),
+        "max": round(max(values), 3),
+        "samples": [round(v, 3) for v in values],
+    }
+
+def sorted_unique(sequence):
+    return sorted(set(sequence))
+
+def shell(command):
+    try:
+        return subprocess.check_output(command, text=True).strip()
+    except Exception:
+        return ""
+
+scenarios = []
+for (scenario, size), items in sorted(grouped.items()):
+    warm_reason_counter = Counter()
+    mutation_kind = None
+    mutation_samples = []
+    for item in items:
+        warm_reason_counter.update(item.get("warm_reason_codes", []))
+        if "mutation" in item:
+            mutation_kind = item["mutation"]["kind"]
+            mutation_samples.append(item["mutation"]["ms"])
+
+    scenarios.append({
+        "scenario": scenario,
+        "size": size,
+        "graph_scan": stats([item["graph_scan_ms"] for item in items]),
+        "coordinator_cold": stats([item["coordinator_cold_ms"] for item in items]),
+        "coordinator_warm": stats([item["coordinator_warm_ms"] for item in items]),
+        "graph_exit_codes": sorted({item["graph_exit_code"] for item in items}),
+        "warm_exit_codes": sorted({item["coordinator_warm_exit_code"] for item in items}),
+        "warm_reason_frequencies": dict(sorted(warm_reason_counter.items())),
+        "warm_file_change_sample": items[0].get("warm_file_changes", {}),
+        "mutation": None if mutation_kind is None else {
+            "kind": mutation_kind,
+            "stats": stats(mutation_samples),
+            "exit_codes": sorted({item["mutation"]["exit_code"] for item in items if "mutation" in item}),
+        }
+    })
+
+payload = {
+    "kind": "validation",
+    "schema_version": 1,
+    "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "swift_version": shell(["swift", "--version"]).splitlines()[0] if shell(["swift", "--version"]) else "",
+    "config": {
+        "preset": preset,
+        "runs": int(runs),
+        "sizes": [int(value) for value in sizes.split()],
+        "scenarios": sorted_unique(row["scenario"] for row in rows),
+    },
+    "validation": scenarios,
+}
+Path(result_path).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+PY
+
+echo "[validation-bench] Wrote $RESULT_PATH"

--- a/Benchmarks/validation-performance-baseline.json
+++ b/Benchmarks/validation-performance-baseline.json
@@ -1,0 +1,668 @@
+{
+  "config": {
+    "preset": "ci",
+    "runs": 1,
+    "scenarios": [
+      "cache-add-delete",
+      "cache-content-change",
+      "duplicate-display-names",
+      "nested-containers",
+      "typealias-heavy",
+      "unresolved-semantic"
+    ],
+    "sizes": [
+      10,
+      50
+    ]
+  },
+  "generated_at": "2026-03-19T05:57:09Z",
+  "kind": "validation",
+  "schema_version": 1,
+  "swift_version": "Apple Swift version 6.2.4 (swiftlang-6.2.4.1.4 clang-1700.6.4.2)",
+  "validation": [
+    {
+      "coordinator_cold": {
+        "iterations": 1,
+        "max": 128.114,
+        "mean": 128.114,
+        "min": 128.114,
+        "samples": [
+          128.114
+        ]
+      },
+      "coordinator_warm": {
+        "iterations": 1,
+        "max": 21.223,
+        "mean": 21.223,
+        "min": 21.223,
+        "samples": [
+          21.223
+        ]
+      },
+      "graph_exit_codes": [
+        3
+      ],
+      "graph_scan": {
+        "iterations": 1,
+        "max": 40.518,
+        "mean": 40.518,
+        "min": 40.518,
+        "samples": [
+          40.518
+        ]
+      },
+      "mutation": {
+        "exit_codes": [
+          3
+        ],
+        "kind": "add-delete",
+        "stats": {
+          "iterations": 1,
+          "max": 111.088,
+          "mean": 111.088,
+          "min": 111.088,
+          "samples": [
+            111.088
+          ]
+        }
+      },
+      "scenario": "cache-add-delete",
+      "size": 10,
+      "warm_exit_codes": [
+        3
+      ],
+      "warm_file_change_sample": {
+        "contentHashReusedFiles": [],
+        "deletedFiles": [],
+        "fallbackMatchedReferences": [],
+        "newFiles": [],
+        "reparsedFiles": []
+      },
+      "warm_reason_frequencies": {
+        "cache-hit-metadata": 1,
+        "live-run-dag-validation": 1
+      }
+    },
+    {
+      "coordinator_cold": {
+        "iterations": 1,
+        "max": 329.774,
+        "mean": 329.774,
+        "min": 329.774,
+        "samples": [
+          329.774
+        ]
+      },
+      "coordinator_warm": {
+        "iterations": 1,
+        "max": 19.788,
+        "mean": 19.788,
+        "min": 19.788,
+        "samples": [
+          19.788
+        ]
+      },
+      "graph_exit_codes": [
+        3
+      ],
+      "graph_scan": {
+        "iterations": 1,
+        "max": 106.303,
+        "mean": 106.303,
+        "min": 106.303,
+        "samples": [
+          106.303
+        ]
+      },
+      "mutation": {
+        "exit_codes": [
+          3
+        ],
+        "kind": "add-delete",
+        "stats": {
+          "iterations": 1,
+          "max": 232.945,
+          "mean": 232.945,
+          "min": 232.945,
+          "samples": [
+            232.945
+          ]
+        }
+      },
+      "scenario": "cache-add-delete",
+      "size": 50,
+      "warm_exit_codes": [
+        3
+      ],
+      "warm_file_change_sample": {
+        "contentHashReusedFiles": [],
+        "deletedFiles": [],
+        "fallbackMatchedReferences": [],
+        "newFiles": [],
+        "reparsedFiles": []
+      },
+      "warm_reason_frequencies": {
+        "cache-hit-metadata": 1,
+        "live-run-dag-validation": 1
+      }
+    },
+    {
+      "coordinator_cold": {
+        "iterations": 1,
+        "max": 129.535,
+        "mean": 129.535,
+        "min": 129.535,
+        "samples": [
+          129.535
+        ]
+      },
+      "coordinator_warm": {
+        "iterations": 1,
+        "max": 20.292,
+        "mean": 20.292,
+        "min": 20.292,
+        "samples": [
+          20.292
+        ]
+      },
+      "graph_exit_codes": [
+        3
+      ],
+      "graph_scan": {
+        "iterations": 1,
+        "max": 35.957,
+        "mean": 35.957,
+        "min": 35.957,
+        "samples": [
+          35.957
+        ]
+      },
+      "mutation": {
+        "exit_codes": [
+          3
+        ],
+        "kind": "content-change",
+        "stats": {
+          "iterations": 1,
+          "max": 140.98,
+          "mean": 140.98,
+          "min": 140.98,
+          "samples": [
+            140.98
+          ]
+        }
+      },
+      "scenario": "cache-content-change",
+      "size": 10,
+      "warm_exit_codes": [
+        3
+      ],
+      "warm_file_change_sample": {
+        "contentHashReusedFiles": [],
+        "deletedFiles": [],
+        "fallbackMatchedReferences": [],
+        "newFiles": [],
+        "reparsedFiles": []
+      },
+      "warm_reason_frequencies": {
+        "cache-hit-metadata": 1,
+        "live-run-dag-validation": 1
+      }
+    },
+    {
+      "coordinator_cold": {
+        "iterations": 1,
+        "max": 482.492,
+        "mean": 482.492,
+        "min": 482.492,
+        "samples": [
+          482.492
+        ]
+      },
+      "coordinator_warm": {
+        "iterations": 1,
+        "max": 21.043,
+        "mean": 21.043,
+        "min": 21.043,
+        "samples": [
+          21.043
+        ]
+      },
+      "graph_exit_codes": [
+        3
+      ],
+      "graph_scan": {
+        "iterations": 1,
+        "max": 179.402,
+        "mean": 179.402,
+        "min": 179.402,
+        "samples": [
+          179.402
+        ]
+      },
+      "mutation": {
+        "exit_codes": [
+          3
+        ],
+        "kind": "content-change",
+        "stats": {
+          "iterations": 1,
+          "max": 338.147,
+          "mean": 338.147,
+          "min": 338.147,
+          "samples": [
+            338.147
+          ]
+        }
+      },
+      "scenario": "cache-content-change",
+      "size": 50,
+      "warm_exit_codes": [
+        3
+      ],
+      "warm_file_change_sample": {
+        "contentHashReusedFiles": [],
+        "deletedFiles": [],
+        "fallbackMatchedReferences": [],
+        "newFiles": [],
+        "reparsedFiles": []
+      },
+      "warm_reason_frequencies": {
+        "cache-hit-metadata": 1,
+        "live-run-dag-validation": 1
+      }
+    },
+    {
+      "coordinator_cold": {
+        "iterations": 1,
+        "max": 98.396,
+        "mean": 98.396,
+        "min": 98.396,
+        "samples": [
+          98.396
+        ]
+      },
+      "coordinator_warm": {
+        "iterations": 1,
+        "max": 20.861,
+        "mean": 20.861,
+        "min": 20.861,
+        "samples": [
+          20.861
+        ]
+      },
+      "graph_exit_codes": [
+        3
+      ],
+      "graph_scan": {
+        "iterations": 1,
+        "max": 22.086,
+        "mean": 22.086,
+        "min": 22.086,
+        "samples": [
+          22.086
+        ]
+      },
+      "mutation": null,
+      "scenario": "duplicate-display-names",
+      "size": 10,
+      "warm_exit_codes": [
+        3
+      ],
+      "warm_file_change_sample": {
+        "contentHashReusedFiles": [],
+        "deletedFiles": [],
+        "fallbackMatchedReferences": [],
+        "newFiles": [],
+        "reparsedFiles": []
+      },
+      "warm_reason_frequencies": {
+        "cache-hit-metadata": 1,
+        "live-run-dag-validation": 1
+      }
+    },
+    {
+      "coordinator_cold": {
+        "iterations": 1,
+        "max": 96.529,
+        "mean": 96.529,
+        "min": 96.529,
+        "samples": [
+          96.529
+        ]
+      },
+      "coordinator_warm": {
+        "iterations": 1,
+        "max": 20.435,
+        "mean": 20.435,
+        "min": 20.435,
+        "samples": [
+          20.435
+        ]
+      },
+      "graph_exit_codes": [
+        3
+      ],
+      "graph_scan": {
+        "iterations": 1,
+        "max": 20.443,
+        "mean": 20.443,
+        "min": 20.443,
+        "samples": [
+          20.443
+        ]
+      },
+      "mutation": null,
+      "scenario": "duplicate-display-names",
+      "size": 50,
+      "warm_exit_codes": [
+        3
+      ],
+      "warm_file_change_sample": {
+        "contentHashReusedFiles": [],
+        "deletedFiles": [],
+        "fallbackMatchedReferences": [],
+        "newFiles": [],
+        "reparsedFiles": []
+      },
+      "warm_reason_frequencies": {
+        "cache-hit-metadata": 1,
+        "live-run-dag-validation": 1
+      }
+    },
+    {
+      "coordinator_cold": {
+        "iterations": 1,
+        "max": 131.605,
+        "mean": 131.605,
+        "min": 131.605,
+        "samples": [
+          131.605
+        ]
+      },
+      "coordinator_warm": {
+        "iterations": 1,
+        "max": 20.963,
+        "mean": 20.963,
+        "min": 20.963,
+        "samples": [
+          20.963
+        ]
+      },
+      "graph_exit_codes": [
+        3
+      ],
+      "graph_scan": {
+        "iterations": 1,
+        "max": 35.059,
+        "mean": 35.059,
+        "min": 35.059,
+        "samples": [
+          35.059
+        ]
+      },
+      "mutation": null,
+      "scenario": "nested-containers",
+      "size": 10,
+      "warm_exit_codes": [
+        3
+      ],
+      "warm_file_change_sample": {
+        "contentHashReusedFiles": [],
+        "deletedFiles": [],
+        "fallbackMatchedReferences": [],
+        "newFiles": [],
+        "reparsedFiles": []
+      },
+      "warm_reason_frequencies": {
+        "cache-hit-metadata": 1,
+        "live-run-dag-validation": 1
+      }
+    },
+    {
+      "coordinator_cold": {
+        "iterations": 1,
+        "max": 335.672,
+        "mean": 335.672,
+        "min": 335.672,
+        "samples": [
+          335.672
+        ]
+      },
+      "coordinator_warm": {
+        "iterations": 1,
+        "max": 21.82,
+        "mean": 21.82,
+        "min": 21.82,
+        "samples": [
+          21.82
+        ]
+      },
+      "graph_exit_codes": [
+        3
+      ],
+      "graph_scan": {
+        "iterations": 1,
+        "max": 102.382,
+        "mean": 102.382,
+        "min": 102.382,
+        "samples": [
+          102.382
+        ]
+      },
+      "mutation": null,
+      "scenario": "nested-containers",
+      "size": 50,
+      "warm_exit_codes": [
+        3
+      ],
+      "warm_file_change_sample": {
+        "contentHashReusedFiles": [],
+        "deletedFiles": [],
+        "fallbackMatchedReferences": [],
+        "newFiles": [],
+        "reparsedFiles": []
+      },
+      "warm_reason_frequencies": {
+        "cache-hit-metadata": 1,
+        "live-run-dag-validation": 1
+      }
+    },
+    {
+      "coordinator_cold": {
+        "iterations": 1,
+        "max": 117.791,
+        "mean": 117.791,
+        "min": 117.791,
+        "samples": [
+          117.791
+        ]
+      },
+      "coordinator_warm": {
+        "iterations": 1,
+        "max": 20.648,
+        "mean": 20.648,
+        "min": 20.648,
+        "samples": [
+          20.648
+        ]
+      },
+      "graph_exit_codes": [
+        0
+      ],
+      "graph_scan": {
+        "iterations": 1,
+        "max": 30.333,
+        "mean": 30.333,
+        "min": 30.333,
+        "samples": [
+          30.333
+        ]
+      },
+      "mutation": null,
+      "scenario": "typealias-heavy",
+      "size": 10,
+      "warm_exit_codes": [
+        0
+      ],
+      "warm_file_change_sample": {
+        "contentHashReusedFiles": [],
+        "deletedFiles": [],
+        "fallbackMatchedReferences": [],
+        "newFiles": [],
+        "reparsedFiles": []
+      },
+      "warm_reason_frequencies": {
+        "cache-hit-metadata": 1,
+        "live-run-dag-validation": 1
+      }
+    },
+    {
+      "coordinator_cold": {
+        "iterations": 1,
+        "max": 180.305,
+        "mean": 180.305,
+        "min": 180.305,
+        "samples": [
+          180.305
+        ]
+      },
+      "coordinator_warm": {
+        "iterations": 1,
+        "max": 20.269,
+        "mean": 20.269,
+        "min": 20.269,
+        "samples": [
+          20.269
+        ]
+      },
+      "graph_exit_codes": [
+        0
+      ],
+      "graph_scan": {
+        "iterations": 1,
+        "max": 64.544,
+        "mean": 64.544,
+        "min": 64.544,
+        "samples": [
+          64.544
+        ]
+      },
+      "mutation": null,
+      "scenario": "typealias-heavy",
+      "size": 50,
+      "warm_exit_codes": [
+        0
+      ],
+      "warm_file_change_sample": {
+        "contentHashReusedFiles": [],
+        "deletedFiles": [],
+        "fallbackMatchedReferences": [],
+        "newFiles": [],
+        "reparsedFiles": []
+      },
+      "warm_reason_frequencies": {
+        "cache-hit-metadata": 1,
+        "live-run-dag-validation": 1
+      }
+    },
+    {
+      "coordinator_cold": {
+        "iterations": 1,
+        "max": 97.96,
+        "mean": 97.96,
+        "min": 97.96,
+        "samples": [
+          97.96
+        ]
+      },
+      "coordinator_warm": {
+        "iterations": 1,
+        "max": 19.141,
+        "mean": 19.141,
+        "min": 19.141,
+        "samples": [
+          19.141
+        ]
+      },
+      "graph_exit_codes": [
+        3
+      ],
+      "graph_scan": {
+        "iterations": 1,
+        "max": 20.736,
+        "mean": 20.736,
+        "min": 20.736,
+        "samples": [
+          20.736
+        ]
+      },
+      "mutation": null,
+      "scenario": "unresolved-semantic",
+      "size": 10,
+      "warm_exit_codes": [
+        3
+      ],
+      "warm_file_change_sample": {
+        "contentHashReusedFiles": [],
+        "deletedFiles": [],
+        "fallbackMatchedReferences": [],
+        "newFiles": [],
+        "reparsedFiles": []
+      },
+      "warm_reason_frequencies": {
+        "cache-hit-metadata": 1,
+        "live-run-dag-validation": 1
+      }
+    },
+    {
+      "coordinator_cold": {
+        "iterations": 1,
+        "max": 91.915,
+        "mean": 91.915,
+        "min": 91.915,
+        "samples": [
+          91.915
+        ]
+      },
+      "coordinator_warm": {
+        "iterations": 1,
+        "max": 19.211,
+        "mean": 19.211,
+        "min": 19.211,
+        "samples": [
+          19.211
+        ]
+      },
+      "graph_exit_codes": [
+        3
+      ],
+      "graph_scan": {
+        "iterations": 1,
+        "max": 19.939,
+        "mean": 19.939,
+        "min": 19.939,
+        "samples": [
+          19.939
+        ]
+      },
+      "mutation": null,
+      "scenario": "unresolved-semantic",
+      "size": 50,
+      "warm_exit_codes": [
+        3
+      ],
+      "warm_file_change_sample": {
+        "contentHashReusedFiles": [],
+        "deletedFiles": [],
+        "fallbackMatchedReferences": [],
+        "newFiles": [],
+        "reparsedFiles": []
+      },
+      "warm_reason_frequencies": {
+        "cache-hit-metadata": 1,
+        "live-run-dag-validation": 1
+      }
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on Keep a Changelog, adapted for the InnoDI release workflow
 
 - No unreleased entries yet.
 
-## 2.1.0
+## 3.0.0
 
 ### Added
 
@@ -22,3 +22,4 @@ The format is based on Keep a Changelog, adapted for the InnoDI release workflow
 ### Changed
 
 - Validation benchmark workflow now distinguishes local exploration from CI regression gating.
+- Promoted strict validation, semantic enforcement, and build-stage release contracts as the new major-version baseline for OSS consumers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to InnoDI should be recorded in this file.
+
+The format is based on Keep a Changelog, adapted for the InnoDI release workflow in [RELEASING.md](RELEASING.md).
+
+## Unreleased
+
+- No unreleased entries yet.
+
+## 2.1.0
+
+### Added
+
+- CI-friendly validation benchmark preset, baseline compare artifacts, and Markdown summary output.
+- Docs entrypoint guidance for `README`, `Validation`, `PolicyBoundaries`, and `ModuleWideInitDetection`.
+- Release governance documents for changelog, migration notes, and artifact schema expectations.
+- OSS repository documents for licensing, contributing, security, and community conduct.
+- Tag-based release workflow with release-gate validation checks and artifact uploads.
+- Automated GitHub Release publication that uses the matching changelog section as the release body.
+
+### Changed
+
+- Validation benchmark workflow now distinguishes local exploration from CI regression gating.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,23 @@
+# Code of Conduct
+
+## Our Standard
+
+Please keep discussion respectful, technical, and constructive.
+
+Examples of expected behavior:
+
+- assume good intent
+- give concrete feedback
+- disagree on ideas without attacking people
+- help keep the project usable for newcomers
+
+Examples of unacceptable behavior:
+
+- harassment or personal attacks
+- abusive language
+- deliberate disruption of discussion or review
+- publishing private information without permission
+
+## Enforcement
+
+Project maintainers may remove comments, close discussions, or restrict participation when behavior violates this standard.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to InnoDI
+
+Thanks for contributing.
+
+## Before Opening a PR
+
+Please keep these checks green:
+
+```bash
+swift test
+(cd Examples/SwiftUIExample && swift test)
+(cd Examples/PreviewInjectionExample && swift test)
+swift run InnoDI-DependencyGraph --root . --validate-dag
+Benchmarks/run-validation-bench.sh --preset ci
+```
+
+Update docs in the same change when behavior changes:
+
+- `README.md`
+- `README.ko.md`
+- `Sources/InnoDI/InnoDI.docc/Validation.md`
+- `Sources/InnoDI/InnoDI.docc/PolicyBoundaries.md`
+- `Sources/InnoDI/InnoDI.docc/ModuleWideInitDetection.md`
+
+## PR Expectations
+
+- Keep changes scoped and explain user-facing behavior changes.
+- Add or update tests for validation, diagnostics, graph output, or examples when behavior changes.
+- If benchmark artifacts or schema expectations change, update `RELEASING.md` and `MIGRATION.md`.
+- If performance changes intentionally, refresh the relevant baseline and call it out in the PR description.
+
+## Issues and Discussions
+
+- Use issues for reproducible bugs, missing diagnostics, or feature requests.
+- Include sample containers or CLI output when reporting graph or validation problems.

--- a/Examples/PreviewInjectionExample/Package.swift
+++ b/Examples/PreviewInjectionExample/Package.swift
@@ -15,6 +15,10 @@ let package = Package(
         .executableTarget(
             name: "PreviewInjectionExample",
             dependencies: ["InnoDI"]
+        ),
+        .testTarget(
+            name: "PreviewInjectionExampleTests",
+            dependencies: ["PreviewInjectionExample"]
         )
     ]
 )

--- a/Examples/PreviewInjectionExample/Sources/PreviewInjectionExample/main.swift
+++ b/Examples/PreviewInjectionExample/Sources/PreviewInjectionExample/main.swift
@@ -1,25 +1,141 @@
 import InnoDI
+import Observation
 import SwiftUI
 
-public protocol QuoteServiceProtocol {
-    func quote() -> String
+enum QuotePreviewError: Error, LocalizedError, Sendable {
+    case unavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable:
+            return "Preview services failed. Swap the root override or retry the load."
+        }
+    }
 }
 
-public struct LiveQuoteService: QuoteServiceProtocol {
+public protocol QuoteServiceProtocol: Sendable {
+    func quote() async throws -> String
+}
+
+public protocol QuoteMetaServiceProtocol: Sendable {
+    func byline() async throws -> String
+}
+
+public struct DelayedQuoteService: QuoteServiceProtocol {
+    let text: String
+    let delayMilliseconds: Int
+
+    public init(text: String, delayMilliseconds: Int) {
+        self.text = text
+        self.delayMilliseconds = delayMilliseconds
+    }
+
+    public func quote() async throws -> String {
+        try await Task.sleep(for: .milliseconds(delayMilliseconds))
+        return text
+    }
+}
+
+public struct DelayedQuoteMetaService: QuoteMetaServiceProtocol {
+    let text: String
+    let delayMilliseconds: Int
+
+    public init(text: String, delayMilliseconds: Int) {
+        self.text = text
+        self.delayMilliseconds = delayMilliseconds
+    }
+
+    public func byline() async throws -> String {
+        try await Task.sleep(for: .milliseconds(delayMilliseconds))
+        return text
+    }
+}
+
+public struct FailingQuoteService: QuoteServiceProtocol {
     public init() {}
-    public func quote() -> String { "Live environment quote" }
+
+    public func quote() async throws -> String {
+        try await Task.sleep(for: .milliseconds(80))
+        throw QuotePreviewError.unavailable
+    }
 }
 
-public struct PreviewQuoteService: QuoteServiceProtocol {
+public struct FailingQuoteMetaService: QuoteMetaServiceProtocol {
     public init() {}
-    public func quote() -> String { "Preview environment quote" }
+
+    public func byline() async throws -> String {
+        throw QuotePreviewError.unavailable
+    }
 }
 
-public final class QuoteViewModel: ObservableObject {
-    @Published private(set) var quote: String
+private struct QuoteServiceKey: EnvironmentKey {
+    static let defaultValue: any QuoteServiceProtocol = DelayedQuoteService(
+        text: "Missing quote service",
+        delayMilliseconds: 0
+    )
+}
 
-    public init(service: any QuoteServiceProtocol) {
-        self.quote = service.quote()
+private struct QuoteMetaServiceKey: EnvironmentKey {
+    static let defaultValue: any QuoteMetaServiceProtocol = DelayedQuoteMetaService(
+        text: "Inject quote meta service at the root boundary",
+        delayMilliseconds: 0
+    )
+}
+
+extension EnvironmentValues {
+    var quoteService: any QuoteServiceProtocol {
+        get { self[QuoteServiceKey.self] }
+        set { self[QuoteServiceKey.self] = newValue }
+    }
+
+    var quoteMetaService: any QuoteMetaServiceProtocol {
+        get { self[QuoteMetaServiceKey.self] }
+        set { self[QuoteMetaServiceKey.self] = newValue }
+    }
+}
+
+public enum QuoteFeaturePhase: Sendable {
+    case idle
+    case loading
+    case loaded(quote: String, byline: String)
+    case failed(String)
+}
+
+@MainActor
+@Observable
+public final class QuoteFeatureModel {
+    public var phase: QuoteFeaturePhase = .idle
+    private var loadTask: Task<Void, Never>?
+
+    public init() {}
+
+    public func load(
+        quoteService: any QuoteServiceProtocol,
+        quoteMetaService: any QuoteMetaServiceProtocol
+    ) {
+        cancel()
+        phase = .loading
+
+        loadTask = Task { [weak self] in
+            do {
+                async let quote = quoteService.quote()
+                async let byline = quoteMetaService.byline()
+                let resolvedQuote = try await quote
+                let resolvedByline = try await byline
+
+                guard !Task.isCancelled, let self else { return }
+                self.phase = .loaded(quote: resolvedQuote, byline: resolvedByline)
+            } catch {
+                guard !Task.isCancelled, let self else { return }
+                let message = (error as? LocalizedError)?.errorDescription ?? "Unknown preview error."
+                self.phase = .failed(message)
+            }
+        }
+    }
+
+    public func cancel() {
+        loadTask?.cancel()
+        loadTask = nil
     }
 }
 
@@ -28,39 +144,178 @@ public struct QuoteContainer {
     @Provide(.input)
     var quoteService: any QuoteServiceProtocol
 
-    @Provide(
-        .transient,
-        factory: { (quoteService: any QuoteServiceProtocol) in
-            QuoteViewModel(service: quoteService)
-        },
-        concrete: true
-    )
-    var viewModel: QuoteViewModel
+    @Provide(.input)
+    var quoteMetaService: any QuoteMetaServiceProtocol
 }
 
-public struct QuoteView: View {
-    @ObservedObject var viewModel: QuoteViewModel
+public struct QuoteLoadingSkeletonView: View {
+    public init() {}
 
-    public init(viewModel: QuoteViewModel) {
-        self.viewModel = viewModel
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            RoundedRectangle(cornerRadius: 14)
+                .fill(.quaternary)
+                .frame(height: 28)
+            RoundedRectangle(cornerRadius: 12)
+                .fill(.quaternary.opacity(0.7))
+                .frame(height: 18)
+            RoundedRectangle(cornerRadius: 12)
+                .fill(.quaternary.opacity(0.55))
+                .frame(height: 18)
+        }
+        .redacted(reason: .placeholder)
+    }
+}
+
+public struct QuoteCardView: View {
+    let phase: QuoteFeaturePhase
+    let retry: () -> Void
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            switch phase {
+            case .idle, .loading:
+                QuoteLoadingSkeletonView()
+            case let .loaded(quote, byline):
+                Text(quote)
+                    .font(.title3.weight(.semibold))
+                Text(byline)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            case let .failed(message):
+                Text("Preview override failed")
+                    .font(.headline)
+                Text(message)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                Button("Retry", action: retry)
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(20)
+        .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 18))
+    }
+}
+
+public struct QuoteFeatureRootView: View {
+    @Environment(\.quoteService) private var quoteService
+    @Environment(\.quoteMetaService) private var quoteMetaService
+    @State private var model = QuoteFeatureModel()
+
+    public init() {}
+
+    public var body: some View {
+        QuoteCardView(phase: model.phase) {
+            model.load(quoteService: quoteService, quoteMetaService: quoteMetaService)
+        }
+        .padding(24)
+        .task {
+            model.load(quoteService: quoteService, quoteMetaService: quoteMetaService)
+        }
+        .onDisappear {
+            model.cancel()
+        }
+    }
+}
+
+public struct QuoteAppRootView: View {
+    let title: String
+    let container: QuoteContainer
+
+    public init(title: String, container: QuoteContainer) {
+        self.title = title
+        self.container = container
     }
 
     public var body: some View {
-        Text(viewModel.quote)
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.headline)
+                .padding(.horizontal, 24)
+                .padding(.top, 24)
+            QuoteFeatureRootView()
+        }
+        .environment(\.quoteService, container.quoteService)
+        .environment(\.quoteMetaService, container.quoteMetaService)
+    }
+}
+
+public struct QuotePreviewMatrixView: View {
+    public init() {}
+
+    public var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                ForEach(QuotePreviewScenario.allCases, id: \.title) { scenario in
+                    QuoteAppRootView(
+                        title: scenario.title,
+                        container: scenario.container
+                    )
+                }
+            }
+            .padding(.vertical, 24)
+        }
+    }
+}
+
+public struct QuotePreviewScenario: CaseIterable {
+    public let title: String
+    public let container: QuoteContainer
+
+    public static var allCases: [QuotePreviewScenario] {
+        [
+            QuotePreviewScenario(
+                title: "Live",
+                container: QuoteContainer(
+                    quoteService: DelayedQuoteService(text: "Live environment quote", delayMilliseconds: 120),
+                    quoteMetaService: DelayedQuoteMetaService(text: "Delivered by the live feature root", delayMilliseconds: 60)
+                )
+            ),
+            QuotePreviewScenario(
+                title: "Preview",
+                container: QuoteContainer(
+                    quoteService: DelayedQuoteService(text: "Preview environment quote", delayMilliseconds: 0),
+                    quoteMetaService: DelayedQuoteMetaService(text: "Preview override injected at the root boundary", delayMilliseconds: 0)
+                )
+            ),
+            QuotePreviewScenario(
+                title: "Failure",
+                container: QuoteContainer(
+                    quoteService: FailingQuoteService(),
+                    quoteMetaService: FailingQuoteMetaService()
+                )
+            )
+        ]
     }
 }
 
 #if os(iOS)
-#Preview("Preview Injection") {
-    let container = QuoteContainer(quoteService: PreviewQuoteService())
-    QuoteView(viewModel: container.viewModel)
+#Preview("Live") {
+    let scenario = QuotePreviewScenario.allCases[0]
+    QuoteAppRootView(title: scenario.title, container: scenario.container)
+}
+
+#Preview("Preview") {
+    let scenario = QuotePreviewScenario.allCases[1]
+    QuoteAppRootView(title: scenario.title, container: scenario.container)
+}
+
+#Preview("Failure") {
+    let scenario = QuotePreviewScenario.allCases[2]
+    QuoteAppRootView(title: scenario.title, container: scenario.container)
+}
+
+#Preview("Matrix") {
+    QuotePreviewMatrixView()
 }
 #endif
 
 @main
 struct PreviewInjectionExampleMain {
     static func main() {
-        let liveContainer = QuoteContainer(quoteService: LiveQuoteService())
-        _ = QuoteView(viewModel: liveContainer.viewModel)
+        let liveScenario = QuotePreviewScenario.allCases[0]
+        _ = QuoteAppRootView(title: liveScenario.title, container: liveScenario.container)
+        _ = QuotePreviewMatrixView()
     }
 }

--- a/Examples/PreviewInjectionExample/Tests/PreviewInjectionExampleTests/PreviewInjectionExampleTests.swift
+++ b/Examples/PreviewInjectionExample/Tests/PreviewInjectionExampleTests/PreviewInjectionExampleTests.swift
@@ -1,0 +1,105 @@
+import Testing
+
+@testable import PreviewInjectionExample
+
+@Suite("PreviewInjectionExample behavior")
+struct PreviewInjectionExampleTests {
+    @Test("Quote model loads quote and byline")
+    @MainActor
+    func quoteModelLoadsSuccessState() async throws {
+        let model = QuoteFeatureModel()
+        model.load(
+            quoteService: DelayedQuoteService(text: "Loaded quote", delayMilliseconds: 0),
+            quoteMetaService: DelayedQuoteMetaService(text: "Loaded byline", delayMilliseconds: 0)
+        )
+
+        try await waitUntilQuoteLoaded(model)
+
+        guard case let .loaded(quote, byline) = model.phase else {
+            Issue.record("Expected loaded quote state.")
+            return
+        }
+        #expect(quote == "Loaded quote")
+        #expect(byline == "Loaded byline")
+    }
+
+    @Test("Quote model failure is recoverable with retry")
+    @MainActor
+    func quoteModelFailsAndRecovers() async throws {
+        let model = QuoteFeatureModel()
+        model.load(
+            quoteService: FailingQuoteService(),
+            quoteMetaService: FailingQuoteMetaService()
+        )
+        try await waitUntilQuoteFailed(model)
+
+        guard case let .failed(message) = model.phase else {
+            Issue.record("Expected failed quote phase.")
+            return
+        }
+        #expect(message.contains("Preview services failed"))
+
+        model.load(
+            quoteService: DelayedQuoteService(text: "Recovered quote", delayMilliseconds: 0),
+            quoteMetaService: DelayedQuoteMetaService(text: "Recovered byline", delayMilliseconds: 0)
+        )
+        try await waitUntilQuoteLoaded(model)
+
+        guard case let .loaded(quote, byline) = model.phase else {
+            Issue.record("Expected loaded phase after retry.")
+            return
+        }
+        #expect(quote == "Recovered quote")
+        #expect(byline == "Recovered byline")
+    }
+
+    @Test("Quote model cancellation leaves loading phase untouched")
+    @MainActor
+    func quoteModelCancelPreventsTerminalWrite() async throws {
+        let model = QuoteFeatureModel()
+        model.load(
+            quoteService: DelayedQuoteService(text: "Slow quote", delayMilliseconds: 150),
+            quoteMetaService: DelayedQuoteMetaService(text: "Slow byline", delayMilliseconds: 150)
+        )
+        model.cancel()
+        try await Task.sleep(for: .milliseconds(220))
+
+        guard case .loading = model.phase else {
+            Issue.record("Expected loading phase to remain after cancellation.")
+            return
+        }
+    }
+
+    @Test("Preview scenarios expose live preview and failure matrix inputs")
+    func previewScenariosExposeMatrixInputs() {
+        #expect(QuotePreviewScenario.allCases.count == 3)
+
+        let titles = QuotePreviewScenario.allCases.map(\.title)
+        #expect(titles == ["Live", "Preview", "Failure"])
+
+        let typeNames = QuotePreviewScenario.allCases.map { String(describing: type(of: $0.container.quoteService)) }
+        #expect(typeNames == ["DelayedQuoteService", "DelayedQuoteService", "FailingQuoteService"])
+    }
+}
+
+@MainActor
+private func waitUntilQuoteLoaded(_ model: QuoteFeatureModel) async throws {
+    for _ in 0..<20 {
+        if case .loaded = model.phase {
+            return
+        }
+        try await Task.sleep(for: .milliseconds(20))
+    }
+    Issue.record("Timed out waiting for loaded quote phase.")
+}
+
+@MainActor
+private func waitUntilQuoteFailed(_ model: QuoteFeatureModel) async throws {
+    for _ in 0..<20 {
+        if case .failed = model.phase {
+            return
+        }
+        try await Task.sleep(for: .milliseconds(20))
+    }
+    Issue.record("Timed out waiting for failed quote phase.")
+}

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -35,11 +35,14 @@ Build:
 ```bash
 cd Examples/SwiftUIExample
 swift build
+swift test
 ```
 
 Highlights:
-- `@DIContainer` for SwiftUI view model wiring
-- Init override with mock service injection
+- a single feature root demonstrates navigation, loading skeletons, recoverable errors, retry, and cancellation
+- multiple services are injected through `Environment` while local `@Observable` state owns screen behavior
+- live, mock, and failing roots still use generated init overrides
+- lightweight behavior tests validate model transitions and root composition scenarios
 
 ### 4) TCA Integration Example
 
@@ -67,11 +70,14 @@ Build:
 ```bash
 cd Examples/PreviewInjectionExample
 swift build
+swift test
 ```
 
 Highlights:
-- `#Preview` with lightweight preview-only container input
-- Preview and live dependencies separated by injection
+- `#Preview` keeps live and preview roots while adding a richer preview matrix
+- multiple root overrides render loading, ready, and failure states without changing feature code
+- local `@Observable` state still owns async loading, retry, and cancellation
+- lightweight behavior tests validate retry, cancellation, and preview matrix inputs
 
 ### 6) Existing CLI Output Formats
 

--- a/Examples/SwiftUIExample/Package.swift
+++ b/Examples/SwiftUIExample/Package.swift
@@ -15,6 +15,10 @@ let package = Package(
         .executableTarget(
             name: "SwiftUIExample",
             dependencies: ["InnoDI"]
+        ),
+        .testTarget(
+            name: "SwiftUIExampleTests",
+            dependencies: ["SwiftUIExample"]
         )
     ]
 )

--- a/Examples/SwiftUIExample/Sources/SwiftUIExample/main.swift
+++ b/Examples/SwiftUIExample/Sources/SwiftUIExample/main.swift
@@ -1,25 +1,168 @@
 import InnoDI
+import Observation
 import SwiftUI
 
-protocol GreetingServiceProtocol {
-    func message() -> String
+struct DashboardSummary: Sendable {
+    let headline: String
+    let status: String
+}
+
+struct ActivityHighlight: Identifiable, Hashable, Sendable {
+    let id: String
+    let title: String
+    let detail: String
+}
+
+protocol GreetingServiceProtocol: Sendable {
+    func loadSummary(for username: String) async throws -> DashboardSummary
+}
+
+protocol ActivityServiceProtocol: Sendable {
+    func loadHighlights(for username: String) async throws -> [ActivityHighlight]
+}
+
+enum ExampleServiceError: Error, LocalizedError, Sendable {
+    case offline
+
+    var errorDescription: String? {
+        switch self {
+        case .offline:
+            return "The live feature root is offline. Retry with a different environment override."
+        }
+    }
 }
 
 struct LiveGreetingService: GreetingServiceProtocol {
-    let username: String
-    func message() -> String { "Hello, \(username)!" }
+    func loadSummary(for username: String) async throws -> DashboardSummary {
+        try await Task.sleep(for: .milliseconds(160))
+        return DashboardSummary(
+            headline: "Hello, \(username)! Your feature root is live.",
+            status: "Two environment services are composed before the first screen appears."
+        )
+    }
+}
+
+struct LiveActivityService: ActivityServiceProtocol {
+    func loadHighlights(for username: String) async throws -> [ActivityHighlight] {
+        try await Task.sleep(for: .milliseconds(120))
+        return [
+            ActivityHighlight(id: "inject", title: "Inject services", detail: "Both services are provided at the root boundary for \(username)."),
+            ActivityHighlight(id: "load", title: "Load asynchronously", detail: "The local @Observable model owns the initial task and cancellation."),
+            ActivityHighlight(id: "navigate", title: "Navigate deeper", detail: "NavigationStack and destination views stay independent of the container.")
+        ]
+    }
 }
 
 struct MockGreetingService: GreetingServiceProtocol {
-    let text: String
-    func message() -> String { text }
+    let headline: String
+    let status: String
+
+    func loadSummary(for username: String) async throws -> DashboardSummary {
+        DashboardSummary(headline: headline, status: status)
+    }
 }
 
-final class GreetingViewModel: ObservableObject {
-    @Published private(set) var text: String
+struct MockActivityService: ActivityServiceProtocol {
+    let highlights: [ActivityHighlight]
 
-    init(service: any GreetingServiceProtocol) {
-        text = service.message()
+    func loadHighlights(for username: String) async throws -> [ActivityHighlight] {
+        highlights
+    }
+}
+
+struct FailingGreetingService: GreetingServiceProtocol {
+    func loadSummary(for username: String) async throws -> DashboardSummary {
+        try await Task.sleep(for: .milliseconds(90))
+        throw ExampleServiceError.offline
+    }
+}
+
+private struct GreetingServiceKey: EnvironmentKey {
+    static let defaultValue: any GreetingServiceProtocol = MockGreetingService(
+        headline: "Missing greeting service",
+        status: "Inject a root service through EnvironmentValues.greetingService."
+    )
+}
+
+private struct ActivityServiceKey: EnvironmentKey {
+    static let defaultValue: any ActivityServiceProtocol = MockActivityService(
+        highlights: [
+            ActivityHighlight(
+                id: "missing",
+                title: "Missing activity service",
+                detail: "Inject a root service through EnvironmentValues.activityService."
+            )
+        ]
+    )
+}
+
+extension EnvironmentValues {
+    var greetingService: any GreetingServiceProtocol {
+        get { self[GreetingServiceKey.self] }
+        set { self[GreetingServiceKey.self] = newValue }
+    }
+
+    var activityService: any ActivityServiceProtocol {
+        get { self[ActivityServiceKey.self] }
+        set { self[ActivityServiceKey.self] = newValue }
+    }
+}
+
+struct DashboardContent: Sendable {
+    let summary: DashboardSummary
+    let highlights: [ActivityHighlight]
+}
+
+enum DashboardLoadState: Sendable {
+    case idle
+    case loading
+    case loaded(DashboardContent)
+    case failed(String)
+}
+
+@MainActor
+@Observable
+final class DashboardFeatureModel {
+    var navigationTitle = "InnoDI Feature Root"
+    var state: DashboardLoadState = .idle
+
+    private var loadTask: Task<Void, Never>?
+
+    func load(
+        username: String,
+        greetingService: any GreetingServiceProtocol,
+        activityService: any ActivityServiceProtocol
+    ) {
+        cancel()
+        state = .loading
+
+        loadTask = Task { [weak self] in
+            do {
+                async let summary = greetingService.loadSummary(for: username)
+                async let highlights = activityService.loadHighlights(for: username)
+                let content = DashboardContent(summary: try await summary, highlights: try await highlights)
+
+                guard !Task.isCancelled, let self else { return }
+                self.state = .loaded(content)
+            } catch {
+                guard !Task.isCancelled, let self else { return }
+                let message = (error as? LocalizedError)?.errorDescription ?? "An unknown feature-root error occurred."
+                self.state = .failed(message)
+            }
+        }
+    }
+
+    func retry(
+        username: String,
+        greetingService: any GreetingServiceProtocol,
+        activityService: any ActivityServiceProtocol
+    ) {
+        load(username: username, greetingService: greetingService, activityService: activityService)
+    }
+
+    func cancel() {
+        loadTask?.cancel()
+        loadTask = nil
     }
 }
 
@@ -28,42 +171,217 @@ struct AppContainer {
     @Provide(.input)
     var username: String
 
-    @Provide(
-        .shared,
-        factory: { (username: String) in
-            LiveGreetingService(username: username)
-        }
-    )
+    @Provide(.shared, factory: { LiveGreetingService() })
     var greetingService: any GreetingServiceProtocol
 
-    @Provide(
-        .transient,
-        factory: { (greetingService: any GreetingServiceProtocol) in
-            GreetingViewModel(service: greetingService)
-        },
-        concrete: true
-    )
-    var greetingViewModel: GreetingViewModel
+    @Provide(.shared, factory: { LiveActivityService() })
+    var activityService: any ActivityServiceProtocol
 }
 
-struct GreetingView: View {
-    @ObservedObject var viewModel: GreetingViewModel
+struct DashboardSkeletonView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            RoundedRectangle(cornerRadius: 14)
+                .fill(.quaternary)
+                .frame(height: 90)
+            ForEach(0..<3, id: \.self) { _ in
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(.quaternary.opacity(0.7))
+                    .frame(height: 58)
+            }
+        }
+        .redacted(reason: .placeholder)
+    }
+}
+
+struct DashboardErrorView: View {
+    let message: String
+    let retry: () -> Void
 
     var body: some View {
-        Text(viewModel.text)
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Recoverable error")
+                .font(.title3.weight(.semibold))
+            Text(message)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            Button("Retry", action: retry)
+                .buttonStyle(.borderedProminent)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(20)
+        .background(.red.opacity(0.08), in: RoundedRectangle(cornerRadius: 20))
+    }
+}
+
+struct DashboardLoadedView: View {
+    let content: DashboardContent
+
+    var body: some View {
+        List {
+            Section("Summary") {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(content.summary.headline)
+                        .font(.headline)
+                    Text(content.summary.status)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 4)
+            }
+
+            Section("Highlights") {
+                ForEach(content.highlights) { highlight in
+                    NavigationLink(value: highlight) {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(highlight.title)
+                                .font(.body.weight(.semibold))
+                            Text(highlight.detail)
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+            }
+        }
+        .listStyle(.automatic)
+    }
+}
+
+struct HighlightDetailView: View {
+    let highlight: ActivityHighlight
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(highlight.title)
+                .font(.largeTitle.bold())
+            Text(highlight.detail)
+                .font(.body)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(24)
+        .navigationTitle("Detail")
+    }
+}
+
+struct DashboardFeatureRootView: View {
+    let username: String
+
+    @Environment(\.greetingService) private var greetingService
+    @Environment(\.activityService) private var activityService
+    @State private var model = DashboardFeatureModel()
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                switch model.state {
+                case .idle, .loading:
+                    DashboardSkeletonView()
+                        .padding(24)
+                case let .loaded(content):
+                    DashboardLoadedView(content: content)
+                case let .failed(message):
+                    DashboardErrorView(message: message) {
+                        model.retry(
+                            username: username,
+                            greetingService: greetingService,
+                            activityService: activityService
+                        )
+                    }
+                    .padding(24)
+                }
+            }
+            .navigationTitle(model.navigationTitle)
+            .navigationDestination(for: ActivityHighlight.self) { highlight in
+                HighlightDetailView(highlight: highlight)
+            }
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button("Reload") {
+                        model.retry(
+                            username: username,
+                            greetingService: greetingService,
+                            activityService: activityService
+                        )
+                    }
+                }
+            }
+        }
+        .task {
+            model.load(
+                username: username,
+                greetingService: greetingService,
+                activityService: activityService
+            )
+        }
+        .onDisappear {
+            model.cancel()
+        }
+    }
+}
+
+struct DashboardAppRootView: View {
+    let container: AppContainer
+
+    var body: some View {
+        DashboardFeatureRootView(username: container.username)
+            .environment(\.greetingService, container.greetingService)
+            .environment(\.activityService, container.activityService)
+    }
+}
+
+struct DashboardRootScenario {
+    let title: String
+    let container: AppContainer
+
+    static func live(username: String = "InnoDI") -> Self {
+        Self(
+            title: "Live",
+            container: AppContainer(username: username)
+        )
+    }
+
+    static func preview(username: String = "Preview") -> Self {
+        Self(
+            title: "Preview",
+            container: AppContainer(
+                username: username,
+                greetingService: MockGreetingService(
+                    headline: "Preview greeting injected at the feature root.",
+                    status: "Mock services can override both environment dependencies at the root boundary."
+                ),
+                activityService: MockActivityService(
+                    highlights: [
+                        ActivityHighlight(id: "preview-1", title: "Preview override", detail: "Generated init parameters still provide root-level overrides."),
+                        ActivityHighlight(id: "preview-2", title: "Retry flow", detail: "The view keeps retry and cancellation logic local to the screen model.")
+                    ]
+                )
+            )
+        )
+    }
+
+    static func failure(username: String = "Offline") -> Self {
+        Self(
+            title: "Failure",
+            container: AppContainer(
+                username: username,
+                greetingService: FailingGreetingService(),
+                activityService: MockActivityService(highlights: [])
+            )
+        )
     }
 }
 
 @main
 struct SwiftUIExampleMain {
     static func main() {
-        let liveContainer = AppContainer(username: "InnoDI")
-        _ = GreetingView(viewModel: liveContainer.greetingViewModel)
-
-        let mockContainer = AppContainer(
-            username: "Ignored",
-            greetingService: MockGreetingService(text: "Hello from mock")
-        )
-        _ = GreetingView(viewModel: mockContainer.greetingViewModel)
+        let liveScenario = DashboardRootScenario.live()
+        _ = DashboardAppRootView(container: liveScenario.container)
+        _ = DashboardAppRootView(container: DashboardRootScenario.preview().container)
+        _ = DashboardAppRootView(container: DashboardRootScenario.failure().container)
     }
 }

--- a/Examples/SwiftUIExample/Tests/SwiftUIExampleTests/SwiftUIExampleTests.swift
+++ b/Examples/SwiftUIExample/Tests/SwiftUIExampleTests/SwiftUIExampleTests.swift
@@ -1,0 +1,125 @@
+import Testing
+
+@testable import SwiftUIExample
+
+@Suite("SwiftUIExample behavior")
+struct SwiftUIExampleTests {
+    @Test("Dashboard model loads success state")
+    @MainActor
+    func dashboardModelLoadsSuccessState() async throws {
+        let model = DashboardFeatureModel()
+
+        model.load(
+            username: "Tester",
+            greetingService: MockGreetingService(
+                headline: "Hello, Tester",
+                status: "Feature root loaded."
+            ),
+            activityService: MockActivityService(
+                highlights: [
+                    ActivityHighlight(id: "one", title: "Loaded", detail: "Async state completed.")
+                ]
+            )
+        )
+
+        try await waitUntilDashboardLoaded(model)
+
+        guard case let .loaded(content) = model.state else {
+            Issue.record("Expected loaded state.")
+            return
+        }
+        #expect(content.summary.headline == "Hello, Tester")
+        #expect(content.highlights.count == 1)
+    }
+
+    @Test("Dashboard model enters failure state and retries")
+    @MainActor
+    func dashboardModelFailsAndRetries() async throws {
+        let model = DashboardFeatureModel()
+
+        model.load(
+            username: "Tester",
+            greetingService: FailingGreetingService(),
+            activityService: MockActivityService(highlights: [])
+        )
+        try await waitUntilDashboardFailed(model)
+
+        guard case let .failed(message) = model.state else {
+            Issue.record("Expected failure state.")
+            return
+        }
+        #expect(message.contains("offline"))
+
+        model.retry(
+            username: "Tester",
+            greetingService: MockGreetingService(
+                headline: "Recovered",
+                status: "Retry uses the same root composition."
+            ),
+            activityService: MockActivityService(
+                highlights: [ActivityHighlight(id: "retry", title: "Retry", detail: "Recovered after retry.")]
+            )
+        )
+        try await waitUntilDashboardLoaded(model)
+
+        guard case let .loaded(content) = model.state else {
+            Issue.record("Expected loaded state after retry.")
+            return
+        }
+        #expect(content.summary.headline == "Recovered")
+    }
+
+    @Test("Dashboard model cancellation prevents terminal state writes")
+    @MainActor
+    func dashboardModelCancelPreventsTerminalStateWrites() async throws {
+        let model = DashboardFeatureModel()
+
+        model.load(
+            username: "Tester",
+            greetingService: LiveGreetingService(),
+            activityService: LiveActivityService()
+        )
+        model.cancel()
+        try await Task.sleep(for: .milliseconds(250))
+
+        guard case .loading = model.state else {
+            Issue.record("Expected loading state to remain after cancellation.")
+            return
+        }
+    }
+
+    @Test("Dashboard root scenarios expose live preview and failure compositions")
+    func dashboardRootScenariosExposeCompositionVariants() {
+        let live = DashboardRootScenario.live(username: "Live")
+        let preview = DashboardRootScenario.preview(username: "Preview")
+        let failure = DashboardRootScenario.failure(username: "Failure")
+
+        #expect(live.title == "Live")
+        #expect(String(describing: type(of: live.container.greetingService)) == "LiveGreetingService")
+        #expect(String(describing: type(of: preview.container.greetingService)) == "MockGreetingService")
+        #expect(String(describing: type(of: failure.container.greetingService)) == "FailingGreetingService")
+        #expect(String(describing: type(of: live.container.activityService)) == "LiveActivityService")
+    }
+}
+
+@MainActor
+private func waitUntilDashboardLoaded(_ model: DashboardFeatureModel) async throws {
+    for _ in 0..<20 {
+        if case .loaded = model.state {
+            return
+        }
+        try await Task.sleep(for: .milliseconds(20))
+    }
+    Issue.record("Timed out waiting for loaded state.")
+}
+
+@MainActor
+private func waitUntilDashboardFailed(_ model: DashboardFeatureModel) async throws {
+    for _ in 0..<20 {
+        if case .failed = model.state {
+            return
+        }
+        try await Task.sleep(for: .milliseconds(20))
+    }
+    Issue.record("Timed out waiting for failed state.")
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 InnoSquad
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,46 @@
+# Migration Notes
+
+This file tracks release-to-release migration guidance when behavior, defaults, or artifact contracts change in a way that users must react to.
+
+## 2.1.0
+
+### Who is affected
+
+- Existing internal consumers upgrading from earlier private tags.
+- CI consumers reading benchmark or validation artifacts.
+
+### Required action
+
+- No code migration is required for normal package consumers.
+- If you parse validation or benchmark JSON artifacts, verify the documented schema versions in `RELEASING.md`.
+
+### Notes
+
+- This release formalizes OSS release documents and release-gate workflows.
+
+## When To Add An Entry
+
+Add a migration section when a release changes:
+
+- macro validation behavior that can break existing containers
+- build-stage validation failure conditions
+- validation artifact schema expectations used by CI or tooling
+- benchmark baseline handling that downstream teams rely on
+
+## Suggested Entry Format
+
+```markdown
+## <version>
+
+### Who is affected
+
+- package consumers using ...
+
+### Required action
+
+- update ...
+
+### Notes
+
+- optional compatibility detail
+```

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,7 +2,7 @@
 
 This file tracks release-to-release migration guidance when behavior, defaults, or artifact contracts change in a way that users must react to.
 
-## 2.1.0
+## 3.0.0
 
 ### Who is affected
 
@@ -11,12 +11,14 @@ This file tracks release-to-release migration guidance when behavior, defaults, 
 
 ### Required action
 
-- No code migration is required for normal package consumers.
+- Review containers that previously relied on permissive validation behavior.
+- Existing code may now fail earlier when strict name-based resolution, declaration-order enforcement, or cross-file custom `init` validation detects invalid wiring.
 - If you parse validation or benchmark JSON artifacts, verify the documented schema versions in `RELEASING.md`.
 
 ### Notes
 
-- This release formalizes OSS release documents and release-gate workflows.
+- This major release formalizes OSS release documents and release-gate workflows.
+- The version bump reflects stricter validation and semantic enforcement rather than a new public macro surface.
 
 ## When To Add An Entry
 

--- a/Package.swift
+++ b/Package.swift
@@ -35,6 +35,15 @@ let package = Package(
             name: "InnoDI",
             dependencies: ["InnoDIMacros"]
         ),
+        .target(
+            name: "InnoDIBuildSupport"
+            ,
+            dependencies: [
+                "InnoDICore",
+                .product(name: "SwiftParser", package: "swift-syntax"),
+                .product(name: "SwiftSyntax", package: "swift-syntax"),
+            ]
+        ),
         .executableTarget(
             name: "InnoDI-DependencyGraph",
             dependencies: [
@@ -43,10 +52,17 @@ let package = Package(
                 .product(name: "SwiftParser", package: "swift-syntax"),
             ]
         ),
+        .executableTarget(
+            name: "InnoDI-DAGValidationCoordinator",
+            dependencies: [
+                "InnoDIBuildSupport"
+            ]
+        ),
         .plugin(
             name: "InnoDIDAGValidationPlugin",
             capability: .buildTool(),
             dependencies: [
+                "InnoDI-DAGValidationCoordinator",
                 "InnoDI-DependencyGraph"
             ]
         ),
@@ -81,6 +97,13 @@ let package = Package(
             name: "InnoDIDependencyGraphCLITests",
             dependencies: [
                 "InnoDI-DependencyGraph"
+            ]
+        ),
+        .testTarget(
+            name: "InnoDIBuildSupportTests",
+            dependencies: [
+                "InnoDIBuildSupport",
+                "InnoDICore"
             ]
         ),
     ]

--- a/Plugins/InnoDIDAGValidationPlugin/plugin.swift
+++ b/Plugins/InnoDIDAGValidationPlugin/plugin.swift
@@ -8,19 +8,23 @@ struct InnoDIDAGValidationPlugin: BuildToolPlugin {
             return []
         }
 
-        let tool = try context.tool(named: "InnoDI-DependencyGraph")
+        let coordinator = try context.tool(named: "InnoDI-DAGValidationCoordinator")
+        let dependencyGraphTool = try context.tool(named: "InnoDI-DependencyGraph")
         let outputDirectory = context.pluginWorkDirectoryURL
         let rootPath = context.package.directoryURL.path
+        let sharedStateDirectory = context.package.directoryURL
+            .appending(path: ".build", directoryHint: .isDirectory)
+            .appending(path: "innodi-dag-validation", directoryHint: .isDirectory)
 
         return [
             .prebuildCommand(
                 displayName: "Validate InnoDI DAG for \(target.name)",
-                executable: tool.url,
+                executable: coordinator.url,
                 arguments: [
                     "--root", rootPath,
-                    "--validate-dag",
-                    "--format", "ascii",
-                    "--output", outputDirectory.appending(path: "dag-validation-\(target.name).txt").path,
+                    "--tool", dependencyGraphTool.url.path,
+                    "--state-dir", sharedStateDirectory.path,
+                    "--output-dir", outputDirectory.path,
                 ],
                 outputFilesDirectory: outputDirectory
             )

--- a/README.ko.md
+++ b/README.ko.md
@@ -20,7 +20,7 @@ Swift Macro 기반의 타입 안전한 의존성 주입 라이브러리입니다
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/InnoSquadCorp/InnoDI.git", from: "2.1.0")
+    .package(url: "https://github.com/InnoSquadCorp/InnoDI.git", from: "3.0.0")
 ]
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -10,6 +10,7 @@ Swift Macro 기반의 타입 안전한 의존성 주입 라이브러리입니다
 - 보일러플레이트 최소화: `init(...)` 자동 생성
 - 스코프 지원: `shared`, `input`, `transient`
 - AutoWiring: `Type.self` + `with:`로 간결한 선언
+- 엄격한 이름 기반 해석: 팩토리 파라미터와 `with:` 의존성은 멤버 이름으로만 해석
 - Init Override: 테스트 시 의존성 직접 주입 가능
 - DIP 지향: concrete 타입 사용 시 `concrete: true` 명시 강제
 
@@ -19,7 +20,7 @@ Swift Macro 기반의 타입 안전한 의존성 주입 라이브러리입니다
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/InnoSquadCorp/InnoDI.git", from: "1.0.0")
+    .package(url: "https://github.com/InnoSquadCorp/InnoDI.git", from: "2.1.0")
 ]
 ```
 
@@ -68,6 +69,21 @@ let client = container.apiClient
 var apiClient: any APIClientProtocol
 ```
 
+## Start Here
+
+처음 보는 사용자는 아래 순서로 읽는 것을 권장합니다.
+
+1. 이 README에서 설치, 컨테이너 문법, 지원 모델을 먼저 확인합니다.
+2. [Validation](Sources/InnoDI/InnoDI.docc/Validation.md) 에서 local/build/global validation과 observability artifact를 확인합니다.
+3. [PolicyBoundaries](Sources/InnoDI/InnoDI.docc/PolicyBoundaries.md) 에서 정확한 matching 규칙, 제외 규칙, fallback 동작을 확인합니다.
+4. [ModuleWideInitDetection](Sources/InnoDI/InnoDI.docc/ModuleWideInitDetection.md) 에서 custom `init` 제한 정책을 확인합니다.
+
+릴리스/운영 문서:
+
+- [CHANGELOG.md](CHANGELOG.md)
+- [RELEASING.md](RELEASING.md)
+- [MIGRATION.md](MIGRATION.md)
+
 ## API 요약
 
 ### `@DIContainer`
@@ -76,9 +92,13 @@ var apiClient: any APIClientProtocol
 @DIContainer(validate: Bool = true, root: Bool = false, validateDAG: Bool = true, mainActor: Bool = false)
 ```
 
+`@DIContainer`가 붙은 타입과 extension 전체에서 사용자 정의 `init`을 지원하지 않습니다.
+매크로는 type body와 같은 파일의 동일 타입 extension을 막고, build plugin은 다른 파일의 extension까지 같은 규칙으로 확장합니다.
+생성된 init을 사용하거나, 수동 wiring이 필요하면 매크로를 제거해야 합니다.
+
 | 파라미터 | 기본값 | 설명 |
 |---|---|---|
-| `validate` | `true` | 스코프/팩토리 검증 활성화. `false`일 때 `.shared`/`.transient` 누락 팩토리는 런타임 `fatalError` fallback으로 처리. `.input`의 factory 금지와 concrete opt-in 규칙은 계속 강제됨. |
+| `validate` | `true` | 호환성 유지를 위한 플래그입니다. `.shared`/`.transient`의 factory 요구사항, `.input` 제약, `concrete: true` opt-in 같은 핵심 생성 불변식은 값과 무관하게 컴파일 타임에 계속 강제됩니다. |
 | `root` | `false` | CLI 그래프에서 루트 컨테이너로 표시할지 여부 |
 | `validateDAG` | `true` | 이 컨테이너의 DAG 검증 참여 여부. `false`면 DAG 검증에서 제외 |
 | `mainActor` | `false` | 생성되는 init/accessor에 `@MainActor` 격리를 적용 |
@@ -243,11 +263,20 @@ Tools/generate-docc.sh
 처음 Pages를 연결하는 저장소라면, Repository Settings에서 Pages Source를
 `GitHub Actions`로 설정해야 합니다.
 
+## License
+
+MIT
+
+[LICENSE](LICENSE) 파일을 참고하세요.
+
 ## Build Tool Plugin
 
 InnoDI는 DAG 검증용 SwiftPM 플러그인을 제공합니다.
 
 - `InnoDIDAGValidationPlugin`
+
+이 플러그인은 패키지 입력 상태별로 검증을 한 번만 수행하고, 같은 결과를 타깃 간에 재사용합니다.
+즉, 각 타깃마다 전체 패키지 그래프를 다시 스캔하지 않습니다.
 
 타깃에 연결 예시:
 
@@ -263,9 +292,9 @@ InnoDI는 DAG 검증용 SwiftPM 플러그인을 제공합니다.
 
 ## 확장 예제
 
-- `Examples/SwiftUIExample`
+- `Examples/SwiftUIExample` - 단일 feature root에서 navigation, loading skeleton, recoverable error/retry, cancellation을 로컬 `@Observable` 상태로 관리
 - `Examples/TCAIntegrationExample`
-- `Examples/PreviewInjectionExample`
+- `Examples/PreviewInjectionExample` - preview/live/failure 루트가 여러 서비스를 environment 경계에서 교체하며 richer preview matrix를 보여줌
 - `Examples/SampleApp`
 
 ## 매크로 성능 회귀 체크

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 
 A Swift Macro-based Dependency Injection library for clean, type-safe DI containers.
 
+## State Ownership
+
+InnoDI is a **static dependency graph and scope validation** framework.
+
+- Use `DIScope` to describe construction lifetime.
+- Use DAG validation and diagnostics to catch graph problems early.
+- Do not treat container resolution as a runtime state machine.
+
+Across the InnoSquad stack, runtime state transitions belong in `InnoFlow`,
+navigation transitions belong in `InnoRouter`, and transport/session lifecycle
+belongs in `InnoNetwork`.
+
 ## Features
 
 - **Compile-time safety**: Macro-based validation catches errors at build time

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ belongs in `InnoNetwork`.
 - **Zero boilerplate**: Auto-generated initializers with optional override parameters
 - **Multiple scopes**: `shared`, `input`, and `transient` lifecycle management
 - **AutoWiring**: Simplified syntax with `Type.self` and `with:` dependencies
+- **Strict name-based resolution**: Factory parameters and `with:` dependencies resolve by member name only
 - **Init Override**: Direct mock injection via init parameters (no separate Overrides struct)
 - **Protocol-first design**: Encourage DIP compliance with `concrete` opt-in
 
@@ -31,7 +32,7 @@ Add InnoDI to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/InnoSquadCorp/InnoDI.git", from: "1.0.0")
+    .package(url: "https://github.com/InnoSquadCorp/InnoDI.git", from: "2.1.0")
 ]
 ```
 
@@ -81,11 +82,30 @@ For more control, use factory closures instead:
 var apiClient: any APIClientProtocol
 ```
 
+## Start Here
+
+If you are new to InnoDI, read the docs in this order:
+
+1. This README for installation, container syntax, and the supported model.
+2. [Validation](Sources/InnoDI/InnoDI.docc/Validation.md) for local/build/global validation and observability artifacts.
+3. [PolicyBoundaries](Sources/InnoDI/InnoDI.docc/PolicyBoundaries.md) for exact matching rules, exclusions, and fallback behavior.
+4. [ModuleWideInitDetection](Sources/InnoDI/InnoDI.docc/ModuleWideInitDetection.md) for the custom `init` restriction model.
+
+Release and maintenance references:
+
+- [CHANGELOG.md](CHANGELOG.md)
+- [RELEASING.md](RELEASING.md)
+- [MIGRATION.md](MIGRATION.md)
+
 ## API Reference
 
 ### `@DIContainer`
 
 Marks a struct as a DI container. Generates `init(...)` with optional override parameters.
+
+`@DIContainer` does not support user-defined `init` declarations in the annotated type or any extension.
+Macro validation rejects body and same-file extension `init` declarations, and the build plugin extends the same rule to cross-file extensions. Boundary details such as generic/constrained exclusions and conservative fallback rules are documented in `PolicyBoundaries`.
+Use the synthesized initializer, or remove the macro and wire the type manually.
 
 ```swift
 @DIContainer(validate: Bool = true, root: Bool = false, validateDAG: Bool = true, mainActor: Bool = false)
@@ -93,7 +113,7 @@ Marks a struct as a DI container. Generates `init(...)` with optional override p
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `validate` | `true` | Enable compile-time scope/factory validation. `false` relaxes missing-factory checks for `.shared`/`.transient` and emits runtime `fatalError` fallback for missing `.shared` and `.transient` factories. `.input` factory prohibition and concrete opt-in remain enforced. |
+| `validate` | `true` | Reserved compatibility flag. Core construction invariants such as `.shared`/`.transient` factory requirements, `.input` restrictions, and `concrete: true` opt-in remain compile-time enforced. |
 | `root` | `false` | Mark container as root in graph rendering. |
 | `validateDAG` | `true` | Enable local/global DAG validation for this container. Set `false` to opt out from DAG checks. |
 | `mainActor` | `false` | Apply `@MainActor` isolation to generated initializer/accessors. |
@@ -122,6 +142,11 @@ Declares a dependency with its scope and factory.
 | `.input` | Provided at container initialization | No |
 | `.shared` | Created once, cached for container lifetime | Yes |
 | `.transient` | New instance created on every access | Yes |
+
+Scope laws:
+- `.input` is external data and must come from container initialization.
+- `.shared` is stable for one container instance and should be reused on repeated access.
+- `.transient` must produce fresh instances and should not be treated as cached state.
 
 ### Async Factory
 
@@ -365,6 +390,9 @@ InnoDI ships a SwiftPM build tool plugin:
 
 - `InnoDIDAGValidationPlugin`
 
+The plugin coordinates validation once per package input state and reuses the shared result across targets,
+instead of rescanning the package graph independently for every target.
+
 Attach it to your app target to fail builds when DAG validation fails:
 
 ```swift
@@ -381,9 +409,9 @@ Attach it to your app target to fail builds when DAG validation fails:
 
 See runnable examples in `/Examples`:
 
-- `/Examples/SwiftUIExample`
+- `/Examples/SwiftUIExample` - a single feature root demonstrates navigation, loading skeletons, recoverable error/retry flow, and cancellation around local `@Observable` state
 - `/Examples/TCAIntegrationExample`
-- `/Examples/PreviewInjectionExample`
+- `/Examples/PreviewInjectionExample` - live, preview, and failure roots render a richer preview matrix by swapping multiple services at the environment boundary
 - `/Examples/SampleApp`
 
 ### Example Output
@@ -440,3 +468,5 @@ Default baseline file:
 ## License
 
 MIT
+
+See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add InnoDI to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/InnoSquadCorp/InnoDI.git", from: "2.1.0")
+    .package(url: "https://github.com/InnoSquadCorp/InnoDI.git", from: "3.0.0")
 ]
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 This document defines the minimum release quality bar for InnoDI.
 
-Current stable public release target: `2.1.0`
+Current stable public release target: `3.0.0`
 
 ## Release Checklist
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,88 @@
+# Releasing InnoDI
+
+This document defines the minimum release quality bar for InnoDI.
+
+Current stable public release target: `2.1.0`
+
+## Release Checklist
+
+Before tagging a release:
+
+1. Update [CHANGELOG.md](CHANGELOG.md).
+2. Decide whether [MIGRATION.md](MIGRATION.md) needs a new entry.
+3. Run the main package test suite and example package tests/builds.
+4. Run benchmark smoke checks:
+   - `Benchmarks/run-validation-bench.sh --preset ci`
+   - `Benchmarks/compare.sh --preset ci`
+5. Decide whether benchmark baselines need an intentional refresh.
+6. Decide whether any artifact schema version changed and document it below.
+7. Confirm the release tag matches the README installation snippet.
+8. Confirm the GitHub Actions `Release Gate` workflow will run from the intended tag.
+9. Confirm the matching `## <tag>` section exists in [CHANGELOG.md](CHANGELOG.md); the release workflow publishes that body automatically.
+
+## Benchmark Baseline Policy
+
+- Validation regression gating uses [Benchmarks/validation-performance-baseline.json](Benchmarks/validation-performance-baseline.json).
+- Refresh the baseline only after an intentional performance change or a deliberate toolchain reset.
+- Baseline refresh command:
+
+```bash
+Benchmarks/compare.sh --preset ci --update-validation-baseline
+```
+
+- Baseline changes must be called out in the changelog or release notes when they materially affect regression expectations.
+
+## Artifact Schema Versioning
+
+These artifacts are treated as release-quality contracts:
+
+- validation metrics JSON artifact
+- validation summary Markdown artifact
+- validation benchmark raw result JSON
+- validation benchmark compare JSON
+- validation benchmark baseline JSON
+
+Versioning rules:
+
+- additive fields: minor schema increment or paired document note
+- changed semantics or removed fields: explicit version bump plus migration note
+- Markdown summaries do not carry a standalone numeric schema field; they follow the paired JSON schema and release notes
+
+Current tracked versions:
+
+- `ValidationMetricsArtifact.currentVersion`: see [ValidationMetrics.swift](Sources/InnoDIBuildSupport/ValidationMetrics.swift)
+- validation benchmark raw result schema: `1`
+- validation benchmark compare schema: `1`
+
+## GitHub Release Notes
+
+The tag-driven `Release Gate` workflow automatically creates the GitHub Release and uses the matching `## <tag>` section from [CHANGELOG.md](CHANGELOG.md) as the release body.
+
+That changelog section should summarize:
+
+- user-facing validation or diagnostics changes
+- benchmark baseline or threshold changes
+- documentation or release-process changes
+- migration impact, if any
+
+## Documentation Expectations
+
+Each release should leave these entrypoints consistent:
+
+1. [README.md](README.md)
+2. [Validation.md](Sources/InnoDI/InnoDI.docc/Validation.md)
+3. [PolicyBoundaries.md](Sources/InnoDI/InnoDI.docc/PolicyBoundaries.md)
+4. [ModuleWideInitDetection.md](Sources/InnoDI/InnoDI.docc/ModuleWideInitDetection.md)
+
+If a release changes user-facing validation behavior, update those docs in the same change.
+
+## Automated Release Artifacts
+
+The release workflow publishes these assets to the GitHub Release:
+
+- validation benchmark JSON artifacts
+- validation benchmark Markdown summaries
+- validation compare JSON/Markdown artifacts
+- packaged DocC archive
+
+If artifact naming or schema changes, update this document and [CHANGELOG.md](CHANGELOG.md) in the same release.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,6 +26,8 @@ or release hardening discussions and are not release blockers for `3.0.0`.
   explicit task lifecycle control.
 - Deduplicate polling and waiting helpers used across tests where it improves
   clarity without obscuring intent.
+- Add suite-level metadata tags/traits to larger Swift Testing suites once the
+  project standardizes on a single categorization convention and syntax.
 
 ### CLI and documentation polish
 - Add explicit `--help` coverage and usage tests for developer-facing tools.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,36 @@
+# InnoDI Roadmap
+
+This document tracks follow-up work that is intentionally deferred from the
+current release candidate. Items listed here came from open PR review feedback
+or release hardening discussions and are not release blockers for `3.0.0`.
+
+## Post-3.0.0 Follow-ups
+
+### Validation coordinator robustness
+- Detect and recover stale lock files in
+  `Sources/InnoDIBuildSupport/ValidationCoordinator.swift`.
+- Add bounded retries and backoff around the coordinator lock acquisition loop
+  so repeated cache misses fail predictably instead of retrying indefinitely.
+- Replace the synchronous `Thread.sleep` polling path with an async wait model if
+  the coordinator API is migrated to Swift Concurrency.
+
+### Macro validation and fix-it quality
+- Filter unresolved factory fix-it suggestions by declaration-order availability
+  so diagnostics do not suggest names that would immediately trigger an
+  unavailable-dependency error.
+- Revisit `model.options.validate` handling for shared factory requirements to
+  ensure runtime fallback and compile-time diagnostics remain aligned.
+
+### Example and test hygiene
+- Revisit SwiftUI example `.task` / `.onDisappear` ownership boundaries for more
+  explicit task lifecycle control.
+- Deduplicate polling and waiting helpers used across tests where it improves
+  clarity without obscuring intent.
+
+### CLI and documentation polish
+- Add explicit `--help` coverage and usage tests for developer-facing tools.
+- Improve docstring coverage for public and package-visible types involved in
+  validation, semantic resolution, and release automation.
+- Keep style-only cleanups, such as idiomatic cast chains and shorthand mapping
+  expressions, out of release-critical PRs unless they materially improve
+  correctness.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are provided for the latest stable release line only.
+
+## Reporting a Vulnerability
+
+Please do not open a public issue for a suspected security vulnerability.
+
+Instead, contact the maintainers privately and include:
+
+- affected version or tag
+- impact summary
+- reproduction steps or proof of concept
+- any suggested mitigation
+
+We will acknowledge receipt, assess impact, and coordinate disclosure once a fix is available.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,11 @@ Security fixes are provided for the latest stable release line only.
 
 Please do not open a public issue for a suspected security vulnerability.
 
-Instead, contact the maintainers privately and include:
+Instead, use GitHub Security Advisories for private reporting:
+
+- <https://github.com/InnoSquadCorp/InnoDI/security/advisories/new>
+
+Include:
 
 - affected version or tag
 - impact summary

--- a/Sources/InnoDI-DAGValidationCoordinator/main.swift
+++ b/Sources/InnoDI-DAGValidationCoordinator/main.swift
@@ -1,0 +1,108 @@
+import Foundation
+import InnoDIBuildSupport
+
+struct CoordinatorArguments {
+    let rootPath: String
+    let toolPath: String
+    let stateDirectoryPath: String
+    let outputDirectoryPath: String
+}
+
+enum CoordinatorExitCode {
+    static let failure: Int32 = 1
+}
+
+do {
+    let arguments = try parseArguments()
+    let outcome = try ValidationCoordinator.coordinate(
+        rootPath: arguments.rootPath,
+        toolPath: arguments.toolPath,
+        stateDirectoryPath: arguments.stateDirectoryPath,
+        outputDirectoryPath: arguments.outputDirectoryPath
+    )
+
+    if outcome.result.exitCode != 0 || !outcome.wasCached {
+        if !outcome.result.stdout.isEmpty {
+            FileHandle.standardOutput.write(Data(outcome.result.stdout.utf8))
+        }
+        if !outcome.result.stderr.isEmpty {
+            FileHandle.standardError.write(Data(outcome.result.stderr.utf8))
+        }
+    }
+    if let verboseSummary = outcome.verboseSummary {
+        FileHandle.standardError.write(Data(verboseSummary.utf8))
+    }
+
+    Foundation.exit(outcome.result.exitCode)
+} catch {
+    fputs("Error: \(error)\n", stderr)
+    Foundation.exit(CoordinatorExitCode.failure)
+}
+
+private func parseArguments() throws -> CoordinatorArguments {
+    let args = Array(CommandLine.arguments.dropFirst())
+    var rootPath: String?
+    var toolPath: String?
+    var stateDirectoryPath: String?
+    var outputDirectoryPath: String?
+    var index = 0
+
+    func requireValue(for option: String) throws -> String {
+        guard index + 1 < args.count else {
+            throw CoordinatorArgumentError.missingValue(option: option)
+        }
+        let value = args[index + 1]
+        guard !value.hasPrefix("-") else {
+            throw CoordinatorArgumentError.missingValue(option: option)
+        }
+        return value
+    }
+
+    while index < args.count {
+        let option = args[index]
+        switch option {
+        case "--root":
+            rootPath = try requireValue(for: option)
+            index += 2
+        case "--tool":
+            toolPath = try requireValue(for: option)
+            index += 2
+        case "--state-dir":
+            stateDirectoryPath = try requireValue(for: option)
+            index += 2
+        case "--output-dir":
+            outputDirectoryPath = try requireValue(for: option)
+            index += 2
+        default:
+            throw CoordinatorArgumentError.unknownOption(option)
+        }
+    }
+
+    guard let rootPath, let toolPath, let stateDirectoryPath, let outputDirectoryPath else {
+        throw CoordinatorArgumentError.missingRequiredArguments
+    }
+
+    return CoordinatorArguments(
+        rootPath: rootPath,
+        toolPath: toolPath,
+        stateDirectoryPath: stateDirectoryPath,
+        outputDirectoryPath: outputDirectoryPath
+    )
+}
+
+enum CoordinatorArgumentError: LocalizedError {
+    case missingValue(option: String)
+    case unknownOption(String)
+    case missingRequiredArguments
+
+    var errorDescription: String? {
+        switch self {
+        case let .missingValue(option):
+            return "Option \(option) requires a value."
+        case let .unknownOption(option):
+            return "Unknown option \(option)."
+        case .missingRequiredArguments:
+            return "Required options: --root, --tool, --state-dir, --output-dir."
+        }
+    }
+}

--- a/Sources/InnoDI-DependencyGraph/AppMain.swift
+++ b/Sources/InnoDI-DependencyGraph/AppMain.swift
@@ -30,14 +30,25 @@ func runDependencyGraphCLI() -> Int32 {
         return writeNoContainersMessage(outputPath: outputPath)
     }
 
-    let containerIDsByDisplayNameAll = Dictionary(grouping: nodes, by: { $0.displayName })
+    let semanticResolver = SemanticResolverIndex(
+        nominalTypes: nodes.map {
+            SemanticNominalTypeRecord(
+                path: $0.semanticPath,
+                components: $0.semanticPath.split(separator: ".").map(String.init)
+            )
+        },
+        topLevelTypeAliases: collector.typeAliases
+    )
+    let containerIDsBySemanticPathAll = Dictionary(grouping: nodes, by: { $0.semanticPath })
         .mapValues { group in group.map(\.id).sorted() }
     let eligibleNodes = nodes.filter(\.validateDAG)
-    let containerIDsByDisplayNameEligible = Dictionary(grouping: eligibleNodes, by: { $0.displayName })
+    let containerIDsBySemanticPathEligible = Dictionary(grouping: eligibleNodes, by: { $0.semanticPath })
         .mapValues { group in group.map(\.id).sorted() }
 
     let usageCollector = ContainerUsageCollector(
-        containerIDsByDisplayName: validateDAG ? containerIDsByDisplayNameEligible : containerIDsByDisplayNameAll
+        allContainerIDsBySemanticPath: containerIDsBySemanticPathAll,
+        eligibleContainerIDsBySemanticPath: validateDAG ? containerIDsBySemanticPathEligible : containerIDsBySemanticPathAll,
+        semanticResolver: semanticResolver
     )
     for parsed in parsedFiles {
         usageCollector.walkFile(relativePath: parsed.relativePath, tree: parsed.tree)
@@ -48,7 +59,7 @@ func runDependencyGraphCLI() -> Int32 {
         return runDAGValidation(
             nodes: nodes,
             edges: edges,
-            ambiguousReferences: usageCollector.ambiguousReferences,
+            semanticIssues: usageCollector.semanticIssues,
             outputPath: outputPath
         )
     }
@@ -69,7 +80,7 @@ func runDependencyGraphCLI() -> Int32 {
 private func runDAGValidation(
     nodes: [DependencyGraphNode],
     edges: [DependencyGraphEdge],
-    ambiguousReferences: [AmbiguousContainerReference],
+    semanticIssues: [SemanticContainerReferenceIssue],
     outputPath: String?
 ) -> Int32 {
     let eligibleNodes = nodes.filter(\.validateDAG)
@@ -79,7 +90,7 @@ private func runDAGValidation(
 
     let nodeIDs = Set(eligibleNodes.map(\.id))
     let eligibleEdges = edges.filter { nodeIDs.contains($0.fromID) && nodeIDs.contains($0.toID) }
-    let eligibleAmbiguous = ambiguousReferences.filter { nodeIDs.contains($0.sourceID) }
+    let eligibleSemanticIssues = semanticIssues.filter { nodeIDs.contains($0.sourceID) }
 
     var adjacency: [String: [String]] = [:]
     for node in eligibleNodes {
@@ -90,16 +101,20 @@ private func runDAGValidation(
     }
 
     let cycles = detectDependencyCycles(adjacency: adjacency)
-    if cycles.isEmpty && eligibleAmbiguous.isEmpty {
+    if cycles.isEmpty && eligibleSemanticIssues.isEmpty {
         return writeValidationMessage("DAG validation passed.\n", outputPath: outputPath)
     }
 
     let labelsByID = Dictionary(uniqueKeysWithValues: nodes.map { ($0.id, $0.displayName) })
     var lines: [String] = ["DAG validation failed."]
 
-    if !eligibleAmbiguous.isEmpty {
+    let ambiguousIssues = eligibleSemanticIssues.filter { $0.state == .ambiguous }
+    let unresolvedIssues = eligibleSemanticIssues.filter { $0.state == .unresolved }
+    let excludedIssues = eligibleSemanticIssues.filter { $0.state == .excluded }
+
+    if !ambiguousIssues.isEmpty {
         lines.append("Ambiguous container references:")
-        let unique = Set(eligibleAmbiguous).sorted { lhs, rhs in
+        let unique = Set(ambiguousIssues).sorted { lhs, rhs in
             if lhs.sourceID == rhs.sourceID {
                 return lhs.destinationDisplayName < rhs.destinationDisplayName
             }
@@ -107,7 +122,43 @@ private func runDAGValidation(
         }
         for item in unique {
             let source = labelsByID[item.sourceID] ?? item.sourceID
-            lines.append("- [graph.ambiguous-container-reference] \(source) -> \(item.destinationDisplayName)")
+            if item.destinationCandidates.isEmpty {
+                lines.append("- [graph.ambiguous-container-reference] \(source) -> \(item.destinationDisplayName)")
+            } else {
+                let candidateSummary = item.destinationCandidates.joined(separator: ", ")
+                lines.append(
+                    "- [graph.ambiguous-container-reference] \(source) -> \(item.destinationDisplayName) candidates: \(candidateSummary)"
+                )
+            }
+        }
+    }
+
+    if !unresolvedIssues.isEmpty {
+        lines.append("Unresolved container references:")
+        let unique = Set(unresolvedIssues).sorted { lhs, rhs in
+            if lhs.sourceID == rhs.sourceID {
+                return lhs.destinationDisplayName < rhs.destinationDisplayName
+            }
+            return lhs.sourceID < rhs.sourceID
+        }
+        for item in unique {
+            let source = labelsByID[item.sourceID] ?? item.sourceID
+            lines.append("- [graph.unresolved-container-reference] \(source) -> \(item.destinationDisplayName)")
+        }
+    }
+
+    if !excludedIssues.isEmpty {
+        lines.append("Excluded container references:")
+        let unique = Set(excludedIssues).sorted { lhs, rhs in
+            if lhs.sourceID == rhs.sourceID {
+                return lhs.destinationDisplayName < rhs.destinationDisplayName
+            }
+            return lhs.sourceID < rhs.sourceID
+        }
+        for item in unique {
+            let source = labelsByID[item.sourceID] ?? item.sourceID
+            let detail = item.excludedReason ?? "unsupported semantic reference shape"
+            lines.append("- [graph.excluded-container-reference] \(source) -> \(item.destinationDisplayName) reason: \(detail)")
         }
     }
 

--- a/Sources/InnoDI-DependencyGraph/Collectors/ContainerCollector.swift
+++ b/Sources/InnoDI-DependencyGraph/Collectors/ContainerCollector.swift
@@ -3,6 +3,7 @@ import SwiftSyntax
 
 final class ContainerCollector: SyntaxVisitor, DeclarationPathTracking {
     var nodes: [DependencyGraphNode] = []
+    var typeAliases: [SemanticTypeAliasRecord] = []
 
     private var currentRelativeFilePath: String = ""
     var declarationPath: [String] = []
@@ -44,6 +45,24 @@ final class ContainerCollector: SyntaxVisitor, DeclarationPathTracking {
         _ = endDeclarationContext()
     }
 
+    override func visit(_ node: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard let target = normalizedSemanticTypeReference(node.initializer.value) else {
+            return .skipChildren
+        }
+
+        let components = declarationPath + [node.name.text]
+        let path = components.joined(separator: ".")
+
+        typeAliases.append(
+            SemanticTypeAliasRecord(
+                path: path,
+                components: components,
+                target: target
+            )
+        )
+        return .skipChildren
+    }
+
     func walkFile(relativePath: String, tree: SourceFileSyntax) {
         currentRelativeFilePath = relativePath
         declarationPath.removeAll(keepingCapacity: true)
@@ -58,6 +77,7 @@ final class ContainerCollector: SyntaxVisitor, DeclarationPathTracking {
 
     private func collectIfContainer(_ node: some DeclGroupSyntax, displayName: String) {
         guard let containerAttr = parseDIContainerAttribute(node.attributes) else { return }
+        let semanticPath = declarationPath.joined(separator: ".")
 
         var requiredInputs: [String] = []
         for member in node.memberBlock.members {
@@ -75,6 +95,7 @@ final class ContainerCollector: SyntaxVisitor, DeclarationPathTracking {
             DependencyGraphNode(
                 id: id,
                 displayName: displayName,
+                semanticPath: semanticPath,
                 isRoot: containerAttr.root,
                 validateDAG: containerAttr.validateDAG,
                 requiredInputs: requiredInputs

--- a/Sources/InnoDI-DependencyGraph/Collectors/ContainerUsageCollector.swift
+++ b/Sources/InnoDI-DependencyGraph/Collectors/ContainerUsageCollector.swift
@@ -1,9 +1,14 @@
 import InnoDICore
 import SwiftSyntax
 
-struct AmbiguousContainerReference: Hashable {
+struct SemanticContainerReferenceIssue: Hashable {
     let sourceID: String
     let destinationDisplayName: String
+    let state: SemanticResolutionState
+    let destinationCandidates: [String]
+    let excludedReason: String?
+    let aliasExpansionTrace: [String]
+    let usedSuffixFallback: Bool
 }
 
 final class ContainerUsageCollector: SyntaxVisitor, DeclarationPathTracking {
@@ -12,16 +17,26 @@ final class ContainerUsageCollector: SyntaxVisitor, DeclarationPathTracking {
         let containerID: String?
     }
 
-    let containerIDsByDisplayName: [String: [String]]
+    let allContainerIDsBySemanticPath: [String: [String]]
+    let eligibleContainerIDsBySemanticPath: [String: [String]]
+    let semanticResolver: SemanticResolverIndex
     var edges: [DependencyGraphEdge] = []
-    var ambiguousReferences: [AmbiguousContainerReference] = []
+    var semanticIssues: [SemanticContainerReferenceIssue] = []
+    var fallbackMatchedReferences: [String] = []
 
     private var currentRelativeFilePath: String = ""
     var declarationPath: [String] = []
     private var activeDeclarations: [DeclarationEntry] = []
 
-    init(containerIDsByDisplayName: [String: [String]], viewMode: SyntaxTreeViewMode = .sourceAccurate) {
-        self.containerIDsByDisplayName = containerIDsByDisplayName
+    init(
+        allContainerIDsBySemanticPath: [String: [String]],
+        eligibleContainerIDsBySemanticPath: [String: [String]],
+        semanticResolver: SemanticResolverIndex,
+        viewMode: SyntaxTreeViewMode = .sourceAccurate
+    ) {
+        self.allContainerIDsBySemanticPath = allContainerIDsBySemanticPath
+        self.eligibleContainerIDsBySemanticPath = eligibleContainerIDsBySemanticPath
+        self.semanticResolver = semanticResolver
         super.init(viewMode: viewMode)
     }
 
@@ -114,68 +129,79 @@ final class ContainerUsageCollector: SyntaxVisitor, DeclarationPathTracking {
     }
 
     private func calledContainerID(_ expr: ExprSyntax, sourceID: String) -> String? {
-        guard let displayName = calledContainerDisplayName(from: expr) else {
+        guard let reference = normalizedSemanticExpressionReference(expr) else {
             return nil
         }
 
-        guard let candidateIDs = containerIDsByDisplayName[displayName] else {
-            return nil
-        }
+        let resolution = semanticResolver.resolvePath(
+            for: reference,
+            candidatePaths: Set(allContainerIDsBySemanticPath.keys)
+        )
 
-        if candidateIDs.count > 1 {
-            ambiguousReferences.append(
-                AmbiguousContainerReference(
+        switch resolution.state {
+        case .resolved:
+            guard let resolvedPath = resolution.resolvedPath,
+                  let allCandidateIDs = allContainerIDsBySemanticPath[resolvedPath] else {
+                return nil
+            }
+            let candidateIDs = eligibleContainerIDsBySemanticPath[resolvedPath] ?? []
+            if candidateIDs.isEmpty && !allCandidateIDs.isEmpty {
+                return nil
+            }
+
+            if candidateIDs.count > 1 {
+                semanticIssues.append(
+                    SemanticContainerReferenceIssue(
+                        sourceID: sourceID,
+                        destinationDisplayName: reference.displayPath,
+                        state: .ambiguous,
+                        destinationCandidates: candidateIDs,
+                        excludedReason: nil,
+                        aliasExpansionTrace: resolution.aliasExpansionTrace,
+                        usedSuffixFallback: resolution.usedSuffixFallback
+                    )
+                )
+                return nil
+            }
+
+            if resolution.usedSuffixFallback {
+                fallbackMatchedReferences.append("\(sourceID) -> \(reference.displayPath)")
+            }
+            return candidateIDs[0]
+        case .ambiguous:
+            let eligibleCandidates = resolution.candidates.flatMap { eligibleContainerIDsBySemanticPath[$0] ?? [] }.sorted()
+            if eligibleCandidates.isEmpty {
+                return nil
+            }
+            if eligibleCandidates.count == 1 {
+                return eligibleCandidates[0]
+            }
+            semanticIssues.append(
+                SemanticContainerReferenceIssue(
                     sourceID: sourceID,
-                    destinationDisplayName: displayName
+                    destinationDisplayName: reference.displayPath,
+                    state: .ambiguous,
+                    destinationCandidates: eligibleCandidates,
+                    excludedReason: nil,
+                    aliasExpansionTrace: resolution.aliasExpansionTrace,
+                    usedSuffixFallback: resolution.usedSuffixFallback
+                )
+            )
+            return nil
+        case .excluded, .unresolved:
+            semanticIssues.append(
+                SemanticContainerReferenceIssue(
+                    sourceID: sourceID,
+                    destinationDisplayName: reference.displayPath,
+                    state: resolution.state,
+                    destinationCandidates: resolution.candidates,
+                    excludedReason: resolution.excludedReason,
+                    aliasExpansionTrace: resolution.aliasExpansionTrace,
+                    usedSuffixFallback: resolution.usedSuffixFallback
                 )
             )
             return nil
         }
-
-        return candidateIDs[0]
-    }
-
-    private func calledContainerDisplayName(from expr: ExprSyntax) -> String? {
-        if let declReference = expr.as(DeclReferenceExprSyntax.self) {
-            return declReference.baseName.text
-        }
-
-        if let memberAccess = expr.as(MemberAccessExprSyntax.self) {
-            let memberName = memberAccess.declName.baseName.text
-            if memberName == "init", let base = memberAccess.base {
-                return calledContainerDisplayName(from: base)
-            }
-            if memberName == "self", let base = memberAccess.base {
-                return calledContainerDisplayName(from: base)
-            }
-            return memberName
-        }
-
-        if let genericSpecialization = expr.as(GenericSpecializationExprSyntax.self) {
-            return calledContainerDisplayName(from: genericSpecialization.expression)
-        }
-
-        if let functionCall = expr.as(FunctionCallExprSyntax.self) {
-            return calledContainerDisplayName(from: functionCall.calledExpression)
-        }
-
-        if let forceUnwrap = expr.as(ForceUnwrapExprSyntax.self) {
-            return calledContainerDisplayName(from: forceUnwrap.expression)
-        }
-
-        if let optionalChaining = expr.as(OptionalChainingExprSyntax.self) {
-            return calledContainerDisplayName(from: optionalChaining.expression)
-        }
-
-        if let tryExpr = expr.as(TryExprSyntax.self) {
-            return calledContainerDisplayName(from: tryExpr.expression)
-        }
-
-        if let awaitExpr = expr.as(AwaitExprSyntax.self) {
-            return calledContainerDisplayName(from: awaitExpr.expression)
-        }
-
-        return nil
     }
 
     private func edgeLabel(from arguments: LabeledExprListSyntax) -> String? {

--- a/Sources/InnoDI-DependencyGraph/Collectors/ContainerUsageCollector.swift
+++ b/Sources/InnoDI-DependencyGraph/Collectors/ContainerUsageCollector.swift
@@ -1,7 +1,7 @@
 import InnoDICore
 import SwiftSyntax
 
-struct SemanticContainerReferenceIssue: Hashable {
+struct SemanticContainerReferenceIssue: Hashable, Sendable {
     let sourceID: String
     let destinationDisplayName: String
     let state: SemanticResolutionState
@@ -20,6 +20,7 @@ final class ContainerUsageCollector: SyntaxVisitor, DeclarationPathTracking {
     let allContainerIDsBySemanticPath: [String: [String]]
     let eligibleContainerIDsBySemanticPath: [String: [String]]
     let semanticResolver: SemanticResolverIndex
+    private let candidatePaths: Set<String>
     var edges: [DependencyGraphEdge] = []
     var semanticIssues: [SemanticContainerReferenceIssue] = []
     var fallbackMatchedReferences: [String] = []
@@ -37,6 +38,7 @@ final class ContainerUsageCollector: SyntaxVisitor, DeclarationPathTracking {
         self.allContainerIDsBySemanticPath = allContainerIDsBySemanticPath
         self.eligibleContainerIDsBySemanticPath = eligibleContainerIDsBySemanticPath
         self.semanticResolver = semanticResolver
+        self.candidatePaths = Set(allContainerIDsBySemanticPath.keys)
         super.init(viewMode: viewMode)
     }
 
@@ -74,6 +76,10 @@ final class ContainerUsageCollector: SyntaxVisitor, DeclarationPathTracking {
 
     override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
         guard let sourceID = activeContainerID else {
+            return .visitChildren
+        }
+
+        guard shouldCollectContainerReference(for: node) else {
             return .visitChildren
         }
 
@@ -135,7 +141,7 @@ final class ContainerUsageCollector: SyntaxVisitor, DeclarationPathTracking {
 
         let resolution = semanticResolver.resolvePath(
             for: reference,
-            candidatePaths: Set(allContainerIDsBySemanticPath.keys)
+            candidatePaths: candidatePaths
         )
 
         switch resolution.state {
@@ -207,5 +213,56 @@ final class ContainerUsageCollector: SyntaxVisitor, DeclarationPathTracking {
     private func edgeLabel(from arguments: LabeledExprListSyntax) -> String? {
         guard let first = arguments.first else { return nil }
         return first.label?.text
+    }
+
+    private func shouldCollectContainerReference(for node: FunctionCallExprSyntax) -> Bool {
+        guard isInsideProvideAttribute(Syntax(node)),
+              let calledReference = normalizedSemanticExpressionReference(node.calledExpression) else {
+            return false
+        }
+
+        let resolution = semanticResolver.resolvePath(for: calledReference, candidatePaths: candidatePaths)
+        switch resolution.state {
+        case .resolved, .ambiguous:
+            return true
+        case .excluded:
+            return true
+        case .unresolved:
+            break
+        }
+
+        guard let propertyTypeReference = enclosingProvideBindingTypeReference(from: Syntax(node)),
+              propertyTypeReference.displayPath == calledReference.displayPath,
+              calledReference.components.last?.hasSuffix("Container") == true else {
+            return false
+        }
+
+        return true
+    }
+
+    private func isInsideProvideAttribute(_ syntax: Syntax) -> Bool {
+        var current = syntax.parent
+        while let node = current {
+            if let attribute = node.as(AttributeSyntax.self),
+               attribute.attributeName.trimmedDescription == "Provide" {
+                return true
+            }
+            current = node.parent
+        }
+        return false
+    }
+
+    private func enclosingProvideBindingTypeReference(from syntax: Syntax) -> SemanticTypeReference? {
+        var current = syntax.parent
+        while let node = current {
+            if let variable = node.as(VariableDeclSyntax.self),
+               parseProvideAttribute(variable.attributes) != nil,
+               let binding = variable.bindings.first,
+               let typeAnnotation = binding.typeAnnotation {
+                return normalizedSemanticTypeReference(typeAnnotation.type)
+            }
+            current = node.parent
+        }
+        return nil
     }
 }

--- a/Sources/InnoDI/InnoDI.docc/DIContainer.md
+++ b/Sources/InnoDI/InnoDI.docc/DIContainer.md
@@ -1,6 +1,7 @@
 # DIContainer
 
 `@DIContainer` marks a type as a dependency container and generates an initializer from declared members.
+User-defined `init` declarations are unsupported inside the annotated type and its same-file extensions.
 
 ## Declaration
 
@@ -15,7 +16,7 @@
 
 ## Parameters
 
-- `validate`: Enables compile-time validation for missing factories and invalid scope usage.
+- `validate`: Reserved compatibility flag. Missing factories and invalid scope usage remain compile-time errors.
 - `root`: Marks the container as a root node for dependency graph rendering.
 - `validateDAG`: Enables local/global dependency cycle validation for this container.
 - `mainActor`: Applies `@MainActor` isolation to generated APIs.

--- a/Sources/InnoDI/InnoDI.docc/DIContainer.md
+++ b/Sources/InnoDI/InnoDI.docc/DIContainer.md
@@ -1,7 +1,7 @@
 # DIContainer
 
 `@DIContainer` marks a type as a dependency container and generates an initializer from declared members.
-User-defined `init` declarations are unsupported inside the annotated type and its same-file extensions.
+User-defined `init` declarations are unsupported inside the annotated type and any extension.
 
 ## Declaration
 

--- a/Sources/InnoDI/InnoDI.docc/ModuleWideInitDetection.md
+++ b/Sources/InnoDI/InnoDI.docc/ModuleWideInitDetection.md
@@ -1,0 +1,37 @@
+# Module-Wide Init Detection
+
+`@DIContainer` now enforces custom `init` restrictions in two layers.
+
+Read this after <doc:Validation> and <doc:PolicyBoundaries>. This page is intentionally narrower than the main validation guide.
+
+## Macro Layer
+
+Macro validation rejects custom `init` declarations in:
+
+- the annotated type body
+- same-file extensions whose type path exactly matches the annotated type
+
+This keeps macro diagnostics fast and local to the expansion context.
+
+## Build Layer
+
+The build plugin extends the same rule to cross-file extensions.
+
+During coordinated build validation, InnoDI scans the package sources and matches:
+
+- `@DIContainer` declarations by normalized nominal path
+- extension `init` declarations by normalized extended type path
+
+Cross-file matches fail the build with the same `container.custom-init-unsupported` rule used by macro diagnostics.
+
+## Current Matching Rules
+
+Build validation keeps the same safety boundary as macro validation while allowing a small semantic helper pass before falling back to source text:
+
+- nested paths like `Outer.Container` are supported
+- semantic helper resolution may match a unique alias or qualified suffix before fallback
+- generic argument extensions are excluded
+- constrained `where` extensions are excluded
+- ambiguous cases fall back to the existing conservative source-text rule
+
+This keeps the build-stage rule deterministic while improving accuracy for straightforward cross-file matches.

--- a/Sources/InnoDI/InnoDI.docc/Overview.md
+++ b/Sources/InnoDI/InnoDI.docc/Overview.md
@@ -9,6 +9,12 @@ The goal is to keep DI wiring explicit while catching invalid graph configuratio
 
 ## Topics
 
+### Start Here
+
+- <doc:Validation>
+- <doc:PolicyBoundaries>
+- <doc:ModuleWideInitDetection>
+
 ### Container API
 
 - <doc:DIContainer>

--- a/Sources/InnoDI/InnoDI.docc/PolicyBoundaries.md
+++ b/Sources/InnoDI/InnoDI.docc/PolicyBoundaries.md
@@ -1,0 +1,46 @@
+# Policy Boundaries
+
+InnoDI keeps validation deterministic by making a few explicit boundary choices.
+
+Read this after <doc:Validation>. If you need the cross-file custom `init` story in depth, continue to <doc:ModuleWideInitDetection>.
+
+## Custom `init` Detection
+
+- Macro validation rejects custom `init` declarations in the annotated type body.
+- Macro validation also rejects same-file extensions whose type path matches the annotated type.
+- Build validation extends the same rule to cross-file extensions.
+
+## Matching Strategy
+
+- Build validation first tries semantic helper resolution for cross-file extension targets.
+- The graph CLI and build-stage validators now share the same semantic helper model for nominal paths, nested paths, and collected typealiases.
+- If semantic resolution is still ambiguous or unsupported, InnoDI falls back to the existing conservative source-text match where that is explicitly supported.
+- Nested paths such as `Outer.Container` are supported.
+- DAG reporting uses semantic states directly:
+  - `resolved`
+  - `ambiguous`
+  - `excluded`
+  - `unresolved`
+
+## Excluded Extension Shapes
+
+- Generic argument extensions are excluded.
+- Constrained `where` extensions are excluded.
+- Unsupported or ambiguous extension targets stay outside the build-stage rule instead of producing speculative matches.
+
+## Declaration Order
+
+- `.input` members are always available.
+- sync `.shared` members can only reference inputs and earlier sync shared members.
+- async `.shared` members can reference inputs, all sync shared members, and earlier async shared members.
+- `.transient` members may reference any container member, but names still resolve strictly.
+
+## Concrete Opt-In
+
+- Protocol-first dependency types are preferred.
+- Concrete shared or transient dependency types require explicit `concrete: true`.
+
+## See Also
+
+- <doc:Validation>
+- <doc:ModuleWideInitDetection>

--- a/Sources/InnoDI/InnoDI.docc/Validation.md
+++ b/Sources/InnoDI/InnoDI.docc/Validation.md
@@ -2,6 +2,15 @@
 
 InnoDI validates dependency definitions in two layers.
 
+## Read This Next
+
+Recommended reading path:
+
+1. `README.md` for installation and container syntax
+2. this document for local/build/global validation behavior
+3. <doc:PolicyBoundaries> for exact matching and exclusion rules
+4. <doc:ModuleWideInitDetection> for custom `init` restriction details
+
 ## Local Container Validation
 
 Macro validation checks:
@@ -9,9 +18,17 @@ Macro validation checks:
 - unknown scopes
 - missing required factories
 - invalid `.input` factory configuration
+- strict name-based factory parameter and `with:` resolution
+- declaration-order availability for shared dependencies
 - concrete opt-in (`concrete: true`) requirements
 - local dependency cycles / unknown dependencies
 - async factory validity (`factory` conflict, scope mismatch, non-async closure)
+- user-defined `init` conflicts inside `@DIContainer` declarations and same-file extensions
+
+Build-stage extension:
+
+- coordinated build validation scans the same package sources for cross-file extension `init` conflicts
+- nested path matching is supported, while generic and constrained extensions remain excluded
 
 ## Global DAG Validation
 
@@ -32,8 +49,37 @@ Container-level opt-out:
 ## Build Tool Plugin
 
 Attach `InnoDIDAGValidationPlugin` to a target to fail build on graph validation errors.
+The plugin coordinates validation once per normalized AST input state and reuses the shared result across targets.
+
+Observability artifacts:
+
+- shared state lives under the package `.build` directory
+- each shared validation signature stores:
+  - `result.json`
+  - `validation-metrics.json`
+  - `validation-summary.md`
+- each plugin invocation output stores:
+  - `dag-validation-stamp.txt`
+  - `dag-validation-metrics.json`
+  - `dag-validation-summary.md`
+- Markdown summaries include:
+  - cache / live-run reason codes
+  - file-level change sections for new, deleted, reparsed, and content-hash-reused files
+  - top offender style truncated file lists for quick CI inspection
+- CI should read artifacts in this order:
+  - Markdown summary
+  - JSON metrics artifact
+  - raw stderr
+
+Verbose logging remains optional through `INNODI_VALIDATION_VERBOSE` or `INNODI_VALIDATION_DEBUG`, but artifact generation is always on.
+
+## Policy Boundaries
+
+For the exact matching and exclusion rules used by macro and build validation, see <doc:PolicyBoundaries>.
 
 ## See Also
 
 - <doc:DIContainer>
 - <doc:Provide>
+- <doc:ModuleWideInitDetection>
+- <doc:PolicyBoundaries>

--- a/Sources/InnoDI/InnoDI.swift
+++ b/Sources/InnoDI/InnoDI.swift
@@ -17,7 +17,7 @@ public enum DIScope {
 /// Marks a type as an InnoDI container and synthesizes initialization/validation behavior.
 ///
 /// - Parameters:
-///   - validate: Enables container-level compile-time validation.
+///   - validate: Reserved compatibility flag. Core construction invariants remain enforced regardless of this value.
 ///   - root: Marks this container as a root for dependency graph rendering.
 ///   - validateDAG: Includes this container in global/local DAG validation.
 ///   - mainActor: Isolates generated container API on the main actor.

--- a/Sources/InnoDIBuildSupport/CustomInitBuildValidator.swift
+++ b/Sources/InnoDIBuildSupport/CustomInitBuildValidator.swift
@@ -1,0 +1,275 @@
+import Foundation
+import InnoDICore
+import SwiftParser
+import SwiftSyntax
+
+package enum CustomInitBuildValidator {
+    package static func validate(rootPath: String) throws -> ValidationIssueReport {
+        let rootURL = URL(fileURLWithPath: rootPath, isDirectory: true)
+        let sourceFiles = discoverValidationSourceFiles(rootPath: rootPath)
+
+        var containersByPath: [String: [ContainerDeclarationRecord]] = [:]
+        var extensionRecords: [ExtensionInitializerRecord] = []
+        var nominalTypes: [SemanticNominalTypeRecord] = []
+        var typeAliases: [SemanticTypeAliasRecord] = []
+
+        for relativePath in sourceFiles {
+            let fileURL = rootURL.appendingPathComponent(relativePath)
+            let source = try String(contentsOf: fileURL, encoding: .utf8)
+            let syntax = Parser.parse(source: source)
+            let collector = CustomInitFileCollector(
+                filePath: fileURL.path(percentEncoded: false),
+                syntax: syntax
+            )
+            collector.walk(syntax)
+
+            for container in collector.containerDeclarations {
+                containersByPath[container.declarationPath, default: []].append(container)
+            }
+            extensionRecords.append(contentsOf: collector.extensionInitializers)
+            nominalTypes.append(contentsOf: collector.nominalTypes)
+            typeAliases.append(contentsOf: collector.typeAliases)
+        }
+
+        let resolver = SemanticResolverIndex(
+            nominalTypes: nominalTypes,
+            topLevelTypeAliases: typeAliases
+        )
+        let candidatePaths = Set(containersByPath.keys)
+        var issues: [ValidationIssue] = []
+
+        for record in extensionRecords {
+            let resolution = resolver.resolvePath(
+                for: record.extendedTypeReference,
+                candidatePaths: candidatePaths
+            )
+
+            let resolvedPath: String
+            switch resolution.state {
+            case .resolved:
+                guard let path = resolution.resolvedPath else {
+                    continue
+                }
+                resolvedPath = path
+            case .ambiguous, .excluded, .unresolved:
+                resolvedPath = record.extendedTypeReference.displayPath
+            }
+
+            guard let container = containersByPath[resolvedPath]?.first(where: { $0.filePath != record.filePath }) else {
+                continue
+            }
+
+            for initializer in record.initializers {
+                issues.append(
+                    ValidationIssue(
+                        code: "container.custom-init-unsupported",
+                        severity: .error,
+                        message: "@DIContainer does not support user-defined init declarations in the annotated type or any extension. Remove the custom init and use the synthesized initializer, or switch to manual wiring.",
+                        location: ValidationIssueLocation(
+                            filePath: record.filePath,
+                            line: initializer.line,
+                            column: initializer.column
+                        ),
+                        notes: [
+                            ValidationIssueNote(
+                                message: "container '\(container.declarationPath)' is declared here.",
+                                location: ValidationIssueLocation(
+                                    filePath: container.filePath,
+                                    line: container.line,
+                                    column: container.column
+                                )
+                            ),
+                            ValidationIssueNote(
+                                message: "The synthesized container initializer already covers .input members and optional dependency overrides.",
+                                location: ValidationIssueLocation(
+                                    filePath: container.filePath,
+                                    line: container.line,
+                                    column: container.column
+                                )
+                            ),
+                            ValidationIssueNote(
+                                message: "Remove this custom initializer, or remove @DIContainer and wire the container manually."
+                            )
+                        ],
+                        remediation: "Prefer the synthesized initializer for .input members, or drop @DIContainer and keep the custom wiring manually.",
+                        metadata: [
+                            "containerPath": container.declarationPath,
+                            "resolutionState": resolution.state.rawValue
+                        ]
+                    )
+                )
+            }
+        }
+
+        issues.sort {
+            if $0.location.filePath != $1.location.filePath { return $0.location.filePath < $1.location.filePath }
+            if $0.location.line != $1.location.line { return $0.location.line < $1.location.line }
+            return $0.location.column < $1.location.column
+        }
+
+        return ValidationIssueReport(issues: issues)
+    }
+}
+
+private struct ContainerDeclarationRecord: Equatable {
+    let declarationPath: String
+    let filePath: String
+    let line: Int
+    let column: Int
+}
+
+private struct ExtensionInitializerRecord: Equatable {
+    struct InitializerLocation: Equatable {
+        let line: Int
+        let column: Int
+    }
+
+    let extendedTypeReference: SemanticTypeReference
+    let filePath: String
+    let initializers: [InitializerLocation]
+}
+
+private final class CustomInitFileCollector: SyntaxVisitor {
+    private let filePath: String
+    private let locationConverter: SourceLocationConverter
+    private var declarationStack: [String] = []
+
+    private(set) var containerDeclarations: [ContainerDeclarationRecord] = []
+    private(set) var extensionInitializers: [ExtensionInitializerRecord] = []
+    private(set) var nominalTypes: [SemanticNominalTypeRecord] = []
+    private(set) var typeAliases: [SemanticTypeAliasRecord] = []
+
+    init(filePath: String, syntax: SourceFileSyntax) {
+        self.filePath = filePath
+        self.locationConverter = SourceLocationConverter(fileName: filePath, tree: syntax)
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        visitNominal(node: Syntax(node), name: node.name.text, attributes: node.attributes)
+    }
+
+    override func visitPost(_ node: StructDeclSyntax) {
+        visitPostNominal()
+    }
+
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+        visitNominal(node: Syntax(node), name: node.name.text, attributes: node.attributes)
+    }
+
+    override func visitPost(_ node: ClassDeclSyntax) {
+        visitPostNominal()
+    }
+
+    override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
+        visitNominal(node: Syntax(node), name: node.name.text, attributes: node.attributes)
+    }
+
+    override func visitPost(_ node: ActorDeclSyntax) {
+        visitPostNominal()
+    }
+
+    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+        visitNominal(node: Syntax(node), name: node.name.text, attributes: node.attributes)
+    }
+
+    override func visitPost(_ node: EnumDeclSyntax) {
+        visitPostNominal()
+    }
+
+    override func visit(_ node: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard let targetReference = normalizedSemanticTypeReference(node.initializer.value) else {
+            return .skipChildren
+        }
+
+        let components = declarationStack + [node.name.text]
+        let path = components.joined(separator: ".")
+
+        typeAliases.append(
+            SemanticTypeAliasRecord(
+                path: path,
+                components: components,
+                target: targetReference
+            )
+        )
+        return .skipChildren
+    }
+
+    override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard node.genericWhereClause == nil,
+              let extendedTypeReference = normalizedSemanticTypeReference(node.extendedType) else {
+            return .skipChildren
+        }
+
+        let initializers = node.memberBlock.members.compactMap { member -> ExtensionInitializerRecord.InitializerLocation? in
+            guard let initializer = member.decl.as(InitializerDeclSyntax.self) else {
+                return nil
+            }
+            let location = locationConverter.location(for: initializer.positionAfterSkippingLeadingTrivia)
+            return ExtensionInitializerRecord.InitializerLocation(
+                line: location.line,
+                column: location.column
+            )
+        }
+
+        if !initializers.isEmpty {
+            extensionInitializers.append(
+                ExtensionInitializerRecord(
+                    extendedTypeReference: extendedTypeReference,
+                    filePath: filePath,
+                    initializers: initializers
+                )
+            )
+        }
+
+        return .skipChildren
+    }
+
+    private func visitNominal(node: Syntax, name: String, attributes: AttributeListSyntax?) -> SyntaxVisitorContinueKind {
+        declarationStack.append(name)
+        let declarationPath = declarationStack.joined(separator: ".")
+        nominalTypes.append(
+            SemanticNominalTypeRecord(
+                path: declarationPath,
+                components: declarationStack
+            )
+        )
+
+        if containsDIContainerAttribute(attributes) {
+            let location = locationConverter.location(for: node.positionAfterSkippingLeadingTrivia)
+            containerDeclarations.append(
+                ContainerDeclarationRecord(
+                    declarationPath: declarationPath,
+                    filePath: filePath,
+                    line: location.line,
+                    column: location.column
+                )
+            )
+        }
+
+        return .visitChildren
+    }
+
+    private func visitPostNominal() {
+        if !declarationStack.isEmpty {
+            declarationStack.removeLast()
+        }
+    }
+}
+
+private func containsDIContainerAttribute(_ attributes: AttributeListSyntax?) -> Bool {
+    guard let attributes else {
+        return false
+    }
+
+    for attribute in attributes {
+        guard let syntax = attribute.as(AttributeSyntax.self) else {
+            continue
+        }
+        if let identifier = syntax.attributeName.as(IdentifierTypeSyntax.self), identifier.name.text == "DIContainer" {
+            return true
+        }
+    }
+
+    return false
+}

--- a/Sources/InnoDIBuildSupport/ValidationCoordinator.swift
+++ b/Sources/InnoDIBuildSupport/ValidationCoordinator.swift
@@ -1,0 +1,349 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+package struct ValidationCommandResult: Codable, Equatable, Sendable {
+    package let exitCode: Int32
+    package let stdout: String
+    package let stderr: String
+
+    package init(exitCode: Int32, stdout: String, stderr: String) {
+        self.exitCode = exitCode
+        self.stdout = stdout
+        self.stderr = stderr
+    }
+}
+
+package struct ValidationExecutionOutcome: Equatable, Sendable {
+    package let result: ValidationCommandResult
+    package let wasCached: Bool
+    package let signature: String
+    package let metricsArtifact: ValidationMetricsArtifact
+    package let verboseSummary: String?
+}
+
+package protocol ValidationCommandRunning: Sendable {
+    func runValidationTool(toolPath: String, rootPath: String) throws -> ValidationCommandResult
+}
+
+package struct SharedValidationRunRecord: Codable, Equatable, Sendable {
+    package let liveRunMetrics: ValidationLiveRunMetrics
+    package let reasonCodes: [ValidationReasonCode]
+    package let issues: [ValidationIssue]
+}
+
+package struct LiveValidationCommandRunner: ValidationCommandRunning {
+    package init() {}
+
+    package func runValidationTool(toolPath: String, rootPath: String) throws -> ValidationCommandResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: toolPath)
+        process.arguments = ["--root", rootPath, "--validate-dag"]
+        process.currentDirectoryURL = URL(fileURLWithPath: rootPath)
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+        return ValidationCommandResult(
+            exitCode: process.terminationStatus,
+            stdout: stdout,
+            stderr: stderr
+        )
+    }
+}
+
+package enum ValidationCoordinator {
+    package static func coordinate(
+        rootPath: String,
+        toolPath: String,
+        stateDirectoryPath: String,
+        outputDirectoryPath: String
+    ) throws -> ValidationExecutionOutcome {
+        try coordinate(
+            rootPath: rootPath,
+            toolPath: toolPath,
+            stateDirectoryPath: stateDirectoryPath,
+            outputDirectoryPath: outputDirectoryPath,
+            runner: LiveValidationCommandRunner()
+        )
+    }
+
+    package static func coordinate<Runner: ValidationCommandRunning>(
+        rootPath: String,
+        toolPath: String,
+        stateDirectoryPath: String,
+        outputDirectoryPath: String,
+        runner: Runner,
+        verboseLoggingEnabled: Bool = ValidationLogging.isVerboseEnabled()
+    ) throws -> ValidationExecutionOutcome {
+        let coordinatorStartTime = CFAbsoluteTimeGetCurrent()
+        let fileManager = FileManager.default
+        let stateDirectoryURL = URL(fileURLWithPath: stateDirectoryPath, isDirectory: true)
+        let outputDirectoryURL = URL(fileURLWithPath: outputDirectoryPath, isDirectory: true)
+
+        try fileManager.createDirectory(at: stateDirectoryURL, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: outputDirectoryURL, withIntermediateDirectories: true)
+
+        let signatureCollectionStartTime = CFAbsoluteTimeGetCurrent()
+        let signatureCollection = try collectValidationSignatureWithMetrics(
+            rootPath: rootPath,
+            stateDirectoryPath: stateDirectoryPath
+        )
+        let signature = signatureCollection.signature
+        let signatureCollectionMilliseconds = validationElapsedMilliseconds(since: signatureCollectionStartTime)
+        let sharedRunDirectory = stateDirectoryURL.appendingPathComponent(signature, isDirectory: true)
+        try fileManager.createDirectory(at: sharedRunDirectory, withIntermediateDirectories: true)
+        try pruneSharedRunDirectories(keepingSignature: signature, in: stateDirectoryURL)
+
+        let resultURL = sharedRunDirectory.appendingPathComponent("result.json")
+        let sharedRunRecordURL = sharedRunDirectory.appendingPathComponent("validation-metrics.json")
+        let sharedSummaryURL = sharedRunDirectory.appendingPathComponent("validation-summary.md")
+        let lockURL = sharedRunDirectory.appendingPathComponent("lock")
+
+        func finalizeOutcome(
+            result: ValidationCommandResult,
+            wasCached: Bool,
+            sharedRunRecord: SharedValidationRunRecord
+        ) throws -> ValidationExecutionOutcome {
+            try writeStamp(signature: signature, result: result, to: outputDirectoryURL)
+            let combinedReasonCodes = Array(
+                Set(signatureCollection.reasonCodes + sharedRunRecord.reasonCodes)
+            )
+            .sorted { $0.rawValue < $1.rawValue }
+
+            let artifact = ValidationMetricsArtifact(
+                signature: signature,
+                wasCached: wasCached,
+                resultExitCode: result.exitCode,
+                reasonCodes: combinedReasonCodes,
+                signatureMetrics: signatureCollection.metrics,
+                fileChanges: signatureCollection.fileChanges,
+                invocationMetrics: ValidationInvocationMetrics(
+                    signatureCollectionMilliseconds: signatureCollectionMilliseconds,
+                    totalCoordinatorMilliseconds: validationElapsedMilliseconds(since: coordinatorStartTime)
+                ),
+                liveRunMetrics: sharedRunRecord.liveRunMetrics,
+                issues: sharedRunRecord.issues,
+                humanSummarySource: "dag-validation-summary.md"
+            )
+            try persistMetricsArtifact(
+                artifact,
+                to: outputDirectoryURL.appendingPathComponent("dag-validation-metrics.json")
+            )
+            try persistSummaryReport(
+                ValidationLogging.renderMarkdownSummary(for: artifact),
+                to: outputDirectoryURL.appendingPathComponent("dag-validation-summary.md")
+            )
+
+            let verboseSummary = verboseLoggingEnabled ? ValidationLogging.renderSummary(for: artifact) : nil
+            return ValidationExecutionOutcome(
+                result: result,
+                wasCached: wasCached,
+                signature: signature,
+                metricsArtifact: artifact,
+                verboseSummary: verboseSummary
+            )
+        }
+
+        if let cachedResult = try loadCachedResult(at: resultURL) {
+            let sharedRunRecord = try loadSharedRunRecord(at: sharedRunRecordURL)
+            return try finalizeOutcome(result: cachedResult, wasCached: true, sharedRunRecord: sharedRunRecord)
+        }
+
+        while true {
+            if let lockDescriptor = try acquireLock(at: lockURL) {
+                defer { releaseLock(descriptor: lockDescriptor, at: lockURL) }
+
+                if let cachedResult = try loadCachedResult(at: resultURL) {
+                    let sharedRunRecord = try loadSharedRunRecord(at: sharedRunRecordURL)
+                    return try finalizeOutcome(result: cachedResult, wasCached: true, sharedRunRecord: sharedRunRecord)
+                }
+
+                let result: ValidationCommandResult
+                let customInitStartTime = CFAbsoluteTimeGetCurrent()
+                let customInitValidation = try CustomInitBuildValidator.validate(rootPath: rootPath)
+                let customInitFailure = customInitValidation.asCommandResult()
+                let customInitValidationMilliseconds = validationElapsedMilliseconds(since: customInitStartTime)
+
+                let dagValidationMilliseconds: Double
+                let liveRunReasonCodes: [ValidationReasonCode]
+                let issues: [ValidationIssue]
+                if let customInitFailure {
+                    result = customInitFailure
+                    dagValidationMilliseconds = 0
+                    liveRunReasonCodes = [.liveRunCustomInitFailure]
+                    issues = customInitValidation.issues
+                } else {
+                    let dagValidationStartTime = CFAbsoluteTimeGetCurrent()
+                    result = try runner.runValidationTool(toolPath: toolPath, rootPath: rootPath)
+                    dagValidationMilliseconds = validationElapsedMilliseconds(since: dagValidationStartTime)
+                    liveRunReasonCodes = [.liveRunDAGValidation]
+                    issues = []
+                }
+
+                let sharedRunRecord = SharedValidationRunRecord(
+                    liveRunMetrics: ValidationLiveRunMetrics(
+                        customInitValidationMilliseconds: customInitValidationMilliseconds,
+                        dagValidationMilliseconds: dagValidationMilliseconds
+                    ),
+                    reasonCodes: liveRunReasonCodes,
+                    issues: issues
+                )
+                try persistSharedRunRecord(sharedRunRecord, to: sharedRunRecordURL)
+                try persistResult(result, to: resultURL)
+                let sharedArtifact = ValidationMetricsArtifact(
+                    signature: signature,
+                    wasCached: false,
+                    resultExitCode: result.exitCode,
+                    reasonCodes: Array(Set(signatureCollection.reasonCodes + liveRunReasonCodes)).sorted { $0.rawValue < $1.rawValue },
+                    signatureMetrics: signatureCollection.metrics,
+                    fileChanges: signatureCollection.fileChanges,
+                    invocationMetrics: ValidationInvocationMetrics(
+                        signatureCollectionMilliseconds: signatureCollectionMilliseconds,
+                        totalCoordinatorMilliseconds: validationElapsedMilliseconds(since: coordinatorStartTime)
+                    ),
+                    liveRunMetrics: sharedRunRecord.liveRunMetrics,
+                    issues: issues,
+                    humanSummarySource: "validation-summary.md"
+                )
+                try persistSummaryReport(
+                    ValidationLogging.renderMarkdownSummary(for: sharedArtifact),
+                    to: sharedSummaryURL
+                )
+
+                return try finalizeOutcome(result: result, wasCached: false, sharedRunRecord: sharedRunRecord)
+            }
+
+            if let cachedResult = try waitForCachedResult(resultURL: resultURL, lockURL: lockURL) {
+                let sharedRunRecord = try loadSharedRunRecord(at: sharedRunRecordURL)
+                return try finalizeOutcome(result: cachedResult, wasCached: true, sharedRunRecord: sharedRunRecord)
+            }
+        }
+    }
+}
+
+private func loadCachedResult(at url: URL) throws -> ValidationCommandResult? {
+    guard FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) else {
+        return nil
+    }
+
+    let data = try Data(contentsOf: url)
+    return try JSONDecoder().decode(ValidationCommandResult.self, from: data)
+}
+
+private func persistResult(_ result: ValidationCommandResult, to url: URL) throws {
+    let data = try JSONEncoder().encode(result)
+    try data.write(to: url, options: .atomic)
+}
+
+private func writeStamp(signature: String, result: ValidationCommandResult, to outputDirectoryURL: URL) throws {
+    let stampURL = outputDirectoryURL.appendingPathComponent("dag-validation-stamp.txt")
+    let content = "signature=\(signature)\nexitCode=\(result.exitCode)\n"
+    try content.write(to: stampURL, atomically: true, encoding: .utf8)
+}
+
+private func persistMetricsArtifact(_ artifact: ValidationMetricsArtifact, to url: URL) throws {
+    let data = try JSONEncoder().encode(artifact)
+    try data.write(to: url, options: .atomic)
+}
+
+private func loadSharedRunRecord(at url: URL) throws -> SharedValidationRunRecord {
+    guard FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) else {
+        return SharedValidationRunRecord(
+            liveRunMetrics: ValidationLiveRunMetrics(
+                customInitValidationMilliseconds: 0,
+                dagValidationMilliseconds: 0
+            ),
+            reasonCodes: [],
+            issues: []
+        )
+    }
+
+    let data = try Data(contentsOf: url)
+    return try JSONDecoder().decode(SharedValidationRunRecord.self, from: data)
+}
+
+private func persistSharedRunRecord(_ record: SharedValidationRunRecord, to url: URL) throws {
+    let data = try JSONEncoder().encode(record)
+    try data.write(to: url, options: .atomic)
+}
+
+private func persistSummaryReport(_ content: String, to url: URL) throws {
+    try content.write(to: url, atomically: true, encoding: .utf8)
+}
+
+private func acquireLock(at url: URL) throws -> Int32? {
+    let path = url.path(percentEncoded: false)
+    let descriptor = open(path, O_CREAT | O_EXCL | O_RDWR, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)
+
+    if descriptor >= 0 {
+        return descriptor
+    }
+
+    if errno == EEXIST {
+        return nil
+    }
+
+    throw POSIXLockError(code: errno, path: path)
+}
+
+private func releaseLock(descriptor: Int32, at url: URL) {
+    close(descriptor)
+    try? FileManager.default.removeItem(at: url)
+}
+
+private func pruneSharedRunDirectories(keepingSignature signature: String, in stateDirectoryURL: URL) throws {
+    let fileManager = FileManager.default
+    let entries = try fileManager.contentsOfDirectory(
+        at: stateDirectoryURL,
+        includingPropertiesForKeys: [.isDirectoryKey],
+        options: [.skipsHiddenFiles]
+    )
+
+    for entry in entries {
+        let values = try entry.resourceValues(forKeys: [.isDirectoryKey])
+        guard values.isDirectory == true, entry.lastPathComponent != signature else {
+            continue
+        }
+        try? fileManager.removeItem(at: entry)
+    }
+}
+
+private func waitForCachedResult(resultURL: URL, lockURL: URL) throws -> ValidationCommandResult? {
+    let timeoutDate = Date().addingTimeInterval(30)
+
+    while Date() < timeoutDate {
+        if let cachedResult = try loadCachedResult(at: resultURL) {
+            return cachedResult
+        }
+
+        if !FileManager.default.fileExists(atPath: lockURL.path(percentEncoded: false)) {
+            return nil
+        }
+
+        Thread.sleep(forTimeInterval: 0.05)
+    }
+
+    return nil
+}
+
+private struct POSIXLockError: LocalizedError {
+    let code: Int32
+    let path: String
+
+    var errorDescription: String? {
+        "Failed to acquire validation lock at '\(path)' (errno: \(code))."
+    }
+}

--- a/Sources/InnoDIBuildSupport/ValidationCoordinator.swift
+++ b/Sources/InnoDIBuildSupport/ValidationCoordinator.swift
@@ -50,11 +50,23 @@ package struct LiveValidationCommandRunner: ValidationCommandRunning {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
 
+        let stdoutBuffer = LockedDataBuffer()
+        let stderrBuffer = LockedDataBuffer()
+        installReadHandler(on: stdoutPipe.fileHandleForReading, buffer: stdoutBuffer)
+        installReadHandler(on: stderrPipe.fileHandleForReading, buffer: stderrBuffer)
+
         try process.run()
         process.waitUntilExit()
 
-        let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stdoutHandle = stdoutPipe.fileHandleForReading
+        let stderrHandle = stderrPipe.fileHandleForReading
+        stdoutHandle.readabilityHandler = nil
+        stderrHandle.readabilityHandler = nil
+        stdoutBuffer.append(stdoutHandle.readDataToEndOfFile())
+        stderrBuffer.append(stderrHandle.readDataToEndOfFile())
+
+        let stdout = String(data: stdoutBuffer.data, encoding: .utf8) ?? ""
+        let stderr = String(data: stderrBuffer.data, encoding: .utf8) ?? ""
 
         return ValidationCommandResult(
             exitCode: process.terminationStatus,
@@ -345,5 +357,38 @@ private struct POSIXLockError: LocalizedError {
 
     var errorDescription: String? {
         "Failed to acquire validation lock at '\(path)' (errno: \(code))."
+    }
+}
+
+private final class LockedDataBuffer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage = Data()
+
+    var data: Data {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    func append(_ chunk: Data) {
+        guard !chunk.isEmpty else {
+            return
+        }
+
+        lock.lock()
+        storage.append(chunk)
+        lock.unlock()
+    }
+}
+
+private func installReadHandler(on handle: FileHandle, buffer: LockedDataBuffer) {
+    handle.readabilityHandler = { readableHandle in
+        let chunk = readableHandle.availableData
+        if chunk.isEmpty {
+            readableHandle.readabilityHandler = nil
+            return
+        }
+
+        buffer.append(chunk)
     }
 }

--- a/Sources/InnoDIBuildSupport/ValidationCoordinator.swift
+++ b/Sources/InnoDIBuildSupport/ValidationCoordinator.swift
@@ -88,7 +88,7 @@ package enum ValidationCoordinator {
         runner: Runner,
         verboseLoggingEnabled: Bool = ValidationLogging.isVerboseEnabled()
     ) throws -> ValidationExecutionOutcome {
-        let coordinatorStartTime = CFAbsoluteTimeGetCurrent()
+        let coordinatorStartTime = validationNow()
         let fileManager = FileManager.default
         let stateDirectoryURL = URL(fileURLWithPath: stateDirectoryPath, isDirectory: true)
         let outputDirectoryURL = URL(fileURLWithPath: outputDirectoryPath, isDirectory: true)
@@ -96,7 +96,7 @@ package enum ValidationCoordinator {
         try fileManager.createDirectory(at: stateDirectoryURL, withIntermediateDirectories: true)
         try fileManager.createDirectory(at: outputDirectoryURL, withIntermediateDirectories: true)
 
-        let signatureCollectionStartTime = CFAbsoluteTimeGetCurrent()
+        let signatureCollectionStartTime = validationNow()
         let signatureCollection = try collectValidationSignatureWithMetrics(
             rootPath: rootPath,
             stateDirectoryPath: stateDirectoryPath
@@ -172,7 +172,7 @@ package enum ValidationCoordinator {
                 }
 
                 let result: ValidationCommandResult
-                let customInitStartTime = CFAbsoluteTimeGetCurrent()
+                let customInitStartTime = validationNow()
                 let customInitValidation = try CustomInitBuildValidator.validate(rootPath: rootPath)
                 let customInitFailure = customInitValidation.asCommandResult()
                 let customInitValidationMilliseconds = validationElapsedMilliseconds(since: customInitStartTime)
@@ -186,7 +186,7 @@ package enum ValidationCoordinator {
                     liveRunReasonCodes = [.liveRunCustomInitFailure]
                     issues = customInitValidation.issues
                 } else {
-                    let dagValidationStartTime = CFAbsoluteTimeGetCurrent()
+                    let dagValidationStartTime = validationNow()
                     result = try runner.runValidationTool(toolPath: toolPath, rootPath: rootPath)
                     dagValidationMilliseconds = validationElapsedMilliseconds(since: dagValidationStartTime)
                     liveRunReasonCodes = [.liveRunDAGValidation]

--- a/Sources/InnoDIBuildSupport/ValidationIssues.swift
+++ b/Sources/InnoDIBuildSupport/ValidationIssues.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+package enum ValidationIssueSeverity: String, Codable, Equatable, Sendable {
+    case error
+    case warning
+    case note
+}
+
+package struct ValidationIssueLocation: Codable, Equatable, Sendable {
+    package let filePath: String
+    package let line: Int
+    package let column: Int
+}
+
+package struct ValidationIssueNote: Codable, Equatable, Sendable {
+    package let message: String
+    package let location: ValidationIssueLocation?
+
+    package init(message: String, location: ValidationIssueLocation? = nil) {
+        self.message = message
+        self.location = location
+    }
+}
+
+package struct ValidationIssue: Codable, Equatable, Sendable {
+    package let code: String
+    package let severity: ValidationIssueSeverity
+    package let message: String
+    package let location: ValidationIssueLocation
+    package let notes: [ValidationIssueNote]
+    package let remediation: String?
+    package let metadata: [String: String]
+
+    package init(
+        code: String,
+        severity: ValidationIssueSeverity,
+        message: String,
+        location: ValidationIssueLocation,
+        notes: [ValidationIssueNote] = [],
+        remediation: String? = nil,
+        metadata: [String: String] = [:]
+    ) {
+        self.code = code
+        self.severity = severity
+        self.message = message
+        self.location = location
+        self.notes = notes
+        self.remediation = remediation
+        self.metadata = metadata
+    }
+}
+
+package struct ValidationIssueReport: Codable, Equatable, Sendable {
+    package let issues: [ValidationIssue]
+
+    package init(issues: [ValidationIssue]) {
+        self.issues = issues
+    }
+
+    package var hasFailures: Bool {
+        !issues.isEmpty
+    }
+
+    package func asCommandResult() -> ValidationCommandResult? {
+        guard hasFailures else {
+            return nil
+        }
+
+        let stderr = ValidationIssueRenderer.renderStderr(issues: issues)
+        return ValidationCommandResult(exitCode: 1, stdout: "", stderr: stderr)
+    }
+}
+
+package enum ValidationIssueRenderer {
+    package static func renderStderr(issues: [ValidationIssue]) -> String {
+        issues
+            .map(renderStderr(issue:))
+            .joined(separator: "\n") + "\n"
+    }
+
+    package static func renderMarkdown(issues: [ValidationIssue]) -> String {
+        guard !issues.isEmpty else {
+            return "## Build Issues\n\nNo structured build issues were emitted.\n"
+        }
+
+        var lines: [String] = ["## Build Issues", ""]
+        for issue in issues {
+            lines.append("### `[\(issue.code)]` \(issue.message)")
+            lines.append("")
+            lines.append("- Severity: `\(issue.severity.rawValue)`")
+            lines.append("- Location: `\(issue.location.filePath):\(issue.location.line):\(issue.location.column)`")
+            if let remediation = issue.remediation {
+                lines.append("- Remediation: \(remediation)")
+            }
+            if !issue.metadata.isEmpty {
+                for key in issue.metadata.keys.sorted() {
+                    lines.append("- \(key): `\(issue.metadata[key] ?? "")`")
+                }
+            }
+            for note in issue.notes {
+                if let location = note.location {
+                    lines.append("- Note: \(note.message) (`\(location.filePath):\(location.line):\(location.column)`)")   
+                } else {
+                    lines.append("- Note: \(note.message)")
+                }
+            }
+            lines.append("")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func renderStderr(issue: ValidationIssue) -> String {
+        var lines: [String] = [
+            "\(issue.location.filePath):\(issue.location.line):\(issue.location.column): \(issue.severity.rawValue): [\(issue.code)] \(issue.message)"
+        ]
+
+        for note in issue.notes {
+            if let location = note.location {
+                lines.append("\(location.filePath):\(location.line):\(location.column): note: \(note.message)")
+            } else {
+                lines.append("note: \(note.message)")
+            }
+        }
+
+        if let remediation = issue.remediation {
+            lines.append("note: Remediation: \(remediation)")
+        }
+
+        return lines.joined(separator: "\n")
+    }
+}

--- a/Sources/InnoDIBuildSupport/ValidationIssues.swift
+++ b/Sources/InnoDIBuildSupport/ValidationIssues.swift
@@ -73,7 +73,11 @@ package struct ValidationIssueReport: Codable, Equatable, Sendable {
 
 package enum ValidationIssueRenderer {
     package static func renderStderr(issues: [ValidationIssue]) -> String {
-        issues
+        guard !issues.isEmpty else {
+            return ""
+        }
+
+        return issues
             .map(renderStderr(issue:))
             .joined(separator: "\n") + "\n"
     }

--- a/Sources/InnoDIBuildSupport/ValidationIssues.swift
+++ b/Sources/InnoDIBuildSupport/ValidationIssues.swift
@@ -58,7 +58,7 @@ package struct ValidationIssueReport: Codable, Equatable, Sendable {
     }
 
     package var hasFailures: Bool {
-        !issues.isEmpty
+        issues.contains { $0.severity == .error }
     }
 
     package func asCommandResult() -> ValidationCommandResult? {
@@ -66,7 +66,8 @@ package struct ValidationIssueReport: Codable, Equatable, Sendable {
             return nil
         }
 
-        let stderr = ValidationIssueRenderer.renderStderr(issues: issues)
+        let failingIssues = issues.filter { $0.severity == .error }
+        let stderr = ValidationIssueRenderer.renderStderr(issues: failingIssues)
         return ValidationCommandResult(exitCode: 1, stdout: "", stderr: stderr)
     }
 }

--- a/Sources/InnoDIBuildSupport/ValidationIssues.swift
+++ b/Sources/InnoDIBuildSupport/ValidationIssues.swift
@@ -90,23 +90,23 @@ package enum ValidationIssueRenderer {
 
         var lines: [String] = ["## Build Issues", ""]
         for issue in issues {
-            lines.append("### `[\(issue.code)]` \(issue.message)")
+            lines.append("### `[\(sanitizeInline(issue.code))]` \(sanitizeInline(issue.message))")
             lines.append("")
-            lines.append("- Severity: `\(issue.severity.rawValue)`")
-            lines.append("- Location: `\(issue.location.filePath):\(issue.location.line):\(issue.location.column)`")
+            lines.append("- Severity: `\(sanitizeInline(issue.severity.rawValue))`")
+            lines.append("- Location: `\(renderLocation(issue.location))`")
             if let remediation = issue.remediation {
-                lines.append("- Remediation: \(remediation)")
+                lines.append("- Remediation: \(sanitizeInline(remediation))")
             }
             if !issue.metadata.isEmpty {
                 for key in issue.metadata.keys.sorted() {
-                    lines.append("- \(key): `\(issue.metadata[key] ?? "")`")
+                    lines.append("- \(sanitizeInline(key)): `\(sanitizeInline(issue.metadata[key] ?? ""))`")
                 }
             }
             for note in issue.notes {
                 if let location = note.location {
-                    lines.append("- Note: \(note.message) (`\(location.filePath):\(location.line):\(location.column)`)")   
+                    lines.append("- Note: \(sanitizeInline(note.message)) (`\(renderLocation(location))`)")
                 } else {
-                    lines.append("- Note: \(note.message)")
+                    lines.append("- Note: \(sanitizeInline(note.message))")
                 }
             }
             lines.append("")
@@ -116,21 +116,36 @@ package enum ValidationIssueRenderer {
 
     private static func renderStderr(issue: ValidationIssue) -> String {
         var lines: [String] = [
-            "\(issue.location.filePath):\(issue.location.line):\(issue.location.column): \(issue.severity.rawValue): [\(issue.code)] \(issue.message)"
+            "\(renderLocation(issue.location)): \(sanitizeInline(issue.severity.rawValue)): [\(sanitizeInline(issue.code))] \(sanitizeInline(issue.message))"
         ]
 
         for note in issue.notes {
             if let location = note.location {
-                lines.append("\(location.filePath):\(location.line):\(location.column): note: \(note.message)")
+                lines.append("\(renderLocation(location)): note: \(sanitizeInline(note.message))")
             } else {
-                lines.append("note: \(note.message)")
+                lines.append("note: \(sanitizeInline(note.message))")
             }
         }
 
         if let remediation = issue.remediation {
-            lines.append("note: Remediation: \(remediation)")
+            lines.append("note: Remediation: \(sanitizeInline(remediation))")
         }
 
         return lines.joined(separator: "\n")
+    }
+
+    private static func renderLocation(_ location: ValidationIssueLocation) -> String {
+        "\(sanitizeInline(location.filePath)):\(location.line):\(location.column)"
+    }
+
+    private static func sanitizeInline(_ text: String) -> String {
+        let sanitizedScalars = text.unicodeScalars.map { scalar in
+            CharacterSet.controlCharacters.contains(scalar) ? " " : String(scalar)
+        }
+        return sanitizedScalars
+            .joined()
+            .replacingOccurrences(of: "`", with: "'")
+            .split(whereSeparator: { $0.isWhitespace })
+            .joined(separator: " ")
     }
 }

--- a/Sources/InnoDIBuildSupport/ValidationMetrics.swift
+++ b/Sources/InnoDIBuildSupport/ValidationMetrics.swift
@@ -1,0 +1,252 @@
+import Foundation
+
+package enum ValidationReasonCode: String, Codable, Equatable, Sendable {
+    case cacheHitMetadata = "cache-hit-metadata"
+    case cacheHitContentHash = "cache-hit-content-hash"
+    case cacheMissContentChanged = "cache-miss-content-changed"
+    case cacheMissNewFile = "cache-miss-new-file"
+    case cacheMissDeletedFile = "cache-miss-deleted-file"
+    case cacheMissManifestVersion = "cache-miss-manifest-version"
+    case liveRunCustomInitFailure = "live-run-custom-init-failure"
+    case liveRunDAGValidation = "live-run-dag-validation"
+}
+
+package struct ValidationSignatureMetrics: Codable, Equatable, Sendable {
+    package let scannedFileCount: Int
+    package let metadataCacheHitCount: Int
+    package let contentHashReuseCount: Int
+    package let astReparseCount: Int
+
+    package var cacheHitCount: Int {
+        metadataCacheHitCount + contentHashReuseCount
+    }
+
+    package var cacheMissCount: Int {
+        astReparseCount
+    }
+}
+
+package struct ValidationFileChangeDetails: Codable, Equatable, Sendable {
+    package let newFiles: [String]
+    package let deletedFiles: [String]
+    package let reparsedFiles: [String]
+    package let contentHashReusedFiles: [String]
+    package let fallbackMatchedReferences: [String]
+
+    package init(
+        newFiles: [String] = [],
+        deletedFiles: [String] = [],
+        reparsedFiles: [String] = [],
+        contentHashReusedFiles: [String] = [],
+        fallbackMatchedReferences: [String] = []
+    ) {
+        self.newFiles = newFiles
+        self.deletedFiles = deletedFiles
+        self.reparsedFiles = reparsedFiles
+        self.contentHashReusedFiles = contentHashReusedFiles
+        self.fallbackMatchedReferences = fallbackMatchedReferences
+    }
+}
+
+package struct ValidationSignatureCollectionResult: Equatable, Sendable {
+    package let signature: String
+    package let metrics: ValidationSignatureMetrics
+    package let reasonCodes: [ValidationReasonCode]
+    package let fileChanges: ValidationFileChangeDetails
+}
+
+package struct ValidationInvocationMetrics: Codable, Equatable, Sendable {
+    package let signatureCollectionMilliseconds: Double
+    package let totalCoordinatorMilliseconds: Double
+}
+
+package struct ValidationLiveRunMetrics: Codable, Equatable, Sendable {
+    package let customInitValidationMilliseconds: Double
+    package let dagValidationMilliseconds: Double
+}
+
+package struct ValidationMetricsArtifact: Codable, Equatable, Sendable {
+    package static let currentVersion = 2
+
+    package let version: Int
+    package let signature: String
+    package let wasCached: Bool
+    package let resultExitCode: Int32
+    package let reasonCodes: [ValidationReasonCode]
+    package let signatureMetrics: ValidationSignatureMetrics
+    package let fileChanges: ValidationFileChangeDetails
+    package let invocationMetrics: ValidationInvocationMetrics
+    package let liveRunMetrics: ValidationLiveRunMetrics
+    package let issues: [ValidationIssue]
+    package let humanSummarySource: String
+
+    package init(
+        version: Int = currentVersion,
+        signature: String,
+        wasCached: Bool,
+        resultExitCode: Int32,
+        reasonCodes: [ValidationReasonCode],
+        signatureMetrics: ValidationSignatureMetrics,
+        fileChanges: ValidationFileChangeDetails,
+        invocationMetrics: ValidationInvocationMetrics,
+        liveRunMetrics: ValidationLiveRunMetrics,
+        issues: [ValidationIssue],
+        humanSummarySource: String
+    ) {
+        self.version = version
+        self.signature = signature
+        self.wasCached = wasCached
+        self.resultExitCode = resultExitCode
+        self.reasonCodes = reasonCodes
+        self.signatureMetrics = signatureMetrics
+        self.fileChanges = fileChanges
+        self.invocationMetrics = invocationMetrics
+        self.liveRunMetrics = liveRunMetrics
+        self.issues = issues
+        self.humanSummarySource = humanSummarySource
+    }
+}
+
+package enum ValidationLogging {
+    package static func isVerboseEnabled(environment: [String: String] = ProcessInfo.processInfo.environment) -> Bool {
+        isTruthy(environment["INNODI_VALIDATION_VERBOSE"]) || isTruthy(environment["INNODI_VALIDATION_DEBUG"])
+    }
+
+    package static func renderSummary(for artifact: ValidationMetricsArtifact) -> String {
+        [
+            "[InnoDI] signature=\(artifact.signature)",
+            "cached=\(artifact.wasCached ? "yes" : "no")",
+            "reasons=\(artifact.reasonCodes.map(\.rawValue).joined(separator: ","))",
+            "scanned=\(artifact.signatureMetrics.scannedFileCount)",
+            "hits=\(artifact.signatureMetrics.cacheHitCount)",
+            "misses=\(artifact.signatureMetrics.cacheMissCount)",
+            "metadata-hit=\(artifact.signatureMetrics.metadataCacheHitCount)",
+            "content-reuse=\(artifact.signatureMetrics.contentHashReuseCount)",
+            "ast-reparse=\(artifact.signatureMetrics.astReparseCount)",
+            "new-files=\(artifact.fileChanges.newFiles.count)",
+            "deleted-files=\(artifact.fileChanges.deletedFiles.count)",
+            "custom-init-ms=\(formatMilliseconds(artifact.liveRunMetrics.customInitValidationMilliseconds))",
+            "dag-ms=\(formatMilliseconds(artifact.liveRunMetrics.dagValidationMilliseconds))",
+            "signature-ms=\(formatMilliseconds(artifact.invocationMetrics.signatureCollectionMilliseconds))",
+            "total-ms=\(formatMilliseconds(artifact.invocationMetrics.totalCoordinatorMilliseconds))",
+            "issues=\(artifact.issues.count)"
+        ].joined(separator: " ") + "\n"
+    }
+
+    package static func renderMarkdownSummary(for artifact: ValidationMetricsArtifact) -> String {
+        var lines: [String] = [
+            "# InnoDI Validation Summary",
+            "",
+            "- Signature: `\(artifact.signature)`",
+            "- Cached: `\(artifact.wasCached ? "yes" : "no")`",
+            "- Exit code: `\(artifact.resultExitCode)`",
+            "- Human summary source: `\(artifact.humanSummarySource)`",
+            ""
+        ]
+
+        if artifact.reasonCodes.isEmpty {
+            lines.append("- Cache / run reasons: none")
+        } else {
+            lines.append("- Cache / run reasons:")
+            for reason in artifact.reasonCodes {
+                lines.append("  - `\(reason.rawValue)`: \(reasonDescription(reason))")
+            }
+        }
+
+        lines.append("")
+        lines.append("## Counts")
+        lines.append("")
+        lines.append("- Scanned files: `\(artifact.signatureMetrics.scannedFileCount)`")
+        lines.append("- Metadata hits: `\(artifact.signatureMetrics.metadataCacheHitCount)`")
+        lines.append("- Content-hash reuses: `\(artifact.signatureMetrics.contentHashReuseCount)`")
+        lines.append("- AST reparses: `\(artifact.signatureMetrics.astReparseCount)`")
+        lines.append("")
+        lines.append("## File Changes")
+        lines.append("")
+        lines.append(contentsOf: renderFileSection(title: "New files", files: artifact.fileChanges.newFiles))
+        lines.append(contentsOf: renderFileSection(title: "Deleted files", files: artifact.fileChanges.deletedFiles))
+        lines.append(contentsOf: renderFileSection(title: "Reparsed files", files: artifact.fileChanges.reparsedFiles))
+        lines.append(contentsOf: renderFileSection(title: "Content-hash reused files", files: artifact.fileChanges.contentHashReusedFiles))
+        if !artifact.fileChanges.fallbackMatchedReferences.isEmpty {
+            lines.append("")
+            lines.append("### Semantic fallback matches")
+            lines.append("")
+            for reference in artifact.fileChanges.fallbackMatchedReferences.prefix(10) {
+                lines.append("- `\(reference)`")
+            }
+            if artifact.fileChanges.fallbackMatchedReferences.count > 10 {
+                lines.append("- ... and \(artifact.fileChanges.fallbackMatchedReferences.count - 10) more")
+            }
+        }
+        lines.append("")
+        lines.append("## Timings")
+        lines.append("")
+        lines.append("- Signature collection: `\(formatMilliseconds(artifact.invocationMetrics.signatureCollectionMilliseconds)) ms`")
+        lines.append("- Custom init validation: `\(formatMilliseconds(artifact.liveRunMetrics.customInitValidationMilliseconds)) ms`")
+        lines.append("- DAG validation: `\(formatMilliseconds(artifact.liveRunMetrics.dagValidationMilliseconds)) ms`")
+        lines.append("- Total coordinator: `\(formatMilliseconds(artifact.invocationMetrics.totalCoordinatorMilliseconds)) ms`")
+        lines.append("")
+        lines.append(ValidationIssueRenderer.renderMarkdown(issues: artifact.issues))
+        lines.append("")
+
+        return lines.joined(separator: "\n")
+    }
+}
+
+package func validationElapsedMilliseconds(since startTime: TimeInterval) -> Double {
+    max(0, (CFAbsoluteTimeGetCurrent() - startTime) * 1_000)
+}
+
+private func isTruthy(_ value: String?) -> Bool {
+    guard let value else {
+        return false
+    }
+
+    switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+    case "1", "true", "yes", "on", "debug", "verbose":
+        return true
+    default:
+        return false
+    }
+}
+
+private func formatMilliseconds(_ value: Double) -> String {
+    String(format: "%.2f", value)
+}
+
+private func reasonDescription(_ reason: ValidationReasonCode) -> String {
+    switch reason {
+    case .cacheHitMetadata:
+        return "All scanned files reused their cached AST digests from unchanged file metadata."
+    case .cacheHitContentHash:
+        return "At least one file changed metadata but reused its cached AST digest after a raw content hash match."
+    case .cacheMissContentChanged:
+        return "At least one file changed content and required a fresh AST parse."
+    case .cacheMissNewFile:
+        return "A newly discovered Swift source file invalidated the previous signature cache."
+    case .cacheMissDeletedFile:
+        return "A previously cached Swift source file disappeared and forced a signature recomputation."
+    case .cacheMissManifestVersion:
+        return "The AST digest manifest version changed, so the cache was rebuilt from scratch."
+    case .liveRunCustomInitFailure:
+        return "The live validation run stopped after a structured cross-file custom init failure."
+    case .liveRunDAGValidation:
+        return "The live validation run executed the DAG validator."
+    }
+}
+
+private func renderFileSection(title: String, files: [String]) -> [String] {
+    var lines = ["### \(title)", ""]
+    if files.isEmpty {
+        lines.append("- none")
+        return lines + [""]
+    }
+
+    for file in files.prefix(10) {
+        lines.append("- `\(file)`")
+    }
+    if files.count > 10 {
+        lines.append("- ... and \(files.count - 10) more")
+    }
+    return lines + [""]
+}

--- a/Sources/InnoDIBuildSupport/ValidationMetrics.swift
+++ b/Sources/InnoDIBuildSupport/ValidationMetrics.swift
@@ -48,7 +48,7 @@ package struct ValidationFileChangeDetails: Codable, Equatable, Sendable {
     }
 }
 
-package struct ValidationSignatureCollectionResult: Equatable, Sendable {
+package struct ValidationSignatureCollectionResult: Codable, Equatable, Sendable {
     package let signature: String
     package let metrics: ValidationSignatureMetrics
     package let reasonCodes: [ValidationReasonCode]
@@ -193,8 +193,12 @@ package enum ValidationLogging {
     }
 }
 
+package func validationNow() -> TimeInterval {
+    ProcessInfo.processInfo.systemUptime
+}
+
 package func validationElapsedMilliseconds(since startTime: TimeInterval) -> Double {
-    max(0, (CFAbsoluteTimeGetCurrent() - startTime) * 1_000)
+    max(0, (validationNow() - startTime) * 1_000)
 }
 
 private func isTruthy(_ value: String?) -> Bool {

--- a/Sources/InnoDIBuildSupport/ValidationSignature.swift
+++ b/Sources/InnoDIBuildSupport/ValidationSignature.swift
@@ -1,0 +1,303 @@
+import Foundation
+import SwiftParser
+import SwiftSyntax
+
+let validationSkipTokens = [
+    "/.build/",
+    "/Derived/",
+    "/Tuist/Dependencies/",
+    "/.tuist/",
+    "/.git/",
+    "/Pods/",
+    "/Carthage/",
+    "/.swiftpm/",
+    "/.xcodeproj/",
+    "/.xcworkspace/"
+]
+
+protocol ValidationSyntaxParsing: Sendable {
+    func parse(source: String) -> SourceFileSyntax
+}
+
+struct LiveValidationSyntaxParser: ValidationSyntaxParsing {
+    func parse(source: String) -> SourceFileSyntax {
+        Parser.parse(source: source)
+    }
+}
+
+struct ValidationFileFingerprint: Codable, Equatable, Sendable {
+    let fileSize: Int
+    let modifiedAt: TimeInterval
+}
+
+struct ValidationFileDigestRecord: Codable, Equatable, Sendable {
+    let fingerprint: ValidationFileFingerprint
+    let contentHash: String
+    let digest: String
+}
+
+struct ValidationDigestManifest: Codable, Equatable, Sendable {
+    static let currentVersion = 2
+
+    let version: Int
+    let files: [String: ValidationFileDigestRecord]
+
+    init(version: Int = currentVersion, files: [String: ValidationFileDigestRecord]) {
+        self.version = version
+        self.files = files
+    }
+}
+
+private struct LoadedValidationDigestManifest {
+    let manifest: ValidationDigestManifest
+    let invalidatedByVersion: Bool
+}
+
+struct ValidationSignatureCollector<Parser: ValidationSyntaxParsing> {
+    let stateDirectoryPath: String
+    let parser: Parser
+
+    func collect(rootPath: String) throws -> String {
+        try collectWithMetrics(rootPath: rootPath).signature
+    }
+
+    func collectWithMetrics(rootPath: String) throws -> ValidationSignatureCollectionResult {
+        let fileManager = FileManager.default
+        let stateDirectoryURL = URL(fileURLWithPath: stateDirectoryPath, isDirectory: true)
+        try fileManager.createDirectory(at: stateDirectoryURL, withIntermediateDirectories: true)
+
+        let manifestURL = stateDirectoryURL.appendingPathComponent("ast-digest-cache.json")
+        let loadedManifest = try loadManifest(at: manifestURL)
+        let existingManifest = loadedManifest.manifest
+        let sourceFiles = discoverValidationSourceFiles(rootPath: rootPath)
+        var updatedRecords: [String: ValidationFileDigestRecord] = [:]
+        var metadataCacheHitCount = 0
+        var contentHashReuseCount = 0
+        var astReparseCount = 0
+        var reasonCodes: Set<ValidationReasonCode> = []
+        var newFiles: [String] = []
+        var deletedFiles: [String] = []
+        var reparsedFiles: [String] = []
+        var contentHashReusedFiles: [String] = []
+
+        if loadedManifest.invalidatedByVersion {
+            reasonCodes.insert(.cacheMissManifestVersion)
+        }
+
+        let deletedFileSet = Set(existingManifest.files.keys).subtracting(sourceFiles)
+        if !deletedFileSet.isEmpty {
+            reasonCodes.insert(.cacheMissDeletedFile)
+        }
+        deletedFiles = deletedFileSet.sorted()
+
+        for relativePath in sourceFiles {
+            let fileURL = URL(fileURLWithPath: rootPath).appendingPathComponent(relativePath)
+            let fingerprint = try makeFingerprint(for: fileURL)
+            let wasCached = existingManifest.files[relativePath] != nil
+
+            if !wasCached {
+                reasonCodes.insert(.cacheMissNewFile)
+                newFiles.append(relativePath)
+            }
+
+            if let cached = existingManifest.files[relativePath], cached.fingerprint == fingerprint {
+                updatedRecords[relativePath] = cached
+                metadataCacheHitCount += 1
+                reasonCodes.insert(.cacheHitMetadata)
+                continue
+            }
+
+            let data = try Data(contentsOf: fileURL)
+            let contentHash = rawContentHash(for: data)
+
+            if let cached = existingManifest.files[relativePath], cached.contentHash == contentHash {
+                updatedRecords[relativePath] = ValidationFileDigestRecord(
+                    fingerprint: fingerprint,
+                    contentHash: contentHash,
+                    digest: cached.digest
+                )
+                contentHashReuseCount += 1
+                contentHashReusedFiles.append(relativePath)
+                reasonCodes.insert(.cacheHitContentHash)
+                continue
+            }
+
+            let source = String(decoding: data, as: UTF8.self)
+            let syntax = parser.parse(source: source)
+            let digest = normalizedDigest(for: syntax)
+            astReparseCount += 1
+            reparsedFiles.append(relativePath)
+            reasonCodes.insert(.cacheMissContentChanged)
+            updatedRecords[relativePath] = ValidationFileDigestRecord(
+                fingerprint: fingerprint,
+                contentHash: contentHash,
+                digest: digest
+            )
+        }
+
+        let manifest = ValidationDigestManifest(files: updatedRecords)
+        try persistManifest(manifest, to: manifestURL)
+
+        var hasher = StableHasher()
+        hasher.combine("count:\(sourceFiles.count)")
+
+        for relativePath in sourceFiles {
+            hasher.combine("file:\(relativePath)")
+            hasher.combine("digest:\(updatedRecords[relativePath]?.digest ?? "missing")")
+        }
+
+        return ValidationSignatureCollectionResult(
+            signature: hasher.finalize(),
+            metrics: ValidationSignatureMetrics(
+                scannedFileCount: sourceFiles.count,
+                metadataCacheHitCount: metadataCacheHitCount,
+                contentHashReuseCount: contentHashReuseCount,
+                astReparseCount: astReparseCount
+            ),
+            reasonCodes: reasonCodes.sorted { $0.rawValue < $1.rawValue },
+            fileChanges: ValidationFileChangeDetails(
+                newFiles: newFiles.sorted(),
+                deletedFiles: deletedFiles,
+                reparsedFiles: reparsedFiles.sorted(),
+                contentHashReusedFiles: contentHashReusedFiles.sorted()
+            )
+        )
+    }
+}
+
+func collectValidationSignature(
+    rootPath: String,
+    stateDirectoryPath: String? = nil
+) throws -> String {
+    try collectValidationSignatureWithMetrics(
+        rootPath: rootPath,
+        stateDirectoryPath: stateDirectoryPath
+    ).signature
+}
+
+func collectValidationSignatureWithMetrics(
+    rootPath: String,
+    stateDirectoryPath: String? = nil
+) throws -> ValidationSignatureCollectionResult {
+    let resolvedStateDirectoryPath: String
+    if let stateDirectoryPath {
+        resolvedStateDirectoryPath = stateDirectoryPath
+    } else {
+        resolvedStateDirectoryPath = URL(fileURLWithPath: rootPath)
+            .appendingPathComponent(".build", isDirectory: true)
+            .appendingPathComponent("innodi-ast-digest-cache", isDirectory: true)
+            .path(percentEncoded: false)
+    }
+
+    return try ValidationSignatureCollector(
+        stateDirectoryPath: resolvedStateDirectoryPath,
+        parser: LiveValidationSyntaxParser()
+    )
+    .collectWithMetrics(rootPath: rootPath)
+}
+
+func discoverValidationSourceFiles(rootPath: String) -> [String] {
+    let fileManager = FileManager.default
+    guard let enumerator = fileManager.enumerator(atPath: rootPath) else {
+        return []
+    }
+
+    var sourceFiles: [String] = []
+
+    while let item = enumerator.nextObject() as? String {
+        if item.hasPrefix(".") { continue }
+        if shouldSkipValidationPath(item) { continue }
+        guard item.hasSuffix(".swift") else { continue }
+        sourceFiles.append(item)
+    }
+
+    return sourceFiles.sorted()
+}
+
+private func shouldSkipValidationPath(_ path: String) -> Bool {
+    for token in validationSkipTokens where path.contains(token) {
+        return true
+    }
+    return false
+}
+
+private func makeFingerprint(for fileURL: URL) throws -> ValidationFileFingerprint {
+    let resourceValues = try fileURL.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
+    return ValidationFileFingerprint(
+        fileSize: resourceValues.fileSize ?? 0,
+        modifiedAt: resourceValues.contentModificationDate?.timeIntervalSince1970 ?? 0
+    )
+}
+
+private func normalizedDigest(for syntax: SourceFileSyntax) -> String {
+    var hasher = StableHasher()
+    appendNormalizedSyntax(Syntax(syntax), to: &hasher)
+    return hasher.finalize()
+}
+
+private func rawContentHash(for data: Data) -> String {
+    var hasher = StableHasher()
+    hasher.combine(data)
+    return hasher.finalize()
+}
+
+private func appendNormalizedSyntax(_ node: Syntax, to hasher: inout StableHasher) {
+    hasher.combine("(\(String(describing: node.kind))")
+
+    if let token = node.as(TokenSyntax.self) {
+        hasher.combine("|\(String(describing: token.tokenKind))")
+        hasher.combine("|\(token.text)")
+    }
+
+    for child in node.children(viewMode: .all) {
+        appendNormalizedSyntax(child, to: &hasher)
+    }
+
+    hasher.combine(")")
+}
+
+private func loadManifest(at url: URL) throws -> LoadedValidationDigestManifest {
+    guard FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) else {
+        return LoadedValidationDigestManifest(
+            manifest: ValidationDigestManifest(files: [:]),
+            invalidatedByVersion: false
+        )
+    }
+
+    let data = try Data(contentsOf: url)
+    let manifest = try JSONDecoder().decode(ValidationDigestManifest.self, from: data)
+    if manifest.version == ValidationDigestManifest.currentVersion {
+        return LoadedValidationDigestManifest(manifest: manifest, invalidatedByVersion: false)
+    }
+    return LoadedValidationDigestManifest(
+        manifest: ValidationDigestManifest(files: [:]),
+        invalidatedByVersion: true
+    )
+}
+
+private func persistManifest(_ manifest: ValidationDigestManifest, to url: URL) throws {
+    let data = try JSONEncoder().encode(manifest)
+    try data.write(to: url, options: .atomic)
+}
+
+struct StableHasher {
+    private var state: UInt64 = 14_695_981_039_346_656_037
+
+    mutating func combine(_ value: String) {
+        for byte in value.utf8 {
+            state ^= UInt64(byte)
+            state &*= 1_099_511_628_211
+        }
+    }
+
+    mutating func combine(_ data: Data) {
+        for byte in data {
+            state ^= UInt64(byte)
+            state &*= 1_099_511_628_211
+        }
+    }
+
+    func finalize() -> String {
+        String(state, radix: 16)
+    }
+}

--- a/Sources/InnoDICore/DependencyGraphCore.swift
+++ b/Sources/InnoDICore/DependencyGraphCore.swift
@@ -1,13 +1,22 @@
 package struct DependencyGraphNode: Hashable {
     package let id: String
     package let displayName: String
+    package let semanticPath: String
     package let isRoot: Bool
     package let validateDAG: Bool
     package let requiredInputs: [String]
 
-    package init(id: String, displayName: String, isRoot: Bool, validateDAG: Bool = true, requiredInputs: [String]) {
+    package init(
+        id: String,
+        displayName: String,
+        semanticPath: String,
+        isRoot: Bool,
+        validateDAG: Bool = true,
+        requiredInputs: [String]
+    ) {
         self.id = id
         self.displayName = displayName
+        self.semanticPath = semanticPath
         self.isRoot = isRoot
         self.validateDAG = validateDAG
         self.requiredInputs = requiredInputs
@@ -27,16 +36,25 @@ package struct DependencyGraphEdge: Hashable {
 }
 
 package func normalizeNodes(_ nodes: [DependencyGraphNode]) -> [DependencyGraphNode] {
-    var map: [String: (displayName: String, isRoot: Bool, validateDAG: Bool, inputs: Set<String>)] = [:]
+    var map: [String: (displayName: String, semanticPath: String, isRoot: Bool, validateDAG: Bool, inputs: Set<String>)] = [:]
 
     for node in nodes {
-        var entry = map[node.id] ?? (displayName: node.displayName, isRoot: false, validateDAG: true, inputs: [])
+        var entry = map[node.id] ?? (
+            displayName: node.displayName,
+            semanticPath: node.semanticPath,
+            isRoot: false,
+            validateDAG: true,
+            inputs: []
+        )
         entry.isRoot = entry.isRoot || node.isRoot
         entry.validateDAG = entry.validateDAG && node.validateDAG
         entry.inputs.formUnion(node.requiredInputs)
 
         if entry.displayName.isEmpty {
             entry.displayName = node.displayName
+        }
+        if entry.semanticPath.isEmpty {
+            entry.semanticPath = node.semanticPath
         }
 
         map[node.id] = entry
@@ -47,6 +65,7 @@ package func normalizeNodes(_ nodes: [DependencyGraphNode]) -> [DependencyGraphN
         return DependencyGraphNode(
             id: id,
             displayName: entry.displayName,
+            semanticPath: entry.semanticPath,
             isRoot: entry.isRoot,
             validateDAG: entry.validateDAG,
             requiredInputs: entry.inputs.sorted()

--- a/Sources/InnoDICore/SemanticResolution.swift
+++ b/Sources/InnoDICore/SemanticResolution.swift
@@ -129,6 +129,9 @@ package struct SemanticResolverIndex: Equatable, Sendable {
                     return Array(candidateComponents.suffix(components.count)) == components
                 }
 
+                guard candidateComponents.count > 1 else {
+                    return false
+                }
                 return Array(components.suffix(candidateComponents.count)) == candidateComponents
             }
             .sorted()
@@ -255,6 +258,14 @@ private struct ResolutionMatch {
     let usedSuffixFallback: Bool
 }
 
+/// Returns a normalized semantic reference for nominal type syntax.
+///
+/// - Important: Generic `IdentifierTypeSyntax` and `MemberTypeSyntax` values
+///   return `nil` because the resolver currently excludes generic shapes from
+///   semantic matching.
+/// - Note: `AttributedTypeSyntax` delegates to its `baseType`.
+/// - Returns: A normalized reference, or `nil` when the type shape is excluded
+///   and the caller must handle the unsupported case conservatively.
 package func normalizedSemanticTypeReference(_ type: TypeSyntax) -> SemanticTypeReference? {
     if let identifier = type.as(IdentifierTypeSyntax.self) {
         guard identifier.genericArgumentClause == nil else {

--- a/Sources/InnoDICore/SemanticResolution.swift
+++ b/Sources/InnoDICore/SemanticResolution.swift
@@ -1,0 +1,337 @@
+import SwiftSyntax
+
+package struct SemanticTypeReference: Codable, Equatable, Sendable {
+    package let displayPath: String
+    package let components: [String]
+
+    package init(displayPath: String, components: [String]) {
+        self.displayPath = displayPath
+        self.components = components
+    }
+}
+
+package struct SemanticNominalTypeRecord: Codable, Equatable, Sendable {
+    package let path: String
+    package let components: [String]
+
+    package init(path: String, components: [String]) {
+        self.path = path
+        self.components = components
+    }
+}
+
+package struct SemanticTypeAliasRecord: Codable, Equatable, Sendable {
+    package let path: String
+    package let components: [String]
+    package let target: SemanticTypeReference
+
+    package init(path: String, components: [String], target: SemanticTypeReference) {
+        self.path = path
+        self.components = components
+        self.target = target
+    }
+}
+
+package enum SemanticResolutionState: String, Codable, Equatable, Sendable {
+    case resolved
+    case ambiguous
+    case excluded
+    case unresolved
+}
+
+package struct SemanticResolutionResult: Codable, Equatable, Sendable {
+    package let state: SemanticResolutionState
+    package let resolvedPath: String?
+    package let candidates: [String]
+    package let excludedReason: String?
+    package let aliasExpansionTrace: [String]
+    package let usedSuffixFallback: Bool
+
+    package init(
+        state: SemanticResolutionState,
+        resolvedPath: String? = nil,
+        candidates: [String] = [],
+        excludedReason: String? = nil,
+        aliasExpansionTrace: [String] = [],
+        usedSuffixFallback: Bool = false
+    ) {
+        self.state = state
+        self.resolvedPath = resolvedPath
+        self.candidates = candidates
+        self.excludedReason = excludedReason
+        self.aliasExpansionTrace = aliasExpansionTrace
+        self.usedSuffixFallback = usedSuffixFallback
+    }
+}
+
+package struct SemanticResolverIndex: Equatable, Sendable {
+    package let nominalTypes: [SemanticNominalTypeRecord]
+    package let typeAliases: [SemanticTypeAliasRecord]
+
+    package init(
+        nominalTypes: [SemanticNominalTypeRecord],
+        topLevelTypeAliases: [SemanticTypeAliasRecord]
+    ) {
+        self.nominalTypes = nominalTypes
+        self.typeAliases = topLevelTypeAliases
+    }
+
+    package func resolvePath(
+        for reference: SemanticTypeReference,
+        candidatePaths: Set<String>
+    ) -> SemanticResolutionResult {
+        let expansions = expandedReferences(for: reference)
+        let exactMatches = uniqueMatches(
+            for: expansions.compactMap { candidate in
+                candidatePaths.contains(candidate.reference.displayPath)
+                    ? ResolutionMatch(
+                        path: candidate.reference.displayPath,
+                        aliasExpansionTrace: candidate.aliasExpansionTrace,
+                        usedSuffixFallback: false
+                    )
+                    : nil
+            }
+        )
+        if let result = resolutionResult(for: exactMatches) {
+            return result
+        }
+
+        let suffixResolutionMatches = uniqueMatches(
+            for: expansions.flatMap { candidate in
+                suffixMatches(for: candidate.reference.components, candidatePaths: candidatePaths).map { path in
+                    ResolutionMatch(
+                        path: path,
+                        aliasExpansionTrace: candidate.aliasExpansionTrace,
+                        usedSuffixFallback: true
+                    )
+                }
+            }
+        )
+        if let result = resolutionResult(for: suffixResolutionMatches) {
+            return result
+        }
+
+        return SemanticResolutionResult(state: .unresolved, aliasExpansionTrace: expansions.flatMap(\.aliasExpansionTrace))
+    }
+
+    private func suffixMatches(
+        for components: [String],
+        candidatePaths: Set<String>
+    ) -> [String] {
+        guard !components.isEmpty else {
+            return []
+        }
+
+        return candidatePaths
+            .filter { path in
+                let candidateComponents = path.split(separator: ".").map(String.init)
+                if candidateComponents.count >= components.count {
+                    return Array(candidateComponents.suffix(components.count)) == components
+                }
+
+                return Array(components.suffix(candidateComponents.count)) == candidateComponents
+            }
+            .sorted()
+    }
+
+    private func expandedReferences(for reference: SemanticTypeReference) -> [ResolutionCandidate] {
+        var queue: [ResolutionCandidate] = [
+            ResolutionCandidate(reference: reference, aliasExpansionTrace: [])
+        ]
+        var visited: Set<String> = [reference.displayPath]
+        var results: [ResolutionCandidate] = []
+
+        while !queue.isEmpty {
+            let current = queue.removeFirst()
+            results.append(current)
+
+            for expansion in directAliasExpansions(for: current.reference) {
+                let key = expansion.reference.displayPath
+                if visited.insert(key).inserted {
+                    queue.append(
+                        ResolutionCandidate(
+                            reference: expansion.reference,
+                            aliasExpansionTrace: current.aliasExpansionTrace + expansion.aliasExpansionTrace
+                        )
+                    )
+                }
+            }
+        }
+
+        return results
+    }
+
+    private func directAliasExpansions(for reference: SemanticTypeReference) -> [ResolutionCandidate] {
+        guard !reference.components.isEmpty else {
+            return []
+        }
+
+        var expansions: [ResolutionCandidate] = []
+
+        for prefixLength in stride(from: reference.components.count, through: 1, by: -1) {
+            let prefix = Array(reference.components.prefix(prefixLength))
+            let remainder = Array(reference.components.dropFirst(prefixLength))
+            let matches = matchingAliases(for: prefix)
+
+            for match in matches {
+                let components = match.target.components + remainder
+                expansions.append(
+                    ResolutionCandidate(
+                        reference: SemanticTypeReference(
+                            displayPath: components.joined(separator: "."),
+                            components: components
+                        ),
+                        aliasExpansionTrace: [match.path]
+                    )
+                )
+            }
+        }
+
+        return expansions
+    }
+
+    private func matchingAliases(for referencePrefix: [String]) -> [SemanticTypeAliasRecord] {
+        typeAliases
+            .filter { alias in
+                if alias.components == referencePrefix {
+                    return true
+                }
+                guard alias.components.count >= referencePrefix.count else {
+                    return false
+                }
+                return Array(alias.components.suffix(referencePrefix.count)) == referencePrefix
+            }
+            .sorted { $0.path < $1.path }
+    }
+
+    private func uniqueMatches(for matches: [ResolutionMatch]) -> [ResolutionMatch] {
+        var seen: Set<String> = []
+        var unique: [ResolutionMatch] = []
+        for match in matches.sorted(by: { lhs, rhs in
+            if lhs.path != rhs.path {
+                return lhs.path < rhs.path
+            }
+            if lhs.usedSuffixFallback != rhs.usedSuffixFallback {
+                return lhs.usedSuffixFallback == false
+            }
+            return lhs.aliasExpansionTrace.joined(separator: "->") < rhs.aliasExpansionTrace.joined(separator: "->")
+        }) {
+            if seen.insert(match.path).inserted {
+                unique.append(match)
+            }
+        }
+        return unique
+    }
+
+    private func resolutionResult(for matches: [ResolutionMatch]) -> SemanticResolutionResult? {
+        guard !matches.isEmpty else {
+            return nil
+        }
+        if matches.count == 1, let match = matches.first {
+            return SemanticResolutionResult(
+                state: .resolved,
+                resolvedPath: match.path,
+                aliasExpansionTrace: match.aliasExpansionTrace,
+                usedSuffixFallback: match.usedSuffixFallback
+            )
+        }
+        return SemanticResolutionResult(
+            state: .ambiguous,
+            candidates: matches.map(\.path),
+            aliasExpansionTrace: Array(Set(matches.flatMap(\.aliasExpansionTrace))).sorted(),
+            usedSuffixFallback: matches.contains(where: \.usedSuffixFallback)
+        )
+    }
+}
+
+private struct ResolutionCandidate {
+    let reference: SemanticTypeReference
+    let aliasExpansionTrace: [String]
+}
+
+private struct ResolutionMatch {
+    let path: String
+    let aliasExpansionTrace: [String]
+    let usedSuffixFallback: Bool
+}
+
+package func normalizedSemanticTypeReference(_ type: TypeSyntax) -> SemanticTypeReference? {
+    if let identifier = type.as(IdentifierTypeSyntax.self) {
+        guard identifier.genericArgumentClause == nil else {
+            return nil
+        }
+
+        let component = identifier.name.text
+        return SemanticTypeReference(displayPath: component, components: [component])
+    }
+
+    if let member = type.as(MemberTypeSyntax.self) {
+        guard member.genericArgumentClause == nil,
+              let base = normalizedSemanticTypeReference(member.baseType) else {
+            return nil
+        }
+
+        let components = base.components + [member.name.text]
+        return SemanticTypeReference(
+            displayPath: components.joined(separator: "."),
+            components: components
+        )
+    }
+
+    if let attributed = type.as(AttributedTypeSyntax.self) {
+        return normalizedSemanticTypeReference(attributed.baseType)
+    }
+
+    return nil
+}
+
+package func normalizedSemanticExpressionReference(_ expr: ExprSyntax) -> SemanticTypeReference? {
+    if let declReference = expr.as(DeclReferenceExprSyntax.self) {
+        let component = declReference.baseName.text
+        return SemanticTypeReference(displayPath: component, components: [component])
+    }
+
+    if let memberAccess = expr.as(MemberAccessExprSyntax.self) {
+        let memberName = memberAccess.declName.baseName.text
+        if memberName == "init" || memberName == "self", let base = memberAccess.base {
+            return normalizedSemanticExpressionReference(base)
+        }
+
+        if let base = memberAccess.base,
+           let baseReference = normalizedSemanticExpressionReference(base) {
+            let components = baseReference.components + [memberName]
+            return SemanticTypeReference(
+                displayPath: components.joined(separator: "."),
+                components: components
+            )
+        }
+
+        return SemanticTypeReference(displayPath: memberName, components: [memberName])
+    }
+
+    if let genericSpecialization = expr.as(GenericSpecializationExprSyntax.self) {
+        return normalizedSemanticExpressionReference(genericSpecialization.expression)
+    }
+
+    if let functionCall = expr.as(FunctionCallExprSyntax.self) {
+        return normalizedSemanticExpressionReference(functionCall.calledExpression)
+    }
+
+    if let forceUnwrap = expr.as(ForceUnwrapExprSyntax.self) {
+        return normalizedSemanticExpressionReference(forceUnwrap.expression)
+    }
+
+    if let optionalChaining = expr.as(OptionalChainingExprSyntax.self) {
+        return normalizedSemanticExpressionReference(optionalChaining.expression)
+    }
+
+    if let tryExpr = expr.as(TryExprSyntax.self) {
+        return normalizedSemanticExpressionReference(tryExpr.expression)
+    }
+
+    if let awaitExpr = expr.as(AwaitExprSyntax.self) {
+        return normalizedSemanticExpressionReference(awaitExpr.expression)
+    }
+
+    return nil
+}

--- a/Sources/InnoDIMacros/ClosureSyntaxHelpers.swift
+++ b/Sources/InnoDIMacros/ClosureSyntaxHelpers.swift
@@ -2,16 +2,18 @@ import SwiftSyntax
 
 struct ClosureParameterList {
     let names: [String]
+    let references: [ClosureParameterReference]
     let hasWildcard: Bool
 }
 
 func parseClosureParameterNames(_ closure: ClosureExprSyntax) -> ClosureParameterList {
     guard let signature = closure.signature,
           let parameterClause = signature.parameterClause else {
-        return ClosureParameterList(names: [], hasWildcard: false)
+        return ClosureParameterList(names: [], references: [], hasWildcard: false)
     }
 
     var names: [String] = []
+    var references: [ClosureParameterReference] = []
     var hasWildcard = false
 
     switch parameterClause {
@@ -23,19 +25,22 @@ func parseClosureParameterNames(_ closure: ClosureExprSyntax) -> ClosureParamete
                 continue
             }
             names.append(name)
+            references.append(ClosureParameterReference(name: name, token: parameter.name))
         }
     case .parameterClause(let parameters):
         for parameter in parameters.parameters {
-            let name = parameter.secondName?.text ?? parameter.firstName.text
+            let token = parameter.secondName ?? parameter.firstName
+            let name = token.text
             if name == "_" {
                 hasWildcard = true
                 continue
             }
             names.append(name)
+            references.append(ClosureParameterReference(name: name, token: token))
         }
     }
 
-    return ClosureParameterList(names: names, hasWildcard: hasWildcard)
+    return ClosureParameterList(names: names, references: references, hasWildcard: hasWildcard)
 }
 
 func makeSelfMemberAccessExpr(name: String, baseName: String = "self") -> ExprSyntax {

--- a/Sources/InnoDIMacros/DIContainerCodeGenerator.swift
+++ b/Sources/InnoDIMacros/DIContainerCodeGenerator.swift
@@ -10,7 +10,6 @@ struct DIContainerCodeGenerator {
             inputMembers: model.inputMembers,
             transientMembers: model.transientMembers,
             accessLevel: model.accessLevel,
-            validateEnabled: model.options.validate,
             mainActorEnabled: model.options.mainActor
         )
     }
@@ -42,7 +41,6 @@ private func makeInitDecl(
     inputMembers: [ProvideMemberModel],
     transientMembers: [ProvideMemberModel],
     accessLevel: String?,
-    validateEnabled: Bool,
     mainActorEnabled: Bool
 ) -> DeclSyntax {
     let modifiers = accessModifiers(accessLevel)
@@ -116,8 +114,7 @@ private func makeInitDecl(
         let availableStorageNames = inputStorageNames + syncSharedMembers.prefix(index).map { "_storage_\($0.name)" }
         let factoryExpr = makeFactoryExpr(
             member: member,
-            availableNames: availableStorageNames,
-            allowMissingFactoryFallback: !validateEnabled
+            availableNames: availableStorageNames
         )
 
         let initializerExpr = ExprSyntax(
@@ -197,8 +194,7 @@ private func optionalParameterType(for type: TypeSyntax) -> TypeSyntax {
 
 private func makeFactoryExpr(
     member: ProvideMemberModel,
-    availableNames: [String],
-    allowMissingFactoryFallback: Bool
+    availableNames: [String]
 ) -> ExprSyntax {
     if let factory = member.factory {
         if let closure = factory.as(ClosureExprSyntax.self) {
@@ -230,25 +226,6 @@ private func makeFactoryExpr(
             rightParen: .rightParenToken()
         )
         return ExprSyntax(call)
-    }
-
-    if allowMissingFactoryFallback {
-        return ExprSyntax(
-            FunctionCallExprSyntax(
-                calledExpression: DeclReferenceExprSyntax(baseName: .identifier("fatalError")),
-                leftParen: .leftParenToken(),
-                arguments: LabeledExprListSyntax([
-                    LabeledExprSyntax(
-                        expression: ExprSyntax(
-                            StringLiteralExprSyntax(
-                                content: "Missing factory for shared dependency '\(member.name)'."
-                            )
-                        )
-                    )
-                ]),
-                rightParen: .rightParenToken()
-            )
-        )
     }
 
     fatalError("No factory expression available - validation should have caught this")
@@ -297,7 +274,7 @@ private func dependencyExpression(
         return ExprSyntax("\(raw: "await \(taskBinding.name).value")")
     }
 
-    return ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier(dependencyName)))
+    fatalError("Unresolved async dependency '\(dependencyName)' reached code generation.")
 }
 
 private func closureArgumentNames(closure: ClosureExprSyntax, availableNames: [String]) -> [String] {
@@ -305,31 +282,30 @@ private func closureArgumentNames(closure: ClosureExprSyntax, availableNames: [S
     var result: [String] = []
 
     for (index, name) in parsedArguments.names.enumerated() {
-        result.append(matchClosureParameter(name: name, index: index, availableNames: availableNames))
+        guard let resolvedName = resolveClosureParameter(name: name, availableNames: availableNames) else {
+            fatalError("Unresolved closure parameter '\(name)' reached code generation at index \(index).")
+        }
+        result.append(resolvedName)
     }
 
     return result
 }
 
-private func matchClosureParameter(name: String, index: Int, availableNames: [String]) -> String {
+private func resolveClosureParameter(name: String, availableNames: [String]) -> String? {
     if availableNames.contains(name) {
         return name
     }
 
     let nameWithoutPrefix = name.hasPrefix("_storage_") ? String(name.dropFirst(9)) : name
 
-    for (i, availableName) in availableNames.enumerated() {
+    for availableName in availableNames {
         let availableWithoutPrefix = availableName.hasPrefix("_storage_") ? String(availableName.dropFirst(9)) : availableName
         if availableWithoutPrefix == nameWithoutPrefix {
-            return availableNames[i]
+            return availableName
         }
     }
 
-    if index < availableNames.count {
-        return availableNames[index]
-    }
-
-    return name
+    return nil
 }
 
 private func mapDependencyNameToStorageName(_ dependencyName: String, availableNames: [String]) -> String {
@@ -344,7 +320,7 @@ private func mapDependencyNameToStorageName(_ dependencyName: String, availableN
         }
     }
 
-    return dependencyName
+    fatalError("Unresolved dependency '\(dependencyName)' reached code generation.")
 }
 
 private func assignExpr(targetName: String, valueName: String) -> ExprSyntax {

--- a/Sources/InnoDIMacros/DIContainerMacro.swift
+++ b/Sources/InnoDIMacros/DIContainerMacro.swift
@@ -1,5 +1,6 @@
 import SwiftSyntax
 import SwiftSyntaxMacros
+import SwiftDiagnostics
 
 public struct DIContainerMacro: MemberMacro {
     public static func expansion(
@@ -16,7 +17,34 @@ public struct DIContainerMacro: MemberMacro {
         providingMembersOf decl: some DeclGroupSyntax,
         in context: some MacroExpansionContext
     ) throws -> [DeclSyntax] {
-        if DIContainerParser.hasUserDefinedInit(in: decl) {
+        let userDefinedInitializers = DIContainerParser.userDefinedInitializers(in: decl)
+        if !userDefinedInitializers.isEmpty {
+            for initializer in userDefinedInitializers {
+                context.diagnose(
+                    Diagnostic(
+                        node: Syntax(initializer),
+                        message: SimpleDiagnostic.containerCustomInitUnsupported(),
+                        notes: [
+                            Note(
+                                node: Syntax(attribute),
+                                message: SimpleNote(
+                                    "The synthesized container initializer already covers .input members and optional dependency overrides.",
+                                    code: .containerCustomInitUnsupported,
+                                    suffix: "synthesized-init"
+                                )
+                            ),
+                            Note(
+                                node: Syntax(initializer),
+                                message: SimpleNote(
+                                    "Remove this custom initializer, or remove @DIContainer and wire the container manually.",
+                                    code: .containerCustomInitUnsupported,
+                                    suffix: "manual-wiring"
+                                )
+                            )
+                        ]
+                    )
+                )
+            }
             return []
         }
 

--- a/Sources/InnoDIMacros/DIContainerModel.swift
+++ b/Sources/InnoDIMacros/DIContainerModel.swift
@@ -1,5 +1,15 @@
 import SwiftSyntax
 
+struct ClosureParameterReference {
+    let name: String
+    let token: TokenSyntax
+}
+
+struct WithDependencyReference {
+    let name: String
+    let keyPath: KeyPathExprSyntax
+}
+
 struct DIContainerExpansionModel {
     let options: DIContainerAttributeInfo
     let accessLevel: String?
@@ -37,7 +47,10 @@ struct ProvideMemberModel {
     let initializer: ExprSyntax?
     let concreteOptIn: Bool
     let withDependencies: [String]
+    let withDependencyReferences: [WithDependencyReference]
     let closureDependencies: [String]
+    let closureParameterReferences: [ClosureParameterReference]
+    let closureHasWildcard: Bool
     let expressionReferences: [String]
     let attribute: AttributeSyntax
     let bindingSyntax: PatternBindingSyntax

--- a/Sources/InnoDIMacros/DIContainerParser.swift
+++ b/Sources/InnoDIMacros/DIContainerParser.swift
@@ -4,10 +4,23 @@ import SwiftSyntax
 import SwiftSyntaxMacros
 
 struct DIContainerParser {
-    static func hasUserDefinedInit(in decl: some DeclGroupSyntax) -> Bool {
-        decl.memberBlock.members.contains { member in
-            member.decl.is(InitializerDeclSyntax.self)
+    static func userDefinedInitializers(in decl: some DeclGroupSyntax) -> [InitializerDeclSyntax] {
+        let bodyInitializers = decl.memberBlock.members.compactMap { $0.decl.as(InitializerDeclSyntax.self) }
+
+        guard let sourceFile = sourceFile(containing: Syntax(decl)),
+              let declarationPath = nominalDeclarationPath(containing: Syntax(decl)) else {
+            return bodyInitializers
         }
+
+        let extensionInitializers = sourceFile.statements.compactMap { statement in
+            statement.item.as(ExtensionDeclSyntax.self)
+        }
+        .filter { matchesSameFileContainerExtension($0, declarationPath: declarationPath) }
+        .flatMap { extensionDecl in
+            extensionDecl.memberBlock.members.compactMap { $0.decl.as(InitializerDeclSyntax.self) }
+        }
+
+        return bodyInitializers + extensionInitializers
     }
 
     static func parse(
@@ -74,13 +87,13 @@ struct DIContainerParser {
                 continue
             }
 
-            let closureDependencies: [String]
+            let closureParameterList: ClosureParameterList
             if let closure = parseResult.factoryExpr?.as(ClosureExprSyntax.self) {
-                closureDependencies = parseClosureParameterNames(closure).names
+                closureParameterList = parseClosureParameterNames(closure)
             } else if let asyncClosure = parseResult.asyncFactoryExpr?.as(ClosureExprSyntax.self) {
-                closureDependencies = parseClosureParameterNames(asyncClosure).names
+                closureParameterList = parseClosureParameterNames(asyncClosure)
             } else {
-                closureDependencies = []
+                closureParameterList = ClosureParameterList(names: [], references: [], hasWildcard: false)
             }
 
             let factoryExpressionReferences: [String]
@@ -99,6 +112,7 @@ struct DIContainerParser {
 
             let initializerExpr = binding.initializer?.value
             let initializerReferences = extractExpressionDependencyReferences(from: initializerExpr)
+            let withDependencyReferences = extractWithDependencyReferences(from: attribute)
 
             members.append(
                 ProvideMemberModel(
@@ -112,7 +126,10 @@ struct DIContainerParser {
                     initializer: initializerExpr,
                     concreteOptIn: parseResult.concrete,
                     withDependencies: parseResult.dependencies,
-                    closureDependencies: closureDependencies,
+                    withDependencyReferences: withDependencyReferences,
+                    closureDependencies: closureParameterList.names,
+                    closureParameterReferences: closureParameterList.references,
+                    closureHasWildcard: closureParameterList.hasWildcard,
                     expressionReferences: deduplicateStrings(factoryExpressionReferences + asyncFactoryExpressionReferences + initializerReferences),
                     attribute: attribute,
                     bindingSyntax: binding
@@ -130,6 +147,83 @@ struct DIContainerParser {
             members: members
         )
     }
+}
+
+private func sourceFile(containing syntax: Syntax) -> SourceFileSyntax? {
+    var current: Syntax? = syntax
+
+    while let node = current {
+        if let sourceFile = node.as(SourceFileSyntax.self) {
+            return sourceFile
+        }
+        current = node.parent
+    }
+
+    return nil
+}
+
+private func nominalDeclarationPath(containing syntax: Syntax) -> String? {
+    var current: Syntax? = syntax
+    var components: [String] = []
+
+    while let node = current {
+        if let name = nominalDeclarationName(for: node) {
+            components.append(name)
+        }
+        current = node.parent
+    }
+
+    guard !components.isEmpty else {
+        return nil
+    }
+
+    return components.reversed().joined(separator: ".")
+}
+
+private func nominalDeclarationName(for syntax: Syntax) -> String? {
+    if let structDecl = syntax.as(StructDeclSyntax.self) {
+        return structDecl.name.text
+    }
+    if let classDecl = syntax.as(ClassDeclSyntax.self) {
+        return classDecl.name.text
+    }
+    if let actorDecl = syntax.as(ActorDeclSyntax.self) {
+        return actorDecl.name.text
+    }
+    if let enumDecl = syntax.as(EnumDeclSyntax.self) {
+        return enumDecl.name.text
+    }
+    return nil
+}
+
+private func matchesSameFileContainerExtension(_ extensionDecl: ExtensionDeclSyntax, declarationPath: String) -> Bool {
+    guard extensionDecl.genericWhereClause == nil else {
+        return false
+    }
+
+    return normalizedSemanticTypeReference(extensionDecl.extendedType)?.displayPath == declarationPath
+}
+
+private func extractWithDependencyReferences(from attribute: AttributeSyntax) -> [WithDependencyReference] {
+    guard let arguments = attribute.arguments?.as(LabeledExprListSyntax.self) else {
+        return []
+    }
+
+    for argument in arguments where argument.label?.text == "with" {
+        guard let arrayExpr = argument.expression.as(ArrayExprSyntax.self) else {
+            return []
+        }
+
+        return arrayExpr.elements.compactMap { element in
+            guard let keyPath = element.expression.as(KeyPathExprSyntax.self),
+                  let property = keyPath.components.last?.component.as(KeyPathPropertyComponentSyntax.self)?.declName.baseName.text else {
+                return nil
+            }
+            return WithDependencyReference(name: property, keyPath: keyPath)
+        }
+    }
+
+    return []
 }
 
 private func containerAccessLevel(for decl: some DeclGroupSyntax) -> String? {

--- a/Sources/InnoDIMacros/DIContainerValidator.swift
+++ b/Sources/InnoDIMacros/DIContainerValidator.swift
@@ -9,10 +9,11 @@ struct DIContainerValidator {
         context: some MacroExpansionContext
     ) -> Bool {
         var hadErrors = false
-        let knownNames = Set(model.members.map(\.name))
+        let resolutionContext = DependencyResolutionContext(members: model.members)
 
-        for member in model.members {
+        for (index, member) in model.members.enumerated() {
             let hasFactory = member.factory != nil || member.asyncFactory != nil || member.typeExpr != nil || member.initializer != nil
+            let hasInputConfiguration = hasFactory || !member.withDependencies.isEmpty
 
             if member.factory != nil, member.asyncFactory != nil {
                 context.diagnose(
@@ -21,21 +22,28 @@ struct DIContainerValidator {
                 hadErrors = true
             }
 
-            if member.scope == .shared && !hasFactory && model.options.validate {
+            if member.closureHasWildcard {
+                context.diagnose(
+                    Diagnostic(node: Syntax(member.attribute), message: SimpleDiagnostic.transientFactoryUnnamedParameters())
+                )
+                hadErrors = true
+            }
+
+            if member.scope == .shared && !hasFactory {
                 context.diagnose(
                     Diagnostic(node: Syntax(member.attribute), message: SimpleDiagnostic.provideSharedFactoryRequired())
                 )
                 hadErrors = true
             }
 
-            if member.scope == .transient && !hasFactory && model.options.validate {
+            if member.scope == .transient && !hasFactory {
                 context.diagnose(
                     Diagnostic(node: Syntax(member.attribute), message: SimpleDiagnostic.provideTransientFactoryRequired())
                 )
                 hadErrors = true
             }
 
-            if member.scope == .input && hasFactory {
+            if member.scope == .input && hasInputConfiguration {
                 context.diagnose(
                     Diagnostic(node: Syntax(member.attribute), message: SimpleDiagnostic.provideInputInvalidConfiguration())
                 )
@@ -61,37 +69,80 @@ struct DIContainerValidator {
 
             if member.scope != .input && !member.concreteOptIn && requiresConcreteOptIn(type: member.type) {
                 context.diagnose(
-                    Diagnostic(
-                        node: Syntax(member.attribute),
-                        message: SimpleDiagnostic.provideConcreteOptInRequired(
-                            name: member.name,
-                            typeDescription: member.type.trimmedDescription
-                        )
-                    )
+                    makeConcreteOptInDiagnostic(member: member)
                 )
                 hadErrors = true
             }
-        }
 
-        if model.options.validateDAG {
-            for member in model.members {
-                for dependency in member.explicitDependencies where !knownNames.contains(dependency) {
+            for dependency in deduplicateStrings(member.closureDependencies) {
+                switch resolutionContext.status(of: dependency, forMemberAt: index) {
+                case .available:
+                    break
+                case .unknown:
                     context.diagnose(
-                        Diagnostic(
-                            node: Syntax(member.attribute),
-                            message: SimpleDiagnostic.containerUnknownDependency(
-                                dependencyName: dependency,
-                                memberName: member.name
-                            )
+                        makeUnresolvedFactoryParameterDiagnostic(
+                            member: member,
+                            dependencyName: dependency,
+                            knownNames: resolutionContext.knownNames
+                        )
+                    )
+                    hadErrors = true
+                case .unavailable:
+                    context.diagnose(
+                        makeUnavailableDependencyDiagnostic(
+                            member: member,
+                            dependencyName: dependency,
+                            referencedMember: model.members.first(where: { $0.name == dependency })
                         )
                     )
                     hadErrors = true
                 }
             }
 
+            for dependency in deduplicateStrings(member.withDependencies) {
+                switch resolutionContext.status(of: dependency, forMemberAt: index) {
+                case .available:
+                    break
+                case .unknown:
+                    context.diagnose(
+                        makeUnresolvedWithDependencyDiagnostic(
+                            member: member,
+                            dependencyName: dependency,
+                            knownNames: resolutionContext.knownNames
+                        )
+                    )
+                    hadErrors = true
+                case .unavailable:
+                    context.diagnose(
+                        makeUnavailableDependencyDiagnostic(
+                            member: member,
+                            dependencyName: dependency,
+                            referencedMember: model.members.first(where: { $0.name == dependency })
+                        )
+                    )
+                    hadErrors = true
+                }
+            }
+
+            for dependency in deduplicateStrings(member.expressionReferences) where resolutionContext.knownNames.contains(dependency) {
+                if resolutionContext.status(of: dependency, forMemberAt: index) == .unavailable {
+                    context.diagnose(
+                        makeUnavailableDependencyDiagnostic(
+                            member: member,
+                            dependencyName: dependency,
+                            referencedMember: model.members.first(where: { $0.name == dependency })
+                        )
+                    )
+                    hadErrors = true
+                }
+            }
+        }
+
+        if model.options.validateDAG {
             var adjacency: [String: [String]] = [:]
-            for member in model.members {
-                let dependencies = member.graphDependencyCandidates.filter { knownNames.contains($0) }
+            for index in model.members.indices {
+                let member = model.members[index]
+                let dependencies = resolutionContext.graphDependencies(forMemberAt: index)
                 adjacency[member.name] = deduplicateStrings(dependencies)
             }
 
@@ -122,6 +173,300 @@ struct DIContainerValidator {
 
         return !hadErrors
     }
+}
+
+private func makeUnresolvedFactoryParameterDiagnostic(
+    member: ProvideMemberModel,
+    dependencyName: String,
+    knownNames: Set<String>
+) -> Diagnostic {
+    let reference = member.closureParameterReferences.first(where: { $0.name == dependencyName })
+    let node = reference.map { Syntax($0.token) } ?? Syntax(member.attribute)
+    let candidates = matchingDependencyCandidates(for: dependencyName, in: knownNames)
+    var notes = [
+        Note(
+            node: Syntax(member.attribute),
+            message: SimpleNote(
+                "Rename the factory parameter to match an injectable member name, or switch to explicit wiring inside the factory body.",
+                code: .provideUnresolvedFactoryParameter,
+                suffix: "resolution"
+            )
+        )
+    ]
+    if candidates.isEmpty {
+        notes.append(
+            Note(
+                node: Syntax(member.bindingSyntax),
+                message: SimpleNote(
+                    "'\(member.name)' can only inject members declared in the container by exact member name.",
+                    code: .provideUnresolvedFactoryParameter,
+                    suffix: "member-scope"
+                )
+            )
+        )
+    } else {
+        notes.append(
+            Note(
+                node: Syntax(member.attribute),
+                message: SimpleNote(
+                    "Closest injectable member candidate: \(candidates.joined(separator: ", ")).",
+                    code: .provideUnresolvedFactoryParameter,
+                    suffix: "candidate"
+                )
+            )
+        )
+    }
+
+    let fixIts = makeRenameTokenFixIts(
+        token: reference?.token,
+        replacementCandidates: candidates,
+        code: .provideUnresolvedFactoryParameter,
+        label: "Rename parameter"
+    )
+
+    return Diagnostic(
+        node: node,
+        message: SimpleDiagnostic.provideUnresolvedFactoryParameter(
+            memberName: member.name,
+            parameterName: dependencyName
+        ),
+        notes: notes,
+        fixIts: fixIts
+    )
+}
+
+private func makeUnresolvedWithDependencyDiagnostic(
+    member: ProvideMemberModel,
+    dependencyName: String,
+    knownNames: Set<String>
+) -> Diagnostic {
+    let reference = member.withDependencyReferences.first(where: { $0.name == dependencyName })
+    let node = reference.map { Syntax($0.keyPath) } ?? Syntax(member.attribute)
+    let candidates = matchingDependencyCandidates(for: dependencyName, in: knownNames)
+    var notes = [
+        Note(
+            node: Syntax(member.attribute),
+            message: SimpleNote(
+                "Use a key path that points to an injectable container member, or replace with: with an explicit factory closure.",
+                code: .provideUnresolvedWithDependency,
+                suffix: "resolution"
+            )
+        )
+    ]
+    if candidates.isEmpty {
+        notes.append(
+            Note(
+                node: Syntax(member.bindingSyntax),
+                message: SimpleNote(
+                    "'\(member.name)' can only autowire key paths that map to container member names.",
+                    code: .provideUnresolvedWithDependency,
+                    suffix: "member-scope"
+                )
+            )
+        )
+    } else {
+        notes.append(
+            Note(
+                node: Syntax(member.attribute),
+                message: SimpleNote(
+                    "Closest injectable member candidate: \(candidates.joined(separator: ", ")).",
+                    code: .provideUnresolvedWithDependency,
+                    suffix: "candidate"
+                )
+            )
+        )
+    }
+
+    let fixIts = makeReplaceSyntaxTextFixIts(
+        syntax: reference.map { Syntax($0.keyPath) },
+        replacementCandidates: candidates.map { "\\.\($0)" },
+        code: .provideUnresolvedWithDependency,
+        label: "Replace key path"
+    )
+
+    return Diagnostic(
+        node: node,
+        message: SimpleDiagnostic.provideUnresolvedWithDependency(
+            memberName: member.name,
+            dependencyName: dependencyName
+        ),
+        notes: notes,
+        fixIts: fixIts
+    )
+}
+
+private func makeUnavailableDependencyDiagnostic(
+    member: ProvideMemberModel,
+    dependencyName: String,
+    referencedMember: ProvideMemberModel?
+) -> Diagnostic {
+    var notes = [
+        Note(
+            node: Syntax(member.attribute),
+            message: SimpleNote(
+                "Shared members can only reference inputs and dependencies that are already available in declaration order. Transient members can reference any container member.",
+                code: .provideUnavailableDependencyReference,
+                suffix: "declaration-order"
+            )
+        )
+    ]
+
+    if let referencedMember {
+        notes.append(
+            Note(
+                node: Syntax(referencedMember.bindingSyntax),
+                message: SimpleNote(
+                    "'\(dependencyName)' is declared here.",
+                    code: .provideUnavailableDependencyReference,
+                    suffix: "declaration-site"
+                )
+            )
+        )
+    } else {
+        notes.append(
+            Note(
+                node: Syntax(member.bindingSyntax),
+                message: SimpleNote(
+                    "Declare '\(dependencyName)' before '\(member.name)', or switch to explicit transient/manual wiring if declaration order cannot change.",
+                    code: .provideUnavailableDependencyReference,
+                    suffix: "resolution"
+                )
+            )
+        )
+    }
+
+    return Diagnostic(
+        node: Syntax(member.attribute),
+        message: SimpleDiagnostic.provideUnavailableDependencyReference(
+            memberName: member.name,
+            dependencyName: dependencyName
+        ),
+        notes: notes
+    )
+}
+
+private func makeConcreteOptInDiagnostic(member: ProvideMemberModel) -> Diagnostic {
+    let notes = [
+        Note(
+            node: Syntax(member.attribute),
+            message: SimpleNote(
+                "If this dependency must remain a concrete type, opt in explicitly with concrete: true.",
+                code: .provideConcreteOptInRequired,
+                suffix: "opt-in"
+            )
+        ),
+        Note(
+            node: Syntax(member.bindingSyntax),
+            message: SimpleNote(
+                "If protocol-first wiring is possible, prefer changing the property type to an existential such as any Protocol.",
+                code: .provideConcreteOptInRequired,
+                suffix: "protocol-first"
+            )
+        )
+    ]
+
+    return Diagnostic(
+        node: Syntax(member.attribute),
+        message: SimpleDiagnostic.provideConcreteOptInRequired(
+            name: member.name,
+            typeDescription: member.type.trimmedDescription
+        ),
+        notes: notes,
+        fixIts: makeConcreteOptInFixIts(attribute: member.attribute)
+    )
+}
+
+private func matchingDependencyCandidates(for dependencyName: String, in knownNames: Set<String>) -> [String] {
+    let normalizedTarget = normalizedDependencyLookupKey(dependencyName)
+    return knownNames
+        .filter { normalizedDependencyLookupKey($0) == normalizedTarget }
+        .sorted()
+}
+
+private func normalizedDependencyLookupKey(_ name: String) -> String {
+    name
+        .filter { $0 != "_" }
+        .lowercased()
+}
+
+private func makeRenameTokenFixIts(
+    token: TokenSyntax?,
+    replacementCandidates: [String],
+    code: InnoDIDiagnosticCode,
+    label: String
+) -> [FixIt] {
+    guard let token, replacementCandidates.count == 1 else {
+        return []
+    }
+
+    let replacement = replacementCandidates[0]
+    return [
+        FixIt(
+            message: SimpleFixIt("\(label) to '\(replacement)'", code: code, suffix: "rename"),
+            changes: [
+                .replaceText(
+                    range: token.positionAfterSkippingLeadingTrivia..<token.endPositionBeforeTrailingTrivia,
+                    with: replacement,
+                    in: Syntax(token.root)
+                )
+            ]
+        )
+    ]
+}
+
+private func makeConcreteOptInFixIts(attribute: AttributeSyntax) -> [FixIt] {
+    guard let arguments = attribute.arguments?.as(LabeledExprListSyntax.self) else {
+        return []
+    }
+
+    let replacement: String
+    if arguments.isEmpty {
+        replacement = "concrete: true"
+    } else if arguments.contains(where: { $0.label?.text == "concrete" }) {
+        return []
+    } else {
+        replacement = ", concrete: true"
+    }
+
+    let insertionPosition = arguments.endPositionBeforeTrailingTrivia
+
+    return [
+        FixIt(
+            message: SimpleFixIt("Add concrete: true", code: .provideConcreteOptInRequired, suffix: "insert-concrete"),
+            changes: [
+                .replaceText(
+                    range: insertionPosition..<insertionPosition,
+                    with: replacement,
+                    in: Syntax(attribute.root)
+                )
+            ]
+        )
+    ]
+}
+
+private func makeReplaceSyntaxTextFixIts(
+    syntax: Syntax?,
+    replacementCandidates: [String],
+    code: InnoDIDiagnosticCode,
+    label: String
+) -> [FixIt] {
+    guard let syntax, replacementCandidates.count == 1 else {
+        return []
+    }
+
+    let replacement = replacementCandidates[0]
+    return [
+        FixIt(
+            message: SimpleFixIt("\(label) with '\(replacement)'", code: code, suffix: "replace"),
+            changes: [
+                .replaceText(
+                    range: syntax.positionAfterSkippingLeadingTrivia..<syntax.endPositionBeforeTrailingTrivia,
+                    with: replacement,
+                    in: Syntax(syntax.root)
+                )
+            ]
+        )
+    ]
 }
 
 private func requiresConcreteOptIn(type: TypeSyntax) -> Bool {

--- a/Sources/InnoDIMacros/DIContainerValidator.swift
+++ b/Sources/InnoDIMacros/DIContainerValidator.swift
@@ -247,7 +247,7 @@ private func makeUnresolvedWithDependencyDiagnostic(
         Note(
             node: Syntax(member.attribute),
             message: SimpleNote(
-                "Use a key path that points to an injectable container member, or replace with: with an explicit factory closure.",
+                "Use a key path that points to an injectable container member, or replace this with an explicit factory closure.",
                 code: .provideUnresolvedWithDependency,
                 suffix: "resolution"
             )

--- a/Sources/InnoDIMacros/DependencyResolution.swift
+++ b/Sources/InnoDIMacros/DependencyResolution.swift
@@ -1,0 +1,78 @@
+import SwiftSyntax
+
+enum DependencyReferenceStatus {
+    case available
+    case unknown
+    case unavailable
+}
+
+struct DependencyResolutionContext {
+    let members: [ProvideMemberModel]
+    let knownNames: Set<String>
+
+    init(members: [ProvideMemberModel]) {
+        self.members = members
+        self.knownNames = Set(members.map(\.name))
+    }
+
+    func availableNames(forMemberAt index: Int) -> Set<String> {
+        guard members.indices.contains(index) else { return [] }
+        let member = members[index]
+
+        switch member.scope {
+        case .input:
+            return []
+        case .shared:
+            let inputNames = Set(members.lazy.filter { $0.scope == .input }.map(\.name))
+            let syncSharedNames = Set(
+                members[..<index]
+                    .lazy
+                    .filter { $0.scope == .shared && !$0.isAsyncFactory }
+                    .map(\.name)
+            )
+
+            if member.isAsyncFactory {
+                let allSyncSharedNames = Set(
+                    members.lazy.filter { $0.scope == .shared && !$0.isAsyncFactory }.map(\.name)
+                )
+                let priorAsyncSharedNames = Set(
+                    members[..<index]
+                        .lazy
+                        .filter { $0.scope == .shared && $0.isAsyncFactory }
+                        .map(\.name)
+                )
+                return inputNames
+                    .union(allSyncSharedNames)
+                    .union(priorAsyncSharedNames)
+            }
+
+            return inputNames.union(syncSharedNames)
+        case .transient:
+            return knownNames
+        }
+    }
+
+    func status(of dependencyName: String, forMemberAt index: Int) -> DependencyReferenceStatus {
+        guard knownNames.contains(dependencyName) else {
+            return .unknown
+        }
+
+        if availableNames(forMemberAt: index).contains(dependencyName) {
+            return .available
+        }
+
+        return .unavailable
+    }
+
+    func graphDependencies(forMemberAt index: Int) -> [String] {
+        guard members.indices.contains(index) else { return [] }
+        let member = members[index]
+        let availableNames = availableNames(forMemberAt: index)
+
+        return deduplicateStrings(
+            member.graphDependencyCandidates.filter { name in
+                knownNames.contains(name) && availableNames.contains(name)
+            }
+        )
+    }
+}

--- a/Sources/InnoDIMacros/Diagnostics.swift
+++ b/Sources/InnoDIMacros/Diagnostics.swift
@@ -65,7 +65,7 @@ struct SimpleDiagnostic: DiagnosticMessage {
     init(_ message: String, code: InnoDIDiagnosticCode, severity: DiagnosticSeverity = .error) {
         self.message = message
         self.code = code
-        self.diagnosticID = MessageID(domain: "InnoDI.\(code.category.rawValue)", id: code.rawValue)
+        self.diagnosticID = code.messageID
         self.severity = severity
     }
 }

--- a/Sources/InnoDIMacros/Diagnostics.swift
+++ b/Sources/InnoDIMacros/Diagnostics.swift
@@ -4,6 +4,7 @@
 //
 
 import SwiftDiagnostics
+import SwiftSyntax
 
 enum InnoDIDiagnosticCategory: String {
     case usage
@@ -22,10 +23,14 @@ enum InnoDIDiagnosticCode: String {
     case provideFactoryConflict = "provide.factory-conflict"
     case provideAsyncFactoryInvalidScope = "provide.async-factory-invalid-scope"
     case provideAsyncFactoryMustBeAsync = "provide.async-factory-must-be-async"
+    case provideUnresolvedFactoryParameter = "provide.unresolved-factory-parameter"
+    case provideUnavailableDependencyReference = "provide.unavailable-dependency-reference"
+    case provideUnresolvedWithDependency = "provide.unresolved-with-dependency"
     case transientFactoryUnnamedParameters = "transient-factory.unnamed-parameters"
     case containerUnknownDependency = "container.unknown-dependency"
     case containerDependencyCycle = "container.dependency-cycle"
     case containerMainActorConflict = "container.mainactor-conflict"
+    case containerCustomInitUnsupported = "container.custom-init-unsupported"
     case graphDependencyCycle = "graph.dependency-cycle"
     case graphAmbiguousContainerReference = "graph.ambiguous-container-reference"
 
@@ -36,10 +41,18 @@ enum InnoDIDiagnosticCode: String {
             return .usage
         case .provideSharedFactoryRequired, .provideTransientFactoryRequired, .provideConcreteOptInRequired,
                 .provideFactoryConflict, .provideAsyncFactoryInvalidScope, .provideAsyncFactoryMustBeAsync,
-                .containerUnknownDependency, .containerDependencyCycle, .containerMainActorConflict, .graphDependencyCycle,
+                .provideUnresolvedFactoryParameter, .provideUnavailableDependencyReference, .provideUnresolvedWithDependency,
+                .containerUnknownDependency, .containerDependencyCycle, .containerMainActorConflict,
+                .containerCustomInitUnsupported, .graphDependencyCycle,
                 .graphAmbiguousContainerReference:
             return .validation
         }
+    }
+}
+
+extension InnoDIDiagnosticCode {
+    var messageID: MessageID {
+        MessageID(domain: "InnoDI.\(category.rawValue)", id: rawValue)
     }
 }
 
@@ -54,6 +67,26 @@ struct SimpleDiagnostic: DiagnosticMessage {
         self.code = code
         self.diagnosticID = MessageID(domain: "InnoDI.\(code.category.rawValue)", id: code.rawValue)
         self.severity = severity
+    }
+}
+
+struct SimpleNote: NoteMessage {
+    let message: String
+    let noteID: MessageID
+
+    init(_ message: String, code: InnoDIDiagnosticCode, suffix: String) {
+        self.message = message
+        self.noteID = MessageID(domain: "InnoDI.\(code.category.rawValue)", id: "\(code.rawValue).note.\(suffix)")
+    }
+}
+
+struct SimpleFixIt: FixItMessage {
+    let message: String
+    let fixItID: MessageID
+
+    init(_ message: String, code: InnoDIDiagnosticCode, suffix: String) {
+        self.message = message
+        self.fixItID = MessageID(domain: "InnoDI.\(code.category.rawValue)", id: "\(code.rawValue).fixit.\(suffix)")
     }
 }
 
@@ -123,9 +156,30 @@ extension SimpleDiagnostic {
         )
     }
 
+    static func provideUnresolvedFactoryParameter(memberName: String, parameterName: String) -> Self {
+        Self(
+            "Factory parameter '\(parameterName)' for '\(memberName)' does not match any injectable container member.",
+            code: .provideUnresolvedFactoryParameter
+        )
+    }
+
+    static func provideUnavailableDependencyReference(memberName: String, dependencyName: String) -> Self {
+        Self(
+            "Dependency '\(dependencyName)' referenced by '\(memberName)' is not available in this declaration order or scope.",
+            code: .provideUnavailableDependencyReference
+        )
+    }
+
+    static func provideUnresolvedWithDependency(memberName: String, dependencyName: String) -> Self {
+        Self(
+            "Dependency '\(dependencyName)' in with: for '\(memberName)' does not match any injectable container member.",
+            code: .provideUnresolvedWithDependency
+        )
+    }
+
     static func transientFactoryUnnamedParameters() -> Self {
         Self(
-            "Transient factory closure parameters must be named for injection.",
+            "Factory closure parameters must be named for injection.",
             code: .transientFactoryUnnamedParameters
         )
     }
@@ -148,6 +202,13 @@ extension SimpleDiagnostic {
         Self(
             "mainActor: true conflicts with existing global actor '@\(actorName)'.",
             code: .containerMainActorConflict
+        )
+    }
+
+    static func containerCustomInitUnsupported() -> Self {
+        Self(
+            "@DIContainer does not support user-defined init declarations in the annotated type or any extension. Remove the custom init and use the synthesized initializer, or switch to manual wiring.",
+            code: .containerCustomInitUnsupported
         )
     }
 }

--- a/Sources/InnoDIMacros/ProvideMacro.swift
+++ b/Sources/InnoDIMacros/ProvideMacro.swift
@@ -110,6 +110,19 @@ public struct ProvideMacro: PeerMacro, AccessorMacro {
             
         case .transient:
             let overrideName = "_override_\(name)"
+
+            if transientDependencyResolutionShouldFail(
+                declaration: declaration,
+                parseResult: parseResult,
+                memberName: name
+            ) {
+                return [fatalErrorGetter(
+                    "Transient dependency resolution failed validation.",
+                    isAsync: parseResult.asyncFactoryExpr != nil,
+                    isThrowing: parseResult.asyncFactoryIsThrowing,
+                    isMainActor: enclosingContainerMainActor
+                )]
+            }
             
             let overrideCheck = CodeBlockItemSyntax(item: .stmt(StmtSyntax(
                 """
@@ -333,4 +346,86 @@ private func enclosingDIContainerInfo(for declaration: some DeclSyntaxProtocol) 
     }
 
     return nil
+}
+
+private func transientDependencyResolutionShouldFail(
+    declaration: some DeclSyntaxProtocol,
+    parseResult: ProvideArguments,
+    memberName: String
+) -> Bool {
+    guard let members = enclosingProvideMemberNames(for: declaration) else {
+        return false
+    }
+
+    let knownNames = Set(members)
+
+    for dependency in parseResult.dependencies where !knownNames.contains(dependency) {
+        return true
+    }
+
+    let parameterNames: [String]
+    if let closure = parseResult.factoryExpr?.as(ClosureExprSyntax.self) {
+        parameterNames = parseClosureParameterNames(closure).names
+    } else if let closure = parseResult.asyncFactoryExpr?.as(ClosureExprSyntax.self) {
+        parameterNames = parseClosureParameterNames(closure).names
+    } else {
+        parameterNames = []
+    }
+
+    for dependency in parameterNames where !knownNames.contains(dependency) {
+        return true
+    }
+
+    if !knownNames.contains(memberName) {
+        return true
+    }
+
+    return false
+}
+
+private func enclosingProvideMemberNames(for declaration: some DeclSyntaxProtocol) -> [String]? {
+    var current: Syntax? = Syntax(declaration).parent
+
+    while let node = current {
+        let declGroup: (any DeclGroupSyntax)?
+        switch true {
+        case node.is(StructDeclSyntax.self):
+            declGroup = node.as(StructDeclSyntax.self)
+        case node.is(ClassDeclSyntax.self):
+            declGroup = node.as(ClassDeclSyntax.self)
+        case node.is(ActorDeclSyntax.self):
+            declGroup = node.as(ActorDeclSyntax.self)
+        default:
+            declGroup = nil
+        }
+
+        if let declGroup,
+           parseDIContainerAttribute(declGroup.attributes) != nil {
+            return declGroup.memberBlock.members.compactMap { member in
+                guard let varDecl = member.decl.as(VariableDeclSyntax.self),
+                      hasProvideAttribute(varDecl.attributes),
+                      let binding = varDecl.bindings.first,
+                      let identifier = binding.pattern.as(IdentifierPatternSyntax.self) else {
+                    return nil
+                }
+                return identifier.identifier.text
+            }
+        }
+
+        current = node.parent
+    }
+
+    return nil
+}
+
+private func hasProvideAttribute(_ attributes: AttributeListSyntax?) -> Bool {
+    guard let attributes else { return false }
+
+    return attributes.contains { element in
+        guard let attribute = element.as(AttributeSyntax.self),
+              let identifier = attribute.attributeName.as(IdentifierTypeSyntax.self) else {
+            return false
+        }
+        return identifier.name.text == "Provide"
+    }
 }

--- a/Tests/InnoDIBuildSupportTests/ValidationCoordinatorTests.swift
+++ b/Tests/InnoDIBuildSupportTests/ValidationCoordinatorTests.swift
@@ -240,6 +240,33 @@ struct ValidationCoordinatorTests {
         #expect(ValidationIssueRenderer.renderStderr(issues: []) == "")
     }
 
+    @Test("Validation issue renderer sanitizes markdown and stderr content")
+    func validationIssueRendererSanitizesRenderedContent() {
+        let issue = ValidationIssue(
+            code: "validation.issue",
+            severity: .error,
+            message: "bad `message`\nnext line",
+            location: ValidationIssueLocation(filePath: "Sources/Feature`\n.swift", line: 3, column: 7),
+            notes: [
+                ValidationIssueNote(
+                    message: "note with\nbreak",
+                    location: ValidationIssueLocation(filePath: "Sources/Note.swift", line: 1, column: 2)
+                )
+            ],
+            remediation: "fix\nthis",
+            metadata: ["reason": "uses `code`\nblock"]
+        )
+
+        let markdown = ValidationIssueRenderer.renderMarkdown(issues: [issue])
+        let stderr = ValidationIssueRenderer.renderStderr(issues: [issue])
+
+        #expect(markdown.contains("bad 'message' next line"))
+        #expect(markdown.contains("Sources/Feature' .swift:3:7"))
+        #expect(markdown.contains("uses 'code' block"))
+        #expect(stderr.contains("[validation.issue] bad 'message' next line"))
+        #expect(stderr.contains("note: note with break"))
+    }
+
     @Test("Validation issue report only fails on error severity")
     func validationIssueReportOnlyFailsOnErrors() {
         let location = ValidationIssueLocation(filePath: "Feature.swift", line: 1, column: 1)
@@ -713,14 +740,23 @@ struct ValidationCoordinatorTests {
 }
 
 private final class MockValidationSyntaxParser: @unchecked Sendable, ValidationSyntaxParsing {
-    private(set) var parsedSources: [String] = []
+    private let lock = NSLock()
+    private var storage: [String] = []
+
+    var parsedSources: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
 
     var parseCount: Int {
         parsedSources.count
     }
 
     func parse(source: String) -> SourceFileSyntax {
-        parsedSources.append(source)
+        lock.lock()
+        storage.append(source)
+        lock.unlock()
         return Parser.parse(source: source)
     }
 }

--- a/Tests/InnoDIBuildSupportTests/ValidationCoordinatorTests.swift
+++ b/Tests/InnoDIBuildSupportTests/ValidationCoordinatorTests.swift
@@ -240,6 +240,70 @@ struct ValidationCoordinatorTests {
         #expect(ValidationIssueRenderer.renderStderr(issues: []) == "")
     }
 
+    @Test("Validation issue report only fails on error severity")
+    func validationIssueReportOnlyFailsOnErrors() {
+        let location = ValidationIssueLocation(filePath: "Feature.swift", line: 1, column: 1)
+        let warning = ValidationIssue(
+            code: "validation.warning",
+            severity: .warning,
+            message: "warning only",
+            location: location
+        )
+        let note = ValidationIssue(
+            code: "validation.note",
+            severity: .note,
+            message: "note only",
+            location: location
+        )
+        let error = ValidationIssue(
+            code: "validation.error",
+            severity: .error,
+            message: "error only",
+            location: location
+        )
+
+        let nonFailingReport = ValidationIssueReport(issues: [warning, note])
+        #expect(nonFailingReport.hasFailures == false)
+        #expect(nonFailingReport.asCommandResult() == nil)
+
+        let failingReport = ValidationIssueReport(issues: [warning, error, note])
+        let commandResult = failingReport.asCommandResult()
+        #expect(failingReport.hasFailures == true)
+        #expect(commandResult?.exitCode == 1)
+        #expect(commandResult?.stderr.contains("[validation.error] error only") == true)
+        #expect(commandResult?.stderr.contains("[validation.warning]") == false)
+    }
+
+    @Test("Live validation command runner drains large process output without deadlock")
+    func liveValidationCommandRunnerHandlesLargeOutput() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let scriptURL = fixture.rootURL.appendingPathComponent("emit-large-output.sh")
+        try """
+        #!/bin/sh
+        i=0
+        while [ "$i" -lt 3000 ]; do
+          printf '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\\n'
+          i=$((i + 1))
+        done
+        printf 'stderr complete\\n' >&2
+        """.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: scriptURL.path(percentEncoded: false)
+        )
+
+        let result = try LiveValidationCommandRunner().runValidationTool(
+            toolPath: scriptURL.path(percentEncoded: false),
+            rootPath: fixture.rootURL.path(percentEncoded: false)
+        )
+
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.count > 150_000)
+        #expect(result.stderr.contains("stderr complete"))
+    }
+
     @Test("Success result is reused for identical input signature")
     func successResultIsReused() throws {
         let fixture = try makeFixture()

--- a/Tests/InnoDIBuildSupportTests/ValidationCoordinatorTests.swift
+++ b/Tests/InnoDIBuildSupportTests/ValidationCoordinatorTests.swift
@@ -210,6 +210,36 @@ struct ValidationCoordinatorTests {
         #expect(third.metrics.astReparseCount == 0)
     }
 
+    @Test("Validation signature collection result is codable")
+    func validationSignatureCollectionResultIsCodable() throws {
+        let result = ValidationSignatureCollectionResult(
+            signature: "abc123",
+            metrics: ValidationSignatureMetrics(
+                scannedFileCount: 3,
+                metadataCacheHitCount: 1,
+                contentHashReuseCount: 1,
+                astReparseCount: 1
+            ),
+            reasonCodes: [.cacheHitMetadata, .cacheMissContentChanged],
+            fileChanges: ValidationFileChangeDetails(
+                newFiles: ["Added.swift"],
+                deletedFiles: ["Removed.swift"],
+                reparsedFiles: ["Feature.swift"],
+                contentHashReusedFiles: ["Stable.swift"]
+            )
+        )
+
+        let data = try JSONEncoder().encode(result)
+        let decoded = try JSONDecoder().decode(ValidationSignatureCollectionResult.self, from: data)
+
+        #expect(decoded == result)
+    }
+
+    @Test("Validation issue renderer emits an empty stderr string for no issues")
+    func validationIssueRendererReturnsEmptyStringForNoIssues() {
+        #expect(ValidationIssueRenderer.renderStderr(issues: []) == "")
+    }
+
     @Test("Success result is reused for identical input signature")
     func successResultIsReused() throws {
         let fixture = try makeFixture()
@@ -595,6 +625,13 @@ struct ValidationCoordinatorTests {
             for: SemanticTypeReference(displayPath: "NestedAlias", components: ["NestedAlias"]),
             candidatePaths: ["Feature.Nested.AppContainer"]
         )
+        let shortReverseSuffix = resolver.resolvePath(
+            for: SemanticTypeReference(
+                displayPath: "PreviewModule.AppContainer",
+                components: ["PreviewModule", "AppContainer"]
+            ),
+            candidatePaths: ["AppContainer"]
+        )
 
         #expect(aliasResolved.state == .resolved)
         #expect(aliasResolved.resolvedPath == "Feature.AppContainer")
@@ -607,6 +644,7 @@ struct ValidationCoordinatorTests {
         #expect(nestedAliasResolved.state == .resolved)
         #expect(nestedAliasResolved.resolvedPath == "Feature.Nested.AppContainer")
         #expect(nestedAliasResolved.aliasExpansionTrace == ["NestedAlias", "Aliases.Active"])
+        #expect(shortReverseSuffix.state == .unresolved)
     }
 }
 

--- a/Tests/InnoDIBuildSupportTests/ValidationCoordinatorTests.swift
+++ b/Tests/InnoDIBuildSupportTests/ValidationCoordinatorTests.swift
@@ -1,0 +1,742 @@
+import Foundation
+import InnoDICore
+import SwiftParser
+import SwiftSyntax
+import Testing
+
+@testable import InnoDIBuildSupport
+
+@Suite("ValidationCoordinator")
+struct ValidationCoordinatorTests {
+    @Test("Whitespace and comments do not change the AST signature")
+    func whitespaceAndCommentsDoNotChangeASTSignature() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let original = try collectValidationSignature(rootPath: fixture.rootURL.path(percentEncoded: false))
+
+        try """
+        // leading comment
+        struct Feature {
+            let value = 1
+        }
+        """.write(
+            to: fixture.rootURL.appendingPathComponent("Feature.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let rewritten = try collectValidationSignature(rootPath: fixture.rootURL.path(percentEncoded: false))
+
+        #expect(original == rewritten)
+    }
+
+    @Test("Validation signature is deterministic regardless of file creation order")
+    func validationSignatureIgnoresFileCreationOrder() throws {
+        let firstRoot = try makeTemporaryRoot()
+        let secondRoot = try makeTemporaryRoot()
+        defer {
+            try? FileManager.default.removeItem(at: firstRoot)
+            try? FileManager.default.removeItem(at: secondRoot)
+        }
+
+        try "struct Alpha { let value = 1 }\n".write(
+            to: firstRoot.appendingPathComponent("Alpha.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "struct Beta { let value = 2 }\n".write(
+            to: firstRoot.appendingPathComponent("Beta.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        try "struct Beta { let value = 2 }\n".write(
+            to: secondRoot.appendingPathComponent("Beta.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "struct Alpha { let value = 1 }\n".write(
+            to: secondRoot.appendingPathComponent("Alpha.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let firstSignature = try collectValidationSignature(rootPath: firstRoot.path(percentEncoded: false))
+        let secondSignature = try collectValidationSignature(rootPath: secondRoot.path(percentEncoded: false))
+
+        #expect(firstSignature == secondSignature)
+    }
+
+    @Test("Unchanged files reuse cached normalized AST digests")
+    func unchangedFilesReuseCachedDigests() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let parser = MockValidationSyntaxParser()
+        let collector = ValidationSignatureCollector(
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            parser: parser
+        )
+
+        _ = try collector.collect(rootPath: fixture.rootURL.path(percentEncoded: false))
+        let firstParseCount = parser.parseCount
+        _ = try collector.collect(rootPath: fixture.rootURL.path(percentEncoded: false))
+
+        #expect(firstParseCount == 1)
+        #expect(parser.parseCount == 1)
+        #expect(parser.parsedSources.count == 1)
+    }
+
+    @Test("Only changed and added files are reparsed, and deleted files drop from the manifest")
+    func onlyChangedAndAddedFilesAreReparsed() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        try "struct Secondary { let value = 2 }\n".write(
+            to: fixture.rootURL.appendingPathComponent("Secondary.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let parser = MockValidationSyntaxParser()
+        let collector = ValidationSignatureCollector(
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            parser: parser
+        )
+
+        _ = try collector.collect(rootPath: fixture.rootURL.path(percentEncoded: false))
+        #expect(parser.parseCount == 2)
+
+        try "struct Feature { let value = 200 }\n".write(
+            to: fixture.rootURL.appendingPathComponent("Feature.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "struct Added { let value = 3 }\n".write(
+            to: fixture.rootURL.appendingPathComponent("Added.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try FileManager.default.removeItem(at: fixture.rootURL.appendingPathComponent("Secondary.swift"))
+
+        _ = try collector.collect(rootPath: fixture.rootURL.path(percentEncoded: false))
+
+        #expect(parser.parseCount == 4)
+
+        let manifest = try loadDigestManifest(at: fixture.stateURL.appendingPathComponent("ast-digest-cache.json"))
+        #expect(manifest.files.keys.sorted() == ["Added.swift", "Feature.swift"])
+    }
+
+    @Test("Comment-only changes preserve the final package signature")
+    func commentOnlyChangesPreservePackageSignature() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let parser = MockValidationSyntaxParser()
+        let collector = ValidationSignatureCollector(
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            parser: parser
+        )
+
+        let firstSignature = try collector.collect(rootPath: fixture.rootURL.path(percentEncoded: false))
+
+        try """
+        // updated comment only
+        struct Feature {
+            let value = 1
+        }
+        """.write(
+            to: fixture.rootURL.appendingPathComponent("Feature.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let secondSignature = try collector.collect(rootPath: fixture.rootURL.path(percentEncoded: false))
+
+        #expect(firstSignature == secondSignature)
+        #expect(parser.parseCount == 2)
+    }
+
+    @Test("Metadata-only changes reuse cached AST digests after content hash check")
+    func metadataOnlyChangesReuseCachedDigests() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let parser = MockValidationSyntaxParser()
+        let collector = ValidationSignatureCollector(
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            parser: parser
+        )
+
+        _ = try collector.collect(rootPath: fixture.rootURL.path(percentEncoded: false))
+        #expect(parser.parseCount == 1)
+
+        let featureURL = fixture.rootURL.appendingPathComponent("Feature.swift")
+        try touch(featureURL, modifiedAt: Date().addingTimeInterval(10))
+
+        _ = try collector.collect(rootPath: fixture.rootURL.path(percentEncoded: false))
+
+        #expect(parser.parseCount == 1)
+    }
+
+    @Test("Signature collector reports cache hits, content reuse, and reparses")
+    func signatureCollectorReportsMetrics() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let parser = MockValidationSyntaxParser()
+        let collector = ValidationSignatureCollector(
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            parser: parser
+        )
+
+        let first = try collector.collectWithMetrics(rootPath: fixture.rootURL.path(percentEncoded: false))
+        #expect(first.metrics.scannedFileCount == 1)
+        #expect(first.metrics.metadataCacheHitCount == 0)
+        #expect(first.metrics.contentHashReuseCount == 0)
+        #expect(first.metrics.astReparseCount == 1)
+
+        let second = try collector.collectWithMetrics(rootPath: fixture.rootURL.path(percentEncoded: false))
+        #expect(second.metrics.metadataCacheHitCount == 1)
+        #expect(second.metrics.contentHashReuseCount == 0)
+        #expect(second.metrics.astReparseCount == 0)
+
+        let featureURL = fixture.rootURL.appendingPathComponent("Feature.swift")
+        try touch(featureURL, modifiedAt: Date().addingTimeInterval(5))
+        let third = try collector.collectWithMetrics(rootPath: fixture.rootURL.path(percentEncoded: false))
+        #expect(third.metrics.metadataCacheHitCount == 0)
+        #expect(third.metrics.contentHashReuseCount == 1)
+        #expect(third.metrics.astReparseCount == 0)
+    }
+
+    @Test("Success result is reused for identical input signature")
+    func successResultIsReused() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let runner = MockValidationRunner(
+            results: [
+                ValidationCommandResult(exitCode: 0, stdout: "DAG validation passed.\n", stderr: "")
+            ]
+        )
+
+        let first = try ValidationCoordinator.coordinate(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            toolPath: "/usr/bin/true",
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            outputDirectoryPath: fixture.outputAURL.path(percentEncoded: false),
+            runner: runner
+        )
+        let second = try ValidationCoordinator.coordinate(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            toolPath: "/usr/bin/true",
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            outputDirectoryPath: fixture.outputBURL.path(percentEncoded: false),
+            runner: runner
+        )
+
+        #expect(first.wasCached == false)
+        #expect(second.wasCached == true)
+        #expect(runner.invocationCount == 1)
+        #expect(FileManager.default.fileExists(atPath: fixture.outputAURL.appendingPathComponent("dag-validation-stamp.txt").path(percentEncoded: false)))
+        #expect(FileManager.default.fileExists(atPath: fixture.outputBURL.appendingPathComponent("dag-validation-stamp.txt").path(percentEncoded: false)))
+    }
+
+    @Test("Coordinator writes metrics artifacts for live and cached executions")
+    func coordinatorWritesMetricsArtifacts() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let runner = MockValidationRunner(
+            results: [
+                ValidationCommandResult(exitCode: 0, stdout: "DAG validation passed.\n", stderr: "")
+            ]
+        )
+
+        let first = try ValidationCoordinator.coordinate(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            toolPath: "/usr/bin/true",
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            outputDirectoryPath: fixture.outputAURL.path(percentEncoded: false),
+            runner: runner,
+            verboseLoggingEnabled: true
+        )
+        let second = try ValidationCoordinator.coordinate(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            toolPath: "/usr/bin/true",
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            outputDirectoryPath: fixture.outputBURL.path(percentEncoded: false),
+            runner: runner,
+            verboseLoggingEnabled: false
+        )
+
+        let firstArtifact = try loadMetricsArtifact(at: fixture.outputAURL.appendingPathComponent("dag-validation-metrics.json"))
+        let secondArtifact = try loadMetricsArtifact(at: fixture.outputBURL.appendingPathComponent("dag-validation-metrics.json"))
+        let firstSummary = try String(
+            contentsOf: fixture.outputAURL.appendingPathComponent("dag-validation-summary.md"),
+            encoding: .utf8
+        )
+
+        #expect(first.metricsArtifact == firstArtifact)
+        #expect(second.metricsArtifact == secondArtifact)
+        #expect(firstArtifact.wasCached == false)
+        #expect(secondArtifact.wasCached == true)
+        #expect(firstArtifact.signatureMetrics.scannedFileCount == 1)
+        #expect(firstArtifact.humanSummarySource == "dag-validation-summary.md")
+        #expect(firstArtifact.reasonCodes.contains(.liveRunDAGValidation))
+        #expect(firstArtifact.fileChanges.newFiles == ["Feature.swift"])
+        #expect(firstArtifact.fileChanges.reparsedFiles == ["Feature.swift"])
+        #expect(firstSummary.contains("# InnoDI Validation Summary"))
+        #expect(firstSummary.contains("cache-miss-new-file"))
+        #expect(firstSummary.contains("### Reparsed files"))
+        #expect(firstSummary.contains("`Feature.swift`"))
+        #expect(first.verboseSummary?.contains("[InnoDI]") == true)
+        #expect(second.verboseSummary == nil)
+    }
+
+    @Test("Failure result is reused for identical input signature")
+    func failureResultIsReused() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let runner = MockValidationRunner(
+            results: [
+                ValidationCommandResult(exitCode: 3, stdout: "", stderr: "DAG validation failed.\n")
+            ]
+        )
+
+        let first = try ValidationCoordinator.coordinate(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            toolPath: "/usr/bin/false",
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            outputDirectoryPath: fixture.outputAURL.path(percentEncoded: false),
+            runner: runner
+        )
+        let second = try ValidationCoordinator.coordinate(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            toolPath: "/usr/bin/false",
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            outputDirectoryPath: fixture.outputBURL.path(percentEncoded: false),
+            runner: runner
+        )
+
+        #expect(first.result.exitCode == 3)
+        #expect(second.result.exitCode == 3)
+        #expect(first.wasCached == false)
+        #expect(second.wasCached == true)
+        #expect(second.result.stderr == "DAG validation failed.\n")
+        #expect(runner.invocationCount == 1)
+    }
+
+    @Test("Concurrent requests share one live validation run")
+    func concurrentRequestsShareOneLiveValidationRun() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let runner = MockValidationRunner(
+            results: [
+                ValidationCommandResult(exitCode: 0, stdout: "DAG validation passed.\n", stderr: "")
+            ],
+            delay: 0.2
+        )
+
+        let outputCURL = fixture.rootURL.appendingPathComponent("output-c", isDirectory: true)
+        let outputDURL = fixture.rootURL.appendingPathComponent("output-d", isDirectory: true)
+
+        let results = try await withThrowingTaskGroup(of: ValidationExecutionOutcome.self) { group in
+            group.addTask {
+                try ValidationCoordinator.coordinate(
+                    rootPath: fixture.rootURL.path(percentEncoded: false),
+                    toolPath: "/usr/bin/true",
+                    stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+                    outputDirectoryPath: outputCURL.path(percentEncoded: false),
+                    runner: runner
+                )
+            }
+            group.addTask {
+                try ValidationCoordinator.coordinate(
+                    rootPath: fixture.rootURL.path(percentEncoded: false),
+                    toolPath: "/usr/bin/true",
+                    stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+                    outputDirectoryPath: outputDURL.path(percentEncoded: false),
+                    runner: runner
+                )
+            }
+
+            var collected: [ValidationExecutionOutcome] = []
+            for try await result in group {
+                collected.append(result)
+            }
+            return collected
+        }
+
+        #expect(results.count == 2)
+        #expect(runner.invocationCount == 1)
+        #expect(results.contains { $0.wasCached })
+        #expect(results.contains { !$0.wasCached })
+    }
+
+    @Test("Changing source input invalidates the cached result")
+    func changingSourceInputInvalidatesCache() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let runner = MockValidationRunner(
+            results: [
+                ValidationCommandResult(exitCode: 0, stdout: "first\n", stderr: ""),
+                ValidationCommandResult(exitCode: 0, stdout: "second\n", stderr: "")
+            ]
+        )
+
+        let first = try ValidationCoordinator.coordinate(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            toolPath: "/usr/bin/true",
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            outputDirectoryPath: fixture.outputAURL.path(percentEncoded: false),
+            runner: runner
+        )
+
+        try "struct Feature { let value = 2 }\n".write(
+            to: fixture.rootURL.appendingPathComponent("Feature.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let second = try ValidationCoordinator.coordinate(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            toolPath: "/usr/bin/true",
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            outputDirectoryPath: fixture.outputBURL.path(percentEncoded: false),
+            runner: runner
+        )
+
+        #expect(first.wasCached == false)
+        #expect(second.wasCached == false)
+        #expect(first.signature != second.signature)
+        #expect(runner.invocationCount == 2)
+    }
+
+    @Test("Cross-file custom init validation fails before DAG runner executes")
+    func crossFileCustomInitValidationFailsBeforeRunnerExecutes() throws {
+        let fixture = try makeCrossFileCustomInitFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let runner = MockValidationRunner(
+            results: [
+                ValidationCommandResult(exitCode: 0, stdout: "unexpected\n", stderr: "")
+            ]
+        )
+
+        let outcome = try ValidationCoordinator.coordinate(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            toolPath: "/usr/bin/true",
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            outputDirectoryPath: fixture.outputAURL.path(percentEncoded: false),
+            runner: runner
+        )
+
+        #expect(outcome.result.exitCode == 1)
+        #expect(outcome.result.stderr.contains("container.custom-init-unsupported"))
+        #expect(outcome.result.stderr.contains("extension"))
+        #expect(outcome.metricsArtifact.issues.count == 1)
+        #expect(outcome.metricsArtifact.reasonCodes.contains(.liveRunCustomInitFailure))
+        #expect(runner.invocationCount == 0)
+    }
+
+    @Test("Same-file custom init conflicts remain outside build-stage validation")
+    func sameFileCustomInitConflictsDoNotShortCircuitBuildValidator() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        try """
+        @DIContainer
+        struct AppContainer {
+            @Provide(.input)
+            var config: Config
+        }
+
+        extension AppContainer {
+            init(config: Config, debug: Bool) {
+                self.init(config: config)
+            }
+        }
+        """.write(
+            to: fixture.rootURL.appendingPathComponent("Container.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let runner = MockValidationRunner(
+            results: [
+                ValidationCommandResult(exitCode: 0, stdout: "DAG validation passed.\n", stderr: "")
+            ]
+        )
+
+        let outcome = try ValidationCoordinator.coordinate(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            toolPath: "/usr/bin/true",
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            outputDirectoryPath: fixture.outputAURL.path(percentEncoded: false),
+            runner: runner
+        )
+
+        #expect(outcome.result.exitCode == 0)
+        #expect(runner.invocationCount == 1)
+    }
+
+    @Test("Cross-file validator matches nested paths exactly and ignores generic or constrained extensions")
+    func crossFileValidatorRespectsExtensionMatchingBoundaries() throws {
+        let rootURL = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        try """
+        struct Outer {
+            @DIContainer
+            struct NestedContainer {
+                @Provide(.input)
+                var config: Config
+            }
+        }
+
+        @DIContainer
+        struct GenericContainer<T> {
+            @Provide(.input)
+            var config: Config
+        }
+        """.write(
+            to: rootURL.appendingPathComponent("Containers.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        try """
+        extension Outer.NestedContainer {
+            init(config: Config, debug: Bool) {
+                self.init(config: config)
+            }
+        }
+
+        extension GenericContainer<String> {
+            init(config: Config, preview: Bool) {
+                self.init(config: config)
+            }
+        }
+
+        extension GenericContainer where T: Sendable {
+            init(config: Config, retries: Int) {
+                self.init(config: config)
+            }
+        }
+        """.write(
+            to: rootURL.appendingPathComponent("Extensions.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let result = try CustomInitBuildValidator.validate(rootPath: rootURL.path(percentEncoded: false))
+
+        #expect(result.issues.count == 1)
+        #expect(result.issues.first?.metadata["containerPath"] == "Outer.NestedContainer")
+    }
+
+    @Test("Semantic resolver expands top-level aliases and unique suffix matches conservatively")
+    func semanticResolverExpandsAliasesAndSuffixes() {
+        let resolver = SemanticResolverIndex(
+            nominalTypes: [
+                SemanticNominalTypeRecord(path: "Feature.AppContainer", components: ["Feature", "AppContainer"]),
+                SemanticNominalTypeRecord(path: "Admin.AppContainer", components: ["Admin", "AppContainer"]),
+                SemanticNominalTypeRecord(path: "Feature.Nested.AppContainer", components: ["Feature", "Nested", "AppContainer"])
+            ],
+            topLevelTypeAliases: [
+                SemanticTypeAliasRecord(
+                    path: "ActiveContainer",
+                    components: ["ActiveContainer"],
+                    target: SemanticTypeReference(
+                        displayPath: "Feature.AppContainer",
+                        components: ["Feature", "AppContainer"]
+                    )
+                ),
+                SemanticTypeAliasRecord(
+                    path: "Aliases.Active",
+                    components: ["Aliases", "Active"],
+                    target: SemanticTypeReference(
+                        displayPath: "Feature.Nested.AppContainer",
+                        components: ["Feature", "Nested", "AppContainer"]
+                    )
+                ),
+                SemanticTypeAliasRecord(
+                    path: "NestedAlias",
+                    components: ["NestedAlias"],
+                    target: SemanticTypeReference(
+                        displayPath: "Aliases.Active",
+                        components: ["Aliases", "Active"]
+                    )
+                )
+            ]
+        )
+
+        let aliasResolved = resolver.resolvePath(
+            for: SemanticTypeReference(displayPath: "ActiveContainer", components: ["ActiveContainer"]),
+            candidatePaths: ["Feature.AppContainer"]
+        )
+        let suffixResolved = resolver.resolvePath(
+            for: SemanticTypeReference(
+                displayPath: "PreviewModule.Feature.AppContainer",
+                components: ["PreviewModule", "Feature", "AppContainer"]
+            ),
+            candidatePaths: ["Feature.AppContainer"]
+        )
+        let ambiguousSuffix = resolver.resolvePath(
+            for: SemanticTypeReference(displayPath: "AppContainer", components: ["AppContainer"]),
+            candidatePaths: ["Feature.AppContainer", "Admin.AppContainer"]
+        )
+        let nestedAliasResolved = resolver.resolvePath(
+            for: SemanticTypeReference(displayPath: "NestedAlias", components: ["NestedAlias"]),
+            candidatePaths: ["Feature.Nested.AppContainer"]
+        )
+
+        #expect(aliasResolved.state == .resolved)
+        #expect(aliasResolved.resolvedPath == "Feature.AppContainer")
+        #expect(aliasResolved.aliasExpansionTrace == ["ActiveContainer"])
+        #expect(suffixResolved.state == .resolved)
+        #expect(suffixResolved.resolvedPath == "Feature.AppContainer")
+        #expect(suffixResolved.usedSuffixFallback == true)
+        #expect(ambiguousSuffix.state == .ambiguous)
+        #expect(ambiguousSuffix.candidates == ["Admin.AppContainer", "Feature.AppContainer"])
+        #expect(nestedAliasResolved.state == .resolved)
+        #expect(nestedAliasResolved.resolvedPath == "Feature.Nested.AppContainer")
+        #expect(nestedAliasResolved.aliasExpansionTrace == ["NestedAlias", "Aliases.Active"])
+    }
+}
+
+private final class MockValidationSyntaxParser: @unchecked Sendable, ValidationSyntaxParsing {
+    private(set) var parsedSources: [String] = []
+
+    var parseCount: Int {
+        parsedSources.count
+    }
+
+    func parse(source: String) -> SourceFileSyntax {
+        parsedSources.append(source)
+        return Parser.parse(source: source)
+    }
+}
+
+private struct FixturePaths {
+    let rootURL: URL
+    let stateURL: URL
+    let outputAURL: URL
+    let outputBURL: URL
+}
+
+private func loadDigestManifest(at url: URL) throws -> ValidationDigestManifest {
+    let data = try Data(contentsOf: url)
+    return try JSONDecoder().decode(ValidationDigestManifest.self, from: data)
+}
+
+private func loadMetricsArtifact(at url: URL) throws -> ValidationMetricsArtifact {
+    let data = try Data(contentsOf: url)
+    return try JSONDecoder().decode(ValidationMetricsArtifact.self, from: data)
+}
+
+private func makeFixture() throws -> FixturePaths {
+    let rootURL = try makeTemporaryRoot()
+    let stateURL = rootURL.appendingPathComponent("state", isDirectory: true)
+    let outputAURL = rootURL.appendingPathComponent("output-a", isDirectory: true)
+    let outputBURL = rootURL.appendingPathComponent("output-b", isDirectory: true)
+
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: stateURL, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: outputAURL, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: outputBURL, withIntermediateDirectories: true)
+
+    try "struct Feature { let value = 1 }\n".write(
+        to: rootURL.appendingPathComponent("Feature.swift"),
+        atomically: true,
+        encoding: .utf8
+    )
+
+    return FixturePaths(
+        rootURL: rootURL,
+        stateURL: stateURL,
+        outputAURL: outputAURL,
+        outputBURL: outputBURL
+    )
+}
+
+private func makeCrossFileCustomInitFixture() throws -> FixturePaths {
+    let fixture = try makeFixture()
+
+    try """
+    @DIContainer
+    struct AppContainer {
+        @Provide(.input)
+        var config: Config
+    }
+    """.write(
+        to: fixture.rootURL.appendingPathComponent("Container.swift"),
+        atomically: true,
+        encoding: .utf8
+    )
+
+    try """
+    extension AppContainer {
+        init(config: Config, debug: Bool) {
+            self.init(config: config)
+        }
+    }
+    """.write(
+        to: fixture.rootURL.appendingPathComponent("Container+Debug.swift"),
+        atomically: true,
+        encoding: .utf8
+    )
+
+    return fixture
+}
+
+private func makeTemporaryRoot() throws -> URL {
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("InnoDI-BuildSupport-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    return rootURL
+}
+
+private func touch(_ url: URL, modifiedAt: Date) throws {
+    try FileManager.default.setAttributes([.modificationDate: modifiedAt], ofItemAtPath: url.path(percentEncoded: false))
+}
+
+private final class MockValidationRunner: ValidationCommandRunning, @unchecked Sendable {
+    private let lock = NSLock()
+    private let results: [ValidationCommandResult]
+    private let delay: TimeInterval
+    private var currentInvocationCount = 0
+
+    init(results: [ValidationCommandResult], delay: TimeInterval = 0) {
+        self.results = results
+        self.delay = delay
+    }
+
+    var invocationCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return currentInvocationCount
+    }
+
+    func runValidationTool(toolPath: String, rootPath: String) throws -> ValidationCommandResult {
+        lock.lock()
+        let invocationIndex = currentInvocationCount
+        currentInvocationCount += 1
+        lock.unlock()
+
+        if delay > 0 {
+            Thread.sleep(forTimeInterval: delay)
+        }
+
+        if invocationIndex < results.count {
+            return results[invocationIndex]
+        }
+
+        return results.last ?? ValidationCommandResult(exitCode: 0, stdout: "", stderr: "")
+    }
+}

--- a/Tests/InnoDICoreTests/DependencyGraphCoreTests.swift
+++ b/Tests/InnoDICoreTests/DependencyGraphCoreTests.swift
@@ -10,6 +10,7 @@ struct DependencyGraphCoreTests {
             DependencyGraphNode(
                 id: "App.swift#AppContainer",
                 displayName: "AppContainer",
+                semanticPath: "AppContainer",
                 isRoot: false,
                 validateDAG: false,
                 requiredInputs: ["config"]
@@ -17,6 +18,7 @@ struct DependencyGraphCoreTests {
             DependencyGraphNode(
                 id: "App.swift#AppContainer",
                 displayName: "AppContainer",
+                semanticPath: "AppContainer",
                 isRoot: true,
                 validateDAG: true,
                 requiredInputs: ["logger", "config"]
@@ -38,12 +40,14 @@ struct DependencyGraphCoreTests {
             DependencyGraphNode(
                 id: "FeatureA/App.swift#AppContainer",
                 displayName: "AppContainer",
+                semanticPath: "FeatureA.AppContainer",
                 isRoot: false,
                 requiredInputs: []
             ),
             DependencyGraphNode(
                 id: "FeatureB/App.swift#AppContainer",
                 displayName: "AppContainer",
+                semanticPath: "FeatureB.AppContainer",
                 isRoot: true,
                 requiredInputs: ["env"]
             )
@@ -53,7 +57,7 @@ struct DependencyGraphCoreTests {
         let originalByID = Dictionary(uniqueKeysWithValues: nodes.map { ($0.id, $0) })
 
         #expect(normalized.count == 2)
-        #expect(normalized.map(\.id) == [
+        #expect(normalized.map { $0.id } == [
             "FeatureA/App.swift#AppContainer",
             "FeatureB/App.swift#AppContainer"
         ])
@@ -69,14 +73,14 @@ struct DependencyGraphCoreTests {
     @Test("Normalizes nodes with deterministic ID ordering")
     func normalizeNodesProducesDeterministicIDOrder() {
         let nodes = [
-            DependencyGraphNode(id: "z.swift#Z", displayName: "Z", isRoot: false, requiredInputs: []),
-            DependencyGraphNode(id: "a.swift#A", displayName: "A", isRoot: false, requiredInputs: []),
-            DependencyGraphNode(id: "m.swift#M", displayName: "M", isRoot: false, requiredInputs: [])
+            DependencyGraphNode(id: "z.swift#Z", displayName: "Z", semanticPath: "Z", isRoot: false, requiredInputs: []),
+            DependencyGraphNode(id: "a.swift#A", displayName: "A", semanticPath: "A", isRoot: false, requiredInputs: []),
+            DependencyGraphNode(id: "m.swift#M", displayName: "M", semanticPath: "M", isRoot: false, requiredInputs: [])
         ]
 
         let normalized = normalizeNodes(nodes)
 
-        #expect(normalized.map(\.id) == ["a.swift#A", "m.swift#M", "z.swift#Z"])
+        #expect(normalized.map { $0.id } == ["a.swift#A", "m.swift#M", "z.swift#Z"])
     }
 
     @Test("Deduplicates identical edges while preserving first-seen order")

--- a/Tests/InnoDICoreTests/ParsingPropertyTests.swift
+++ b/Tests/InnoDICoreTests/ParsingPropertyTests.swift
@@ -7,6 +7,29 @@ import InnoDITestSupport
 
 @Suite("Parsing Property Tests")
 struct ParsingPropertyTests {
+    @Test("parseProvideArguments defaults scope to shared when omitted")
+    func parseProvideArgumentsDefaultsToShared() throws {
+        let source = """
+        struct Container {
+            @Provide(factory: Service())
+            var value: Value
+        }
+        """
+
+        let file = Parser.parse(source: source)
+        guard let structDecl = file.statements.first?.item.as(StructDeclSyntax.self),
+              let varDecl = structDecl.memberBlock.members.first?.decl.as(VariableDeclSyntax.self),
+              let attr = varDecl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Expected container and @Provide declaration.")
+            return
+        }
+
+        let parsed = parseProvideArguments(attr)
+
+        #expect(parsed.scope == .shared)
+        #expect(parsed.scopeName == "shared")
+    }
+
     @Test("parseProvideArguments keeps semantic result across shuffled arguments", arguments: Array(0..<200))
     func parseProvideArgumentsIsOrderStable(seed: Int) throws {
         var rng = SeededRandom(seed: UInt64(seed + 1))
@@ -54,5 +77,29 @@ struct ParsingPropertyTests {
         #expect((parsed.factoryExpr != nil) == includeFactory)
         #expect(parsed.concrete == includeConcrete)
         #expect(parsed.dependencies == (includeWith ? ["config", "logger"] : []))
+    }
+
+    @Test("parseProvideArguments preserves each declared scope")
+    func parseProvideArgumentsRoundTripsScopes() throws {
+        for scope in [ProvideScope.shared, .input, .transient] {
+            let source = """
+            struct Container {
+                @Provide(.\(scope.rawValue))
+                var value: Value
+            }
+            """
+
+            let file = Parser.parse(source: source)
+            guard let structDecl = file.statements.first?.item.as(StructDeclSyntax.self),
+                  let varDecl = structDecl.memberBlock.members.first?.decl.as(VariableDeclSyntax.self),
+                  let attr = varDecl.attributes.first?.as(AttributeSyntax.self) else {
+                Issue.record("Expected container and @Provide declaration.")
+                return
+            }
+
+            let parsed = parseProvideArguments(attr)
+            #expect(parsed.scope == scope)
+            #expect(parsed.scopeName == scope.rawValue)
+        }
     }
 }

--- a/Tests/InnoDIDependencyGraphCLITests/DependencyGraphCLITests.swift
+++ b/Tests/InnoDIDependencyGraphCLITests/DependencyGraphCLITests.swift
@@ -241,6 +241,23 @@ struct DependencyGraphCLITests {
         #expect(result.stderr.contains("[graph.unresolved-container-reference]"))
         #expect(result.stderr.contains("MissingFeatureContainer"))
     }
+
+    @Test("@Provide service construction is not reported as a container edge")
+    func validateDAGIgnoresProvideServiceConstruction() throws {
+        let fixtureURL = try makeProvideConstructionFixtureProject()
+        defer { try? FileManager.default.removeItem(at: fixtureURL) }
+
+        let result = try runCLI([
+            "--root", fixtureURL.path(percentEncoded: false),
+            "--validate-dag"
+        ])
+
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.contains("DAG validation passed."))
+        #expect(!result.stderr.contains("Unresolved container references:"))
+        #expect(!result.stderr.contains("APIClient"))
+        #expect(!result.stderr.contains("LiveGreetingService"))
+    }
 }
 
 private struct CLIRunResult {
@@ -408,6 +425,36 @@ private func makeFixtureProject() throws -> URL {
 
     try featureContainerSource.write(
         to: fixtureURL.appendingPathComponent("FeatureContainer.swift"),
+        atomically: true,
+        encoding: .utf8
+    )
+
+    return fixtureURL
+}
+
+private func makeProvideConstructionFixtureProject() throws -> URL {
+    let fixtureURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("InnoDI-CLI-Provide-Construction-\(UUID().uuidString)", isDirectory: true)
+
+    try FileManager.default.createDirectory(at: fixtureURL, withIntermediateDirectories: true)
+
+    try """
+    import InnoDI
+
+    protocol GreetingService {}
+    struct LiveGreetingService: GreetingService {}
+    struct APIClient {}
+
+    @DIContainer(root: true)
+    struct AppContainer {
+        @Provide(.shared, factory: APIClient(), concrete: true)
+        var apiClient: APIClient
+
+        @Provide(.shared, factory: LiveGreetingService())
+        var greetingService: any GreetingService
+    }
+    """.write(
+        to: fixtureURL.appendingPathComponent("AppContainer.swift"),
         atomically: true,
         encoding: .utf8
     )

--- a/Tests/InnoDIDependencyGraphCLITests/DependencyGraphCLITests.swift
+++ b/Tests/InnoDIDependencyGraphCLITests/DependencyGraphCLITests.swift
@@ -197,6 +197,50 @@ struct DependencyGraphCLITests {
         #expect(result.stderr.contains("[graph.dependency-cycle]"))
         #expect(!result.stderr.contains("Ambiguous container references:"))
     }
+
+    @Test("Validate DAG resolves top-level typealias container references")
+    func validateDAGResolvesTopLevelTypeAliasReferences() throws {
+        let fixtureURL = try makeTypeAliasReferenceFixtureProject()
+        defer { try? FileManager.default.removeItem(at: fixtureURL) }
+
+        let result = try runCLI([
+            "--root", fixtureURL.path(percentEncoded: false),
+            "--validate-dag"
+        ])
+
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.contains("DAG validation passed."))
+    }
+
+    @Test("Validate DAG resolves nested typealias chains")
+    func validateDAGResolvesNestedTypeAliasChains() throws {
+        let fixtureURL = try makeNestedTypeAliasReferenceFixtureProject()
+        defer { try? FileManager.default.removeItem(at: fixtureURL) }
+
+        let result = try runCLI([
+            "--root", fixtureURL.path(percentEncoded: false),
+            "--validate-dag"
+        ])
+
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.contains("DAG validation passed."))
+    }
+
+    @Test("Validate DAG reports unresolved semantic references")
+    func validateDAGReportsUnresolvedSemanticReferences() throws {
+        let fixtureURL = try makeUnresolvedReferenceFixtureProject()
+        defer { try? FileManager.default.removeItem(at: fixtureURL) }
+
+        let result = try runCLI([
+            "--root", fixtureURL.path(percentEncoded: false),
+            "--validate-dag"
+        ])
+
+        #expect(result.exitCode == 3)
+        #expect(result.stderr.contains("Unresolved container references:"))
+        #expect(result.stderr.contains("[graph.unresolved-container-reference]"))
+        #expect(result.stderr.contains("MissingFeatureContainer"))
+    }
 }
 
 private struct CLIRunResult {
@@ -371,6 +415,100 @@ private func makeFixtureProject() throws -> URL {
     return fixtureURL
 }
 
+private func makeTypeAliasReferenceFixtureProject() throws -> URL {
+    let fixtureURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("InnoDI-CLI-TypeAlias-\(UUID().uuidString)", isDirectory: true)
+
+    try FileManager.default.createDirectory(at: fixtureURL, withIntermediateDirectories: true)
+
+    try """
+    import InnoDI
+
+    @DIContainer(root: true)
+    struct AppContainer {
+        @Provide(.input)
+        var config: String
+    }
+
+    typealias ActiveContainer = AppContainer
+
+    func buildFeature(config: String) {
+        _ = ActiveContainer(config: config)
+    }
+    """.write(
+        to: fixtureURL.appendingPathComponent("TypeAliasFeature.swift"),
+        atomically: true,
+        encoding: .utf8
+    )
+
+    return fixtureURL
+}
+
+private func makeNestedTypeAliasReferenceFixtureProject() throws -> URL {
+    let fixtureURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("InnoDI-CLI-Nested-TypeAlias-\(UUID().uuidString)", isDirectory: true)
+
+    try FileManager.default.createDirectory(at: fixtureURL, withIntermediateDirectories: true)
+
+    try """
+    import InnoDI
+
+    enum Feature {
+        @DIContainer
+        struct LiveContainer {
+            @Provide(.input)
+            var config: String
+        }
+
+        typealias ActiveContainer = LiveContainer
+    }
+
+    typealias RootAlias = Feature.ActiveContainer
+
+    @DIContainer(root: true)
+    struct AppContainer {
+        @Provide(.input)
+        var config: String
+    }
+
+    func buildFeature(config: String) {
+        _ = RootAlias(config: config)
+    }
+    """.write(
+        to: fixtureURL.appendingPathComponent("NestedTypeAliasFeature.swift"),
+        atomically: true,
+        encoding: .utf8
+    )
+
+    return fixtureURL
+}
+
+private func makeUnresolvedReferenceFixtureProject() throws -> URL {
+    let fixtureURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("InnoDI-CLI-Unresolved-\(UUID().uuidString)", isDirectory: true)
+
+    try FileManager.default.createDirectory(at: fixtureURL, withIntermediateDirectories: true)
+
+    try """
+    import InnoDI
+
+    @DIContainer(root: true)
+    struct AppContainer {
+        @Provide(.input)
+        var config: String
+        
+        @Provide(.shared, factory: MissingFeatureContainer(config: config), concrete: true)
+        var feature: MissingFeatureContainer
+    }
+    """.write(
+        to: fixtureURL.appendingPathComponent("UnresolvedFeature.swift"),
+        atomically: true,
+        encoding: .utf8
+    )
+
+    return fixtureURL
+}
+
 private func makeNoContainerFixtureProject() throws -> URL {
     let fixtureURL = FileManager.default.temporaryDirectory
         .appendingPathComponent("InnoDI-CLI-NoContainer-\(UUID().uuidString)", isDirectory: true)
@@ -477,17 +615,19 @@ private func makeAmbiguousReferenceFixtureProject() throws -> URL {
     let featureASource = """
     import InnoDI
 
-    @DIContainer
-    struct FeatureContainer {
-        @Provide(.input)
-        var value: Int
+    enum FeatureA {
+        @DIContainer
+        struct FeatureContainer {
+            @Provide(.input)
+            var value: Int
+        }
     }
     """
 
     let featureBSource = """
     import InnoDI
 
-    enum Namespace {
+    enum FeatureB {
         @DIContainer
         struct FeatureContainer {
             @Provide(.input)
@@ -538,17 +678,19 @@ private func makeAmbiguousOptedOutReferenceFixtureProject() throws -> URL {
     let featureASource = """
     import InnoDI
 
-    @DIContainer(validateDAG: false)
-    struct FeatureContainer {
-        @Provide(.input)
-        var value: Int
+    enum FeatureA {
+        @DIContainer(validateDAG: false)
+        struct FeatureContainer {
+            @Provide(.input)
+            var value: Int
+        }
     }
     """
 
     let featureBSource = """
     import InnoDI
 
-    enum Namespace {
+    enum FeatureB {
         @DIContainer(validateDAG: false)
         struct FeatureContainer {
             @Provide(.input)

--- a/Tests/InnoDIMacrosTests/DIContainerMacroTests.swift
+++ b/Tests/InnoDIMacrosTests/DIContainerMacroTests.swift
@@ -235,7 +235,7 @@ struct DIContainerMacroTests {
     }
 
     @Test
-    func validateFalseAllowsMissingSharedFactoryWithRuntimeFallback() throws {
+    func validateFalseStillRejectsMissingSharedFactory() throws {
         let source = """
         @DIContainer(validate: false)
         struct AppContainer {
@@ -258,9 +258,8 @@ struct DIContainerMacroTests {
             in: context
         )
 
-        #expect(!generated.isEmpty)
-        #expect(generated.first?.description.contains("Missing factory for shared dependency 'service'.") == true)
-        #expect(context.diagnostics.isEmpty)
+        #expect(generated.isEmpty)
+        #expect(context.diagnostics.contains { $0.message.contains("@Provide(.shared) requires factory: <expr>, type: Type.self, or property initializer.") })
     }
 
     @Test
@@ -319,15 +318,54 @@ struct DIContainerMacroTests {
         #expect(context.diagnostics.contains { $0.message.contains("@Provide(.input) should not include a factory") })
     }
 
+    @Test("input scope rejects type-based dependency wiring")
+    func inputScopeRejectsWithDependencies() throws {
+        let source = """
+        @DIContainer
+        struct AppContainer {
+            @Provide(.input)
+            var config: Config
+
+            @Provide(.input, APIClient.self, with: [\\.config])
+            var apiClient: APIClient
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let decl = parsed.statements.first?.item.as(StructDeclSyntax.self),
+              let attr = decl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse @DIContainer with invalid input wiring")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        let generated = try DIContainerMacro.expansion(
+            of: attr,
+            providingMembersOf: decl,
+            in: context
+        )
+
+        #expect(generated.isEmpty)
+        #expect(
+            context.diagnostics.contains {
+                $0.message.contains("@Provide(.input) should not include a factory")
+            }
+        )
+    }
+
     @Test
     func detectsContainerDependencyCycle() throws {
         let source = """
         @DIContainer
         struct AppContainer {
-            @Provide(.shared, factory: ServiceA(serviceB: serviceB), concrete: true)
+            @Provide(.transient, factory: { (serviceB: ServiceB) in
+                ServiceA(serviceB: serviceB)
+            }, concrete: true)
             var serviceA: ServiceA
 
-            @Provide(.shared, factory: ServiceB(serviceA: serviceA), concrete: true)
+            @Provide(.transient, factory: { (serviceA: ServiceA) in
+                ServiceB(serviceA: serviceA)
+            }, concrete: true)
             var serviceB: ServiceB
         }
         """
@@ -370,7 +408,10 @@ struct DIContainerMacroTests {
         let generated = try DIContainerMacro.expansion(of: attr, providingMembersOf: decl, in: context)
 
         #expect(generated.isEmpty)
-        #expect(context.diagnostics.contains { $0.message.contains("Unknown dependency 'missing'") })
+        #expect(context.diagnostics.contains { $0.message.contains("missing") })
+        #expect(context.diagnostics.contains {
+            $0.diagnosticID == MessageID(domain: "InnoDI.validation", id: "provide.unresolved-with-dependency")
+        })
     }
 
     @Test
@@ -378,10 +419,14 @@ struct DIContainerMacroTests {
         let source = """
         @DIContainer(validateDAG: false)
         struct AppContainer {
-            @Provide(.shared, factory: ServiceA(serviceB: serviceB), concrete: true)
+            @Provide(.transient, factory: { (serviceB: ServiceB) in
+                ServiceA(serviceB: serviceB)
+            }, concrete: true)
             var serviceA: ServiceA
 
-            @Provide(.shared, factory: ServiceB(serviceA: serviceA), concrete: true)
+            @Provide(.transient, factory: { (serviceA: ServiceA) in
+                ServiceB(serviceA: serviceA)
+            }, concrete: true)
             var serviceB: ServiceB
         }
         """
@@ -586,5 +631,657 @@ struct DIContainerMacroTests {
         #expect(initCode.contains("Task<"))
         #expect(initCode.contains("await"))
         #expect(context.diagnostics.isEmpty)
+    }
+
+    @Test("Factory parameter names must resolve by name without positional fallback")
+    func factoryParameterNamesMustResolveStrictly() throws {
+        let source = """
+        @DIContainer
+        struct AppContainer {
+            @Provide(.input)
+            var config: Config
+
+            @Provide(.input)
+            var logger: Logger
+
+            @Provide(.shared, factory: { (wrongName: Config, logger: Logger) in
+                Service(config: wrongName, logger: logger)
+            }, concrete: true)
+            var service: Service
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let decl = parsed.statements.first?.item.as(StructDeclSyntax.self),
+              let attr = decl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse strict factory parameter case")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        let generated = try DIContainerMacro.expansion(of: attr, providingMembersOf: decl, in: context)
+
+        #expect(generated.isEmpty)
+        #expect(context.diagnostics.contains { $0.message.contains("wrongName") })
+        #expect(context.diagnostics.contains {
+            $0.diagnosticID == MessageID(domain: "InnoDI.validation", id: "provide.unresolved-factory-parameter")
+        })
+    }
+
+    @Test("Reordered factory parameters are allowed when names match")
+    func reorderedFactoryParametersRemainValid() throws {
+        let source = """
+        @DIContainer
+        struct AppContainer {
+            @Provide(.input)
+            var config: Config
+
+            @Provide(.input)
+            var logger: Logger
+
+            @Provide(.shared, factory: { (logger: Logger, config: Config) in
+                Service(config: config, logger: logger)
+            }, concrete: true)
+            var service: Service
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let decl = parsed.statements.first?.item.as(StructDeclSyntax.self),
+              let attr = decl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse reordered factory parameter case")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        let generated = try DIContainerMacro.expansion(of: attr, providingMembersOf: decl, in: context)
+
+        #expect(!generated.isEmpty)
+        #expect(context.diagnostics.isEmpty)
+    }
+
+    @Test("Sync shared dependencies cannot reference later shared members")
+    func syncSharedDependenciesRejectForwardReferences() throws {
+        let source = """
+        @DIContainer
+        struct AppContainer {
+            @Provide(.input)
+            var config: Config
+
+            @Provide(.shared, factory: { (laterService: LaterService) in
+                Service(laterService: laterService)
+            }, concrete: true)
+            var service: Service
+
+            @Provide(.shared, factory: LaterService(config: config), concrete: true)
+            var laterService: LaterService
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let decl = parsed.statements.first?.item.as(StructDeclSyntax.self),
+              let attr = decl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse forward reference case")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        let generated = try DIContainerMacro.expansion(of: attr, providingMembersOf: decl, in: context)
+
+        #expect(generated.isEmpty)
+        #expect(context.diagnostics.contains { $0.message.contains("laterService") })
+        #expect(context.diagnostics.contains {
+            $0.diagnosticID == MessageID(domain: "InnoDI.validation", id: "provide.unavailable-dependency-reference")
+        })
+    }
+
+    @Test("with: dependencies reject later shared members")
+    func withDependenciesRejectForwardReferences() throws {
+        let source = """
+        @DIContainer
+        struct AppContainer {
+            @Provide(.input)
+            var config: Config
+
+            @Provide(.shared, Service.self, with: [\\.laterService], concrete: true)
+            var service: Service
+
+            @Provide(.shared, factory: LaterService(config: config), concrete: true)
+            var laterService: LaterService
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let decl = parsed.statements.first?.item.as(StructDeclSyntax.self),
+              let attr = decl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse with forward reference case")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        let generated = try DIContainerMacro.expansion(of: attr, providingMembersOf: decl, in: context)
+
+        #expect(generated.isEmpty)
+        #expect(context.diagnostics.contains { $0.message.contains("laterService") })
+        #expect(context.diagnostics.contains {
+            $0.diagnosticID == MessageID(domain: "InnoDI.validation", id: "provide.unavailable-dependency-reference")
+        })
+    }
+
+    @Test("Async shared dependencies cannot reference later async shared members")
+    func asyncSharedDependenciesRejectForwardReferences() throws {
+        let source = """
+        @DIContainer
+        struct AppContainer {
+            @Provide(.input)
+            var config: Config
+
+            @Provide(.shared, asyncFactory: { (laterService: LaterService) async in
+                Service(laterService: laterService)
+            }, concrete: true)
+            var service: Service
+
+            @Provide(.shared, asyncFactory: { (config: Config) async in
+                LaterService(config: config)
+            }, concrete: true)
+            var laterService: LaterService
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let decl = parsed.statements.first?.item.as(StructDeclSyntax.self),
+              let attr = decl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse async forward reference case")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        let generated = try DIContainerMacro.expansion(of: attr, providingMembersOf: decl, in: context)
+
+        #expect(generated.isEmpty)
+        #expect(context.diagnostics.contains { $0.message.contains("laterService") })
+        #expect(context.diagnostics.contains {
+            $0.diagnosticID == MessageID(domain: "InnoDI.validation", id: "provide.unavailable-dependency-reference")
+        })
+    }
+
+    @Test("Custom init inside container body is rejected explicitly")
+    func customInitInsideContainerBodyIsRejected() throws {
+        let source = """
+        @DIContainer
+        struct AppContainer {
+            @Provide(.input)
+            var config: Config
+
+            init(config: Config) {
+                self.config = config
+            }
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let decl = parsed.statements.first?.item.as(StructDeclSyntax.self),
+              let attr = decl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse custom init container")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        let generated = try DIContainerMacro.expansion(of: attr, providingMembersOf: decl, in: context)
+
+        #expect(generated.isEmpty)
+        #expect(context.diagnostics.contains {
+            $0.diagnosticID == MessageID(domain: "InnoDI.validation", id: "container.custom-init-unsupported")
+        })
+    }
+
+    @Test("Custom init inside same-file extension is rejected explicitly")
+    func customInitInsideSameFileExtensionIsRejected() throws {
+        let source = """
+        @DIContainer
+        struct AppContainer {
+            @Provide(.input)
+            var config: Config
+        }
+
+        extension AppContainer {
+            init(config: Config, debug: Bool) {
+                self.init(config: config)
+            }
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let decl = parsed.statements.first?.item.as(StructDeclSyntax.self),
+              let attr = decl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse container with same-file extension init")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        let generated = try DIContainerMacro.expansion(of: attr, providingMembersOf: decl, in: context)
+
+        #expect(generated.isEmpty)
+        #expect(context.diagnostics.contains {
+            $0.diagnosticID == MessageID(domain: "InnoDI.validation", id: "container.custom-init-unsupported")
+        })
+    }
+
+    @Test("Other same-file extensions do not trigger custom init rejection")
+    func customInitInOtherSameFileExtensionDoesNotTriggerRejection() throws {
+        let source = """
+        @DIContainer
+        struct AppContainer {
+            @Provide(.input)
+            var config: Config
+        }
+
+        struct Helper {
+            let value: Int
+        }
+
+        extension Helper {
+            init(value: Int, doubled: Bool) {
+                self.init(value: value * (doubled ? 2 : 1))
+            }
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let decl = parsed.statements.first?.item.as(StructDeclSyntax.self),
+              let attr = decl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse container with unrelated extension init")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        let generated = try DIContainerMacro.expansion(of: attr, providingMembersOf: decl, in: context)
+
+        #expect(!generated.isEmpty)
+        #expect(context.diagnostics.isEmpty)
+    }
+
+    @Test("All offending initializers in body and same-file extension are diagnosed")
+    func allOffendingInitializersAreDiagnosed() throws {
+        let source = """
+        @DIContainer
+        struct AppContainer {
+            @Provide(.input)
+            var config: Config
+
+            init(config: Config) {
+                self.config = config
+            }
+        }
+
+        extension AppContainer {
+            init(config: Config, debug: Bool) {
+                self.init(config: config)
+            }
+
+            init(config: Config, retries: Int) {
+                self.init(config: config)
+            }
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let decl = parsed.statements.first?.item.as(StructDeclSyntax.self),
+              let attr = decl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse container with multiple offending inits")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        let generated = try DIContainerMacro.expansion(of: attr, providingMembersOf: decl, in: context)
+
+        let diagnostics = context.diagnostics.filter {
+            $0.diagnosticID == MessageID(domain: "InnoDI.validation", id: "container.custom-init-unsupported")
+        }
+
+        #expect(generated.isEmpty)
+        #expect(diagnostics.count == 3)
+    }
+
+    @Test("Cross-file extension initializers are outside the current detection policy")
+    func crossFileExtensionInitializersAreIgnored() throws {
+        let containerSource = """
+        @DIContainer
+        struct AppContainer {
+            @Provide(.input)
+            var config: Config
+        }
+        """
+        let extensionSource = """
+        extension AppContainer {
+            init(config: Config, debug: Bool) {
+                self.init(config: config)
+            }
+        }
+        """
+
+        let parsedContainer = Parser.parse(source: containerSource)
+        _ = Parser.parse(source: extensionSource)
+
+        guard let decl = parsedContainer.statements.first?.item.as(StructDeclSyntax.self) else {
+            Issue.record("Should parse cross-file policy fixture")
+            return
+        }
+
+        let initializers = DIContainerParser.userDefinedInitializers(in: decl)
+        #expect(initializers.isEmpty)
+    }
+
+    @Test("Nested same-file extensions for the annotated type are rejected")
+    func nestedSameFileExtensionInitializersAreRejected() throws {
+        let source = """
+        struct Outer {
+            @DIContainer
+            struct AppContainer {
+                @Provide(.input)
+                var config: Config
+            }
+        }
+
+        extension Outer.AppContainer {
+            init(config: Config, debug: Bool) {
+                self.init(config: config)
+            }
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let outerDecl = parsed.statements.first?.item.as(StructDeclSyntax.self),
+              let nestedDecl = outerDecl.memberBlock.members.first?.decl.as(StructDeclSyntax.self),
+              let attr = nestedDecl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse nested container")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        let generated = try DIContainerMacro.expansion(of: attr, providingMembersOf: nestedDecl, in: context)
+
+        #expect(generated.isEmpty)
+        #expect(context.diagnostics.contains {
+            $0.diagnosticID == MessageID(domain: "InnoDI.validation", id: "container.custom-init-unsupported")
+        })
+    }
+
+    @Test("Generic argument same-file extensions are excluded from custom init detection")
+    func genericArgumentExtensionsAreExcluded() throws {
+        let source = """
+        @DIContainer
+        struct AppContainer<T> {
+            @Provide(.input)
+            var config: Config
+        }
+
+        extension AppContainer<String> {
+            init(config: Config, debug: Bool) {
+                self.init(config: config)
+            }
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let decl = parsed.statements.first?.item.as(StructDeclSyntax.self),
+              let attr = decl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse generic argument extension fixture")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        let generated = try DIContainerMacro.expansion(of: attr, providingMembersOf: decl, in: context)
+
+        #expect(!generated.isEmpty)
+        #expect(context.diagnostics.isEmpty)
+    }
+
+    @Test("Constrained same-file extensions are excluded from custom init detection")
+    func constrainedExtensionsAreExcluded() throws {
+        let source = """
+        @DIContainer
+        struct AppContainer<T> {
+            @Provide(.input)
+            var config: Config
+        }
+
+        extension AppContainer where T: Sendable {
+            init(config: Config, debug: Bool) {
+                self.init(config: config)
+            }
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let decl = parsed.statements.first?.item.as(StructDeclSyntax.self),
+              let attr = decl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse constrained extension fixture")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        let generated = try DIContainerMacro.expansion(of: attr, providingMembersOf: decl, in: context)
+
+        #expect(!generated.isEmpty)
+        #expect(context.diagnostics.isEmpty)
+    }
+
+    @Test("Factory parameter diagnostics include notes and a unique rename fix-it")
+    func unresolvedFactoryParameterDiagnosticsIncludeRenameFixIt() throws {
+        let source = """
+        @DIContainer
+        struct AppContainer {
+            @Provide(.input)
+            var baseURL: String
+
+            @Provide(.shared, factory: { (base_url: String) in
+                Service(baseURL: base_url)
+            }, concrete: true)
+            var service: Service
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let decl = parsed.statements.first?.item.as(StructDeclSyntax.self),
+              let attr = decl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse unresolved factory parameter fixture")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        let generated = try DIContainerMacro.expansion(of: attr, providingMembersOf: decl, in: context)
+
+        guard let diagnostic = context.diagnostics.first(where: {
+            $0.diagnosticID == MessageID(domain: "InnoDI.validation", id: "provide.unresolved-factory-parameter")
+        }) else {
+            Issue.record("Expected unresolved factory parameter diagnostic")
+            return
+        }
+
+        #expect(generated.isEmpty)
+        #expect(!diagnostic.notes.isEmpty)
+        #expect(diagnostic.fixIts.count == 1)
+        #expect(diagnostic.fixIts.first?.message.message.contains("baseURL") == true)
+    }
+
+    @Test("Factory parameter diagnostics skip fix-its when multiple candidates exist")
+    func unresolvedFactoryParameterDiagnosticsSkipAmbiguousFixIt() throws {
+        let source = """
+        @DIContainer
+        struct AppContainer {
+            @Provide(.input)
+            var apiClient: APIClient
+
+            @Provide(.input)
+            var api_client: APIClient
+
+            @Provide(.shared, factory: { (apiclient: APIClient) in
+                Service(client: apiclient)
+            }, concrete: true)
+            var service: Service
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let decl = parsed.statements.first?.item.as(StructDeclSyntax.self),
+              let attr = decl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse ambiguous unresolved factory parameter fixture")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        let generated = try DIContainerMacro.expansion(of: attr, providingMembersOf: decl, in: context)
+
+        guard let diagnostic = context.diagnostics.first(where: {
+            $0.diagnosticID == MessageID(domain: "InnoDI.validation", id: "provide.unresolved-factory-parameter")
+        }) else {
+            Issue.record("Expected unresolved factory parameter diagnostic")
+            return
+        }
+
+        #expect(generated.isEmpty)
+        #expect(diagnostic.notes.count == 2)
+        #expect(diagnostic.fixIts.isEmpty)
+    }
+
+    @Test("with dependency diagnostics include notes and a unique replacement fix-it")
+    func unresolvedWithDependencyDiagnosticsIncludeReplacementFixIt() throws {
+        let source = """
+        @DIContainer
+        struct AppContainer {
+            @Provide(.input)
+            var baseURL: String
+
+            @Provide(.shared, Service.self, with: [\\.base_url], concrete: true)
+            var service: Service
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let decl = parsed.statements.first?.item.as(StructDeclSyntax.self),
+              let attr = decl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse unresolved with dependency fixture")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        let generated = try DIContainerMacro.expansion(of: attr, providingMembersOf: decl, in: context)
+
+        guard let diagnostic = context.diagnostics.first(where: {
+            $0.diagnosticID == MessageID(domain: "InnoDI.validation", id: "provide.unresolved-with-dependency")
+        }) else {
+            Issue.record("Expected unresolved with dependency diagnostic")
+            return
+        }
+
+        #expect(generated.isEmpty)
+        #expect(!diagnostic.notes.isEmpty)
+        #expect(diagnostic.fixIts.count == 1)
+        #expect(diagnostic.fixIts.first?.message.message.contains("\\.baseURL") == true)
+    }
+
+    @Test("Unavailable dependency diagnostics explain declaration-order constraints")
+    func unavailableDependencyDiagnosticsIncludeNotes() throws {
+        let source = """
+        @DIContainer
+        struct AppContainer {
+            @Provide(.shared, factory: { (laterService: LaterService) in
+                Service(laterService: laterService)
+            }, concrete: true)
+            var service: Service
+
+            @Provide(.shared, factory: LaterService(), concrete: true)
+            var laterService: LaterService
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let decl = parsed.statements.first?.item.as(StructDeclSyntax.self),
+              let attr = decl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse unavailable dependency fixture")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        let generated = try DIContainerMacro.expansion(of: attr, providingMembersOf: decl, in: context)
+
+        guard let diagnostic = context.diagnostics.first(where: {
+            $0.diagnosticID == MessageID(domain: "InnoDI.validation", id: "provide.unavailable-dependency-reference")
+        }) else {
+            Issue.record("Expected unavailable dependency diagnostic")
+            return
+        }
+
+        #expect(generated.isEmpty)
+        #expect(!diagnostic.notes.isEmpty)
+        #expect(diagnostic.fixIts.isEmpty)
+    }
+
+    @Test("Custom init diagnostics include guidance notes and no fix-it")
+    func customInitDiagnosticsIncludeGuidanceNotes() throws {
+        let source = """
+        @DIContainer
+        struct AppContainer {
+            @Provide(.input)
+            var config: Config
+
+            init(config: Config) {
+                self.config = config
+            }
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let decl = parsed.statements.first?.item.as(StructDeclSyntax.self),
+              let attr = decl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse custom init guidance fixture")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        _ = try DIContainerMacro.expansion(of: attr, providingMembersOf: decl, in: context)
+
+        guard let diagnostic = context.diagnostics.first(where: {
+            $0.diagnosticID == MessageID(domain: "InnoDI.validation", id: "container.custom-init-unsupported")
+        }) else {
+            Issue.record("Expected custom init diagnostic")
+            return
+        }
+
+        #expect(diagnostic.notes.count == 2)
+        #expect(diagnostic.fixIts.isEmpty)
+    }
+
+    @Test("Concrete opt-in diagnostics include guidance notes and a safe fix-it")
+    func concreteOptInDiagnosticsIncludeSafeFixIt() throws {
+        let source = """
+        @DIContainer
+        struct AppContainer {
+            @Provide(.shared, factory: APIClient())
+            var apiClient: APIClient
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let decl = parsed.statements.first?.item.as(StructDeclSyntax.self),
+              let attr = decl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse concrete opt-in fixture")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        _ = try DIContainerMacro.expansion(of: attr, providingMembersOf: decl, in: context)
+
+        guard let diagnostic = context.diagnostics.first(where: {
+            $0.diagnosticID == MessageID(domain: "InnoDI.validation", id: "provide.concrete-opt-in-required")
+        }) else {
+            Issue.record("Expected concrete opt-in diagnostic")
+            return
+        }
+
+        #expect(diagnostic.notes.count == 2)
+        #expect(diagnostic.fixIts.count == 1)
+        #expect(diagnostic.fixIts.first?.message.message.contains("concrete: true") == true)
     }
 }

--- a/Tests/InnoDIMacrosTests/DiagnosticsTests.swift
+++ b/Tests/InnoDIMacrosTests/DiagnosticsTests.swift
@@ -23,9 +23,13 @@ struct DiagnosticsTests {
             .provideFactoryConflict,
             .provideAsyncFactoryInvalidScope,
             .provideAsyncFactoryMustBeAsync,
+            .provideUnresolvedFactoryParameter,
+            .provideUnavailableDependencyReference,
+            .provideUnresolvedWithDependency,
             .containerUnknownDependency,
             .containerDependencyCycle,
             .containerMainActorConflict,
+            .containerCustomInitUnsupported,
             .graphDependencyCycle,
             .graphAmbiguousContainerReference
         ]
@@ -54,9 +58,13 @@ struct DiagnosticsTests {
             (SimpleDiagnostic.provideFactoryConflict(), MessageID(domain: "InnoDI.validation", id: "provide.factory-conflict")),
             (SimpleDiagnostic.provideAsyncFactoryInvalidScope(), MessageID(domain: "InnoDI.validation", id: "provide.async-factory-invalid-scope")),
             (SimpleDiagnostic.provideAsyncFactoryMustBeAsync(), MessageID(domain: "InnoDI.validation", id: "provide.async-factory-must-be-async")),
+            (SimpleDiagnostic.provideUnresolvedFactoryParameter(memberName: "service", parameterName: "missing"), MessageID(domain: "InnoDI.validation", id: "provide.unresolved-factory-parameter")),
+            (SimpleDiagnostic.provideUnavailableDependencyReference(memberName: "service", dependencyName: "later"), MessageID(domain: "InnoDI.validation", id: "provide.unavailable-dependency-reference")),
+            (SimpleDiagnostic.provideUnresolvedWithDependency(memberName: "service", dependencyName: "missing"), MessageID(domain: "InnoDI.validation", id: "provide.unresolved-with-dependency")),
             (SimpleDiagnostic.containerUnknownDependency(dependencyName: "missing", memberName: "service"), MessageID(domain: "InnoDI.validation", id: "container.unknown-dependency")),
             (SimpleDiagnostic.containerDependencyCycle(path: "a -> b -> a"), MessageID(domain: "InnoDI.validation", id: "container.dependency-cycle")),
             (SimpleDiagnostic.containerMainActorConflict(actorName: "FeatureActor"), MessageID(domain: "InnoDI.validation", id: "container.mainactor-conflict")),
+            (SimpleDiagnostic.containerCustomInitUnsupported(), MessageID(domain: "InnoDI.validation", id: "container.custom-init-unsupported")),
             (SimpleDiagnostic("Graph cycle", code: .graphDependencyCycle), MessageID(domain: "InnoDI.validation", id: "graph.dependency-cycle")),
             (SimpleDiagnostic("Ambiguous reference", code: .graphAmbiguousContainerReference), MessageID(domain: "InnoDI.validation", id: "graph.ambiguous-container-reference"))
         ]

--- a/Tests/InnoDIMacrosTests/ProvideMacroTests.swift
+++ b/Tests/InnoDIMacrosTests/ProvideMacroTests.swift
@@ -214,6 +214,47 @@ struct ProvideMacroTests {
         #expect(context.diagnostics.contains { $0.message.contains("must be named for injection") })
     }
 
+    @Test("Transient accessor avoids generating broken self references for unknown parameters")
+    func transientFactoryClosureWithUnknownParameterFallsBackToFatalErrorGetter() throws {
+        let source = """
+        @DIContainer
+        struct AppContainer {
+            @Provide(.input)
+            var apiClient: APIClient
+
+            @Provide(.transient, factory: { (missing: APIClient) in ViewModel(apiClient: missing) })
+            var viewModel: ViewModel
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let decl = parsed.statements.first?.item.as(StructDeclSyntax.self),
+              let targetVarDecl = decl.memberBlock.members
+                  .compactMap({ $0.decl.as(VariableDeclSyntax.self) })
+                  .first(where: { varDecl in
+                      guard let binding = varDecl.bindings.first,
+                            let identifier = binding.pattern.as(IdentifierPatternSyntax.self) else {
+                          return false
+                      }
+                      return identifier.identifier.text == "viewModel"
+                  }),
+              let attr = targetVarDecl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse transient unknown parameter case")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        let accessors = try ProvideMacro.expansion(
+            of: attr,
+            providingAccessorsOf: targetVarDecl,
+            in: context
+        )
+
+        let generated = accessors.map(\.description).joined(separator: "\n")
+        #expect(generated.contains("fatalError"))
+        #expect(!generated.contains("self.missing"))
+    }
+
     @Test("Closure parameter parser skips wildcard placeholders and keeps named args")
     func parseClosureParameterNamesSkipsWildcard() throws {
         let source = """

--- a/Tools/extract-release-notes.sh
+++ b/Tools/extract-release-notes.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <tag>" >&2
+  exit 1
+fi
+
+tag="$1"
+changelog="CHANGELOG.md"
+
+if [[ ! -f "$changelog" ]]; then
+  echo "missing $changelog" >&2
+  exit 1
+fi
+
+notes="$(
+  awk -v tag="$tag" '
+    $0 == "## " tag { found = 1; next }
+    found && /^## / { exit }
+    found { print }
+    END {
+      if (!found) {
+        exit 2
+      }
+    }
+  ' "$changelog"
+)"
+
+if [[ -z "${notes//[$' \t\r\n']/}" ]]; then
+  echo "no release notes found for tag $tag in $changelog" >&2
+  exit 1
+fi
+
+printf '%s\n' "$notes"

--- a/Tools/extract-release-notes.sh
+++ b/Tools/extract-release-notes.sh
@@ -15,6 +15,7 @@ if [[ ! -f "$changelog" ]]; then
   exit 1
 fi
 
+awk_status=0
 notes="$(
   awk -v tag="$tag" '
     $0 == "## " tag { found = 1; next }
@@ -26,7 +27,14 @@ notes="$(
       }
     }
   ' "$changelog"
-)"
+)" || awk_status=$?
+
+if [[ $awk_status -eq 2 ]]; then
+  echo "no release notes found for tag $tag in $changelog" >&2
+  exit 1
+elif [[ $awk_status -ne 0 ]]; then
+  exit "$awk_status"
+fi
 
 if [[ -z "${notes//[$' \t\r\n']/}" ]]; then
   echo "no release notes found for tag $tag in $changelog" >&2


### PR DESCRIPTION
## Summary
- align this release candidate as the public `3.0.0` OSS release rather than `2.1.0`
- fix the DAG collector false positives that were breaking `macro-tests` on the repository root
- address release, correctness, and stability review feedback that directly affects the 3.0.0 release candidate

## What changed
- promoted release docs and install snippets from `2.1.0` to `3.0.0`, including changelog, migration notes, and release checklist wording
- narrowed DAG container-edge collection so `@Provide` service construction does not create false unresolved container references, while real missing container references still fail validation
- hardened release-note extraction, structured issue rendering, monotonic validation timing, and diagnostic ID consistency
- clarified the `@DIContainer` extension-init rule in docs and added a concrete private reporting channel in `SECURITY.md`
- added regression coverage for the collector fix, codable validation signature results, empty issue rendering, and semantic suffix-matching boundaries

## Verification
- `swift run InnoDI-DependencyGraph --root . --validate-dag`
- `swift test --filter DependencyGraphCLITests`
- `swift test --filter ValidationCoordinatorTests`
- `swift test --filter InnoDIMacrosTests`
- `swift test`
- `(cd Examples/SwiftUIExample && swift test)`
- `(cd Examples/PreviewInjectionExample && swift test)`
- `Benchmarks/run-validation-bench.sh --preset ci`
- `bash Tools/extract-release-notes.sh 3.0.0`
- `bash Tools/extract-release-notes.sh does-not-exist` (expected non-zero with explicit error)

## Notes
- this PR intentionally defers non-blocking style/example-ownership/docstring/helper-dedup feedback to follow-up work
- `Benchmarks/results/validation.json` is still a local/generated artifact and is not part of this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 태그 기반 릴리스 게이트와 자동 릴리스 게시 파이프라인 추가
  * 로컬/CI 벤치마크 프리셋, 검증 벤치 및 비교/기준 갱신 워크플로우 도입
  * 예제 앱들에 비동기 로딩·취소·재시도·복구 UI 및 풍부한 프리뷰 매트릭스 추가

* **문서화**
  * CHANGELOG, RELEASING, MIGRATION, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY 등 거버넌스 문서 추가 및 검증/플러그인 문서 강화

* **테스트**
  * 광범위한 검증·플러그인·예제 테스트 및 벤치마크 아티팩트 업로드 자동화 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->