### PR TITLE
feat(@DIContainer): generate Overrides builder for testing ergonomics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,15 +116,42 @@ The project uses a layered architecture with four main modules:
 
 ### How the Macros Work
 
-**@DIContainer** generates:
-- An `init` with parameters for:
-  - `.input` scoped properties (required parameters)
-  - `.shared` and `.transient` scoped properties (optional override parameters)
-- No separate `Overrides` struct is generated in the current architecture
-- The init body:
-  1. Assigns all `.input` properties to generated storage
-  2. Resolves `.shared` properties with `override ?? factory`
-  3. Stores `.transient` overrides for accessor-time usage
+**@DIContainer** generates up to four kinds of declarations:
+
+1. **Primary `init`** with parameters for:
+   - `.input` scoped properties (required parameters)
+   - `.shared` and `.transient` scoped properties (optional override parameters)
+   The init body:
+   1. Assigns all `.input` properties to generated storage
+   2. Resolves `.shared` properties with `override ?? factory`
+   3. Stores `.transient` overrides for accessor-time usage
+
+2. **Nested `struct Overrides`** — one optional stored property per `.shared` /
+   `.transient` member, all defaulting to `nil`. Access level mirrors the
+   container. Emitted only when the container has at least one `.shared` or
+   `.transient` member (input-only containers skip all builder scaffolding).
+
+3. **Convenience `init(<inputs…>, _ applyOverrides: (inout Overrides) -> Void)`**
+   that constructs an `Overrides`, lets the closure populate named members,
+   then delegates to the primary init. Propagates `@MainActor` when set.
+
+4. **Four `static func withOverrides<T>` effect overloads**
+   (`sync` / `throws` / `async` / `async throws`) — thin wrappers that call
+   the convenience init with a `Self(...)` and run a caller-supplied
+   `operation` closure against it.
+
+The `@attached(member, names:)` declaration in `Sources/InnoDI/InnoDI.swift`
+must enumerate `named(init)`, `named(Overrides)`, and `named(withOverrides)`;
+omitting any of these causes the Swift compiler to reject the synthesized
+declarations at use sites.
+
+**User-defined `Overrides` type caveat**: If the container body already
+declares a nested `Overrides` (struct/class/enum/actor/typealias), the macro
+emits the `container.overrides-name-conflict` warning (see
+`Sources/InnoDIMacros/DIContainerParser.swift::findOverridesNameConflict`)
+and skips generating (2)–(4); only the primary init is emitted. Detection
+lives in `DIContainerParser` and short-circuits inside
+`DIContainerMacro.expansion(...)` before `generateAll`.
 
 **@Provide** scope semantics:
 - `.shared`: Singleton-like dependencies created by factory in init (requires `factory:` parameter)
@@ -159,8 +186,16 @@ The generated `init` inherits the access level of the container type (public, in
 When modifying macro behavior:
 1. Update parsing logic in `InnoDICore/Parsing.swift` first
 2. Update macro expansion in `InnoDIMacros/DIContainerMacro.swift`
-3. Add test cases to `Tests/InnoDIMacrosTests/`
-4. Consider CLI implications in `Sources/InnoDI-DependencyGraph/` modules (`Collectors`, `Rendering`, `Output`, `CLI`)
+3. If you introduce a new generated declaration name, add it to
+   `@attached(member, names: …)` in `Sources/InnoDI/InnoDI.swift` — otherwise
+   the compiler rejects the synthesized decls at use sites (this burned the
+   `Overrides` / `withOverrides` builder rollout; failure mode was
+   "type has no member 'withOverrides'").
+4. Add test cases to `Tests/InnoDIMacrosTests/` (and
+   `Tests/InnoDIRuntimeTests/` when the change is observable at runtime — the
+   runtime target depends on `InnoDI` only, so it compiles against real macro
+   output end-to-end).
+5. Consider CLI implications in `Sources/InnoDI-DependencyGraph/` modules (`Collectors`, `Rendering`, `Output`, `CLI`)
 
 When adding diagnostics:
 - Use `SimpleDiagnostic` for error messages

--- a/Package.swift
+++ b/Package.swift
@@ -116,5 +116,11 @@ let package = Package(
                 "InnoDICore"
             ]
         ),
+        .testTarget(
+            name: "InnoDIRuntimeTests",
+            dependencies: [
+                "InnoDI"
+            ]
+        ),
     ]
 )

--- a/README.ko.md
+++ b/README.ko.md
@@ -11,7 +11,7 @@ Swift Macro 기반의 타입 안전한 의존성 주입 라이브러리입니다
 - 스코프 지원: `shared`, `input`, `transient`
 - AutoWiring: `Type.self` + `with:`로 간결한 선언
 - 엄격한 이름 기반 해석: 팩토리 파라미터와 `with:` 의존성은 멤버 이름으로만 해석
-- Init Override: 테스트 시 의존성 직접 주입 가능
+- Init Override: 테스트 시 의존성 직접 주입 가능 (위치 파라미터 + 명명 `Overrides` 빌더 + `withOverrides` 스코프 헬퍼)
 - DIP 지향: concrete 타입 사용 시 `concrete: true` 명시 강제
 
 ## 설치
@@ -95,6 +95,18 @@ var apiClient: any APIClientProtocol
 `@DIContainer`가 붙은 타입과 extension 전체에서 사용자 정의 `init`을 지원하지 않습니다.
 매크로는 type body와 같은 파일의 동일 타입 extension을 막고, build plugin은 다른 파일의 extension까지 같은 규칙으로 확장합니다.
 생성된 init을 사용하거나, 수동 wiring이 필요하면 매크로를 제거해야 합니다.
+
+`@DIContainer`는 아래 네 종류 선언을 생성합니다:
+
+1. primary `init(...)` — 필수 `.input` 파라미터 + optional `.shared`/`.transient` override 파라미터
+2. `.shared` / `.transient` 멤버가 하나라도 있을 때 nested `struct Overrides`
+   (아래 [Overrides 빌더로 테스트하기](#overrides-빌더로-테스트하기) 참고)
+3. convenience `init(<inputs…>, _ applyOverrides: (inout Overrides) -> Void)` — 명명 override를 primary init으로 연결
+4. sync / throws / async / async throws 4가지 effect 조합의
+   `static func withOverrides<T>(<inputs…>, _ applyOverrides:, operation:)`
+
+input-only 컨테이너, 그리고 사용자가 직접 `Overrides` 타입을 선언한 컨테이너는
+빌더 생성을 생략합니다 (뒤 [사용자 정의 `Overrides` 충돌](#사용자-정의-overrides-충돌) 참고).
 
 | 파라미터 | 기본값 | 설명 |
 |---|---|---|
@@ -201,6 +213,84 @@ let test = AppContainer(baseURL: "https://test.example.com", apiClient: MockAPIC
 ```swift
 init(baseURL: String, apiClient: (any APIClientProtocol)? = nil)
 ```
+
+## Overrides 빌더로 테스트하기
+
+`.shared` / `.transient` 멤버가 하나라도 있으면, `@DIContainer`는 위 위치
+파라미터 외에 **명명 override** 빌더도 함께 생성합니다. 테스트가 바꾸려는
+멤버만 지정하면 나머지는 그대로 원래 factory로 해석됩니다.
+
+### 트레일링 클로저 convenience init
+
+```swift
+@DIContainer
+struct AppContainer {
+    @Provide(.input)
+    var baseURL: String
+
+    @Provide(.shared, factory: { APIClient(baseURL: baseURL) })
+    var apiClient: any APIClientProtocol
+
+    @Provide(.transient, factory: { (apiClient: any APIClientProtocol) in
+        HomeViewModel(api: apiClient)
+    }, concrete: true)
+    var homeViewModel: HomeViewModel
+}
+
+let container = AppContainer(baseURL: "https://test.example.com") {
+    $0.apiClient = MockAPIClient()
+}
+// container.apiClient 는 MockAPIClient
+// container.homeViewModel 은 mock 을 타고 흐른 상태로 해석됨
+```
+
+shared override는 downstream transient factory에도 전파됩니다.
+
+### `withOverrides` 스코프 연산
+
+`swift-dependencies`의 `withDependencies { } operation:` 스타일과 동일하게,
+override 수명을 하나의 연산에 묶고 싶을 때 사용합니다:
+
+```swift
+let result = try await AppContainer.withOverrides(baseURL: "https://test.example.com") { overrides in
+    overrides.apiClient = MockAPIClient()
+} operation: { container in
+    try await container.homeViewModel.load()
+}
+```
+
+4가지 effect 조합이 모두 생성되므로 sync 호출에서 `try await`를 붙일 필요는
+없습니다:
+
+| 오버로드 | 시그니처 형태 |
+|---|---|
+| sync, non-throwing | `(Container) -> T` |
+| sync, throwing | `(Container) throws -> T` |
+| async, non-throwing | `(Container) async -> T` |
+| async, throwing | `(Container) async throws -> T` |
+
+생성되는 모든 선언은 컨테이너의 access level을 미러링하고 (`public` 컨테이너
+→ `public` 빌더), `@MainActor` 컨테이너에는 `@MainActor`가 전파됩니다.
+
+### async `.shared` override
+
+`asyncFactory`로 선언된 `.shared` 멤버도 빌더에서는 평범한 옵셔널
+(`var apiClient: APIClient? = nil`) 로 노출됩니다. `Task<…>` 로 감쌀 필요가
+없고, 생성 시점에 값만 넘기면 primary init이 동일한 task-backed accessor로
+감싸 줍니다.
+
+### `.transient` override는 저장값을 반환
+
+`.transient` override는 매 접근 때 **같은 저장값을 그대로 반환**합니다.
+테스트에서 특정 값을 고정해두고 assertion 하기 쉬운 의도된 동작입니다.
+
+### 사용자 정의 `Overrides` 충돌
+
+컨테이너 내부에 이미 `Overrides` 타입(struct/class/enum/actor/typealias)이
+있으면 매크로는 `container.overrides-name-conflict` 경고를 발행하고
+`Overrides` / convenience init / `withOverrides` 생성을 **전부 생략**합니다.
+primary init만 그대로 생성되므로 기존 호출부는 영향이 없습니다. 빌더 API를
+되살리려면 사용자 정의 타입을 rename 하거나 제거하면 됩니다.
 
 ## Dependency Graph CLI
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ belongs in `InnoNetwork`.
 - **Multiple scopes**: `shared`, `input`, and `transient` lifecycle management
 - **AutoWiring**: Simplified syntax with `Type.self` and `with:` dependencies
 - **Strict name-based resolution**: Factory parameters and `with:` dependencies resolve by member name only
-- **Init Override**: Direct mock injection via init parameters (no separate Overrides struct)
+- **Init Override**: Direct mock injection via init parameters, plus a named `Overrides` builder with a trailing-closure convenience init and `withOverrides` helpers
+
 - **Protocol-first design**: Encourage DIP compliance with `concrete` opt-in
 
 ## Installation
@@ -101,7 +102,14 @@ Release and maintenance references:
 
 ### `@DIContainer`
 
-Marks a struct as a DI container. Generates `init(...)` with optional override parameters.
+Marks a struct as a DI container. Generates:
+
+1. A primary `init(...)` with required `.input` parameters and optional overrides for `.shared` / `.transient` members.
+2. When the container declares any `.shared` or `.transient` member, a nested `struct Overrides` (see [Testing with the Overrides builder](#testing-with-the-overrides-builder)).
+3. A convenience `init(<inputs…>, _ applyOverrides: (inout Overrides) -> Void)` that funnels named overrides into the primary init.
+4. Four `static func withOverrides<T>(<inputs…>, _ applyOverrides:, operation:)` effect overloads — `sync` / `throws` / `async` / `async throws` — that build a scoped container and run an operation against it.
+
+Input-only containers, and containers where the user declares their own nested `Overrides` type, skip the scaffolding (see [User-defined Overrides conflict](#user-defined-overrides-conflict)).
 
 `@DIContainer` does not support user-defined `init` declarations in the annotated type or any extension.
 Macro validation rejects body and same-file extension `init` declarations, and the build plugin extends the same rule to cross-file extensions. Boundary details such as generic/constrained exclusions and conservative fallback rules are documented in `PolicyBoundaries`.
@@ -313,6 +321,96 @@ init(baseURL: String, apiClient: (any APIClientProtocol)? = nil)
 - `.input` parameters are required
 - `.shared` and `.transient` parameters are optional with `nil` default
 - When `nil`, the factory creates the instance; when provided, uses the injected value
+
+## Testing with the Overrides builder
+
+Positional overrides on the generated init work, but they force every test to
+restate every optional parameter. For containers with any `.shared` or
+`.transient` member, `@DIContainer` additionally emits a named builder so tests
+only touch the members they actually want to replace.
+
+### Convenience init with a trailing closure
+
+Use the trailing-closure convenience init when you want to hold on to the
+container yourself:
+
+```swift
+@DIContainer
+struct AppContainer {
+    @Provide(.input)
+    var baseURL: String
+
+    @Provide(.shared, factory: { APIClient(baseURL: baseURL) })
+    var apiClient: any APIClientProtocol
+
+    @Provide(.transient, factory: { (apiClient: any APIClientProtocol) in
+        HomeViewModel(api: apiClient)
+    }, concrete: true)
+    var homeViewModel: HomeViewModel
+}
+
+let container = AppContainer(baseURL: "https://test.example.com") {
+    $0.apiClient = MockAPIClient()
+}
+// container.apiClient is MockAPIClient
+// container.homeViewModel resolves through the mocked apiClient
+```
+
+Only the members you set on the builder are overridden; the rest still flow
+through the original factories. Shared overrides cascade: downstream
+`.transient` factories that read the shared member observe the mock.
+
+### `withOverrides` scoped operation
+
+When you want override lifetime bound to a single operation — mirroring
+`swift-dependencies`' `withDependencies { } operation:` style — use the
+generated `static withOverrides`:
+
+```swift
+let result = try await AppContainer.withOverrides(baseURL: "https://test.example.com") { overrides in
+    overrides.apiClient = MockAPIClient()
+} operation: { container in
+    try await container.homeViewModel.load()
+}
+```
+
+Four overloads are generated for every effect shape, so you never have to
+`try await` a synchronous callsite:
+
+| Overload | Signature shape |
+|---|---|
+| sync, non-throwing | `(Container) -> T` |
+| sync, throwing | `(Container) throws -> T` |
+| async, non-throwing | `(Container) async -> T` |
+| async, throwing | `(Container) async throws -> T` |
+
+All generated builder surfaces inherit the container's access level (`public`
+containers produce `public` builders) and propagate `@MainActor` when the
+container is main-actor isolated.
+
+### Async `.shared` overrides
+
+Async-factory `.shared` members appear on the builder as plain optional values
+(`var apiClient: APIClient? = nil`), *not* as `Task<APIClient, …>?`. The
+generated init still wraps the resolved value in the same task-backed accessor
+used in production — overriding just short-circuits the factory with the value
+you supplied.
+
+### `.transient` overrides return the stored value
+
+Setting a `.transient` override returns **that exact value** on every access
+of the accessor (overrides bypass the per-access factory). This matches the
+convenience init's semantics and makes it trivial to pin a single value for
+assertion.
+
+### User-defined `Overrides` conflict
+
+If your container already declares a nested `Overrides` type (`struct`,
+`class`, `enum`, `actor`, or `typealias`), the macro emits the
+`container.overrides-name-conflict` warning and **skips generating** the
+`Overrides` struct, the convenience init, and the `withOverrides` overloads —
+the primary init is unchanged. Rename your type to restore the builder API, or
+leave it in place to keep your own implementation.
 
 ## Dependency Graph Visualization
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,34 @@ This document tracks follow-up work that is intentionally deferred from the
 current release candidate. Items listed here came from open PR review feedback
 or release hardening discussions and are not release blockers for `3.0.1`.
 
+## Recently landed
+
+### Testing ergonomics — Overrides builder (Phase J)
+- `@DIContainer` now emits a nested `struct Overrides`, a trailing-closure
+  convenience `init(<inputs…>, _ applyOverrides:)`, and four
+  `static withOverrides<T>` effect overloads for containers with any
+  `.shared` / `.transient` member. Closes the Top-1 testing ergonomics gap
+  identified in the post-PR-#17 comparison report.
+- Input-only containers skip the scaffolding silently; user-declared
+  `Overrides` types trigger the new `container.overrides-name-conflict`
+  warning.
+
+## Next priorities
+
+With the override builder shipped, the remaining Top-tier UX improvements are
+re-ordered as:
+
+1. `@Lazy` — defer initialization of expensive `.shared` members until first
+   access, without forcing authors to hand-roll a cached closure.
+2. `Provider<T>` — give call sites a factory handle when they need to pull
+   multiple `.transient` instances per scope without retaining the container.
+3. `@SubContainer` — first-class nested containers for per-screen or
+   per-request scopes, replacing today's convention of hand-wiring child
+   containers through `.input` parameters.
+4. Scope subdivision (request / session / scenario) — evaluate whether the
+   three built-in scopes need finer-grained lifetime variants, especially for
+   server-side and multi-window use.
+
 ## Post-3.0.1 Follow-ups
 
 ### Validation coordinator robustness

--- a/Sources/InnoDI/InnoDI.swift
+++ b/Sources/InnoDI/InnoDI.swift
@@ -13,7 +13,7 @@ public enum DIScope {
     case transient
 }
 
-@attached(member, names: named(init))
+@attached(member, names: named(init), named(Overrides), named(withOverrides))
 /// Marks a type as an InnoDI container and synthesizes initialization/validation behavior.
 ///
 /// - Parameters:

--- a/Sources/InnoDIMacros/DIContainerCodeGenerator.swift
+++ b/Sources/InnoDIMacros/DIContainerCodeGenerator.swift
@@ -13,6 +13,25 @@ struct DIContainerCodeGenerator {
             mainActorEnabled: model.options.mainActor
         )
     }
+
+    /// Generates the full member set: primary init + (if applicable) `Overrides`
+    /// struct + convenience init + 4 `withOverrides` effect overloads.
+    ///
+    /// When the container has no `.shared`/`.transient` members, the overrides
+    /// scaffolding is skipped silently — an empty `Overrides` builder would
+    /// only add autocomplete noise.
+    static func generateAll(for model: DIContainerExpansionModel) -> [DeclSyntax] {
+        var decls: [DeclSyntax] = [generateInit(for: model)]
+
+        guard let overridesStruct = makeOverridesStructDecl(model: model) else {
+            return decls
+        }
+
+        decls.append(overridesStruct)
+        decls.append(makeConvenienceInitDecl(model: model))
+        decls.append(contentsOf: makeWithOverridesMethods(model: model))
+        return decls
+    }
 }
 
 private struct AsyncTaskBinding {
@@ -366,4 +385,331 @@ private func mainActorAttributeList() -> AttributeListSyntax {
             )
         )
     ])
+}
+
+// MARK: - Overrides builder
+
+private func overrideCandidateMembers(_ model: DIContainerExpansionModel) -> [ProvideMemberModel] {
+    model.sharedMembers + model.transientMembers
+}
+
+private func makeOverridesStructDecl(model: DIContainerExpansionModel) -> DeclSyntax? {
+    let candidates = overrideCandidateMembers(model)
+    guard !candidates.isEmpty else { return nil }
+
+    let modifiers = accessModifiers(model.accessLevel)
+    let memberDecls: [MemberBlockItemSyntax] = candidates.map { member in
+        let variableDecl = VariableDeclSyntax(
+            bindingSpecifier: .keyword(.var),
+            bindings: PatternBindingListSyntax([
+                PatternBindingSyntax(
+                    pattern: IdentifierPatternSyntax(identifier: .identifier(member.name)),
+                    typeAnnotation: TypeAnnotationSyntax(type: optionalParameterType(for: member.type)),
+                    initializer: InitializerClauseSyntax(value: NilLiteralExprSyntax())
+                )
+            ])
+        )
+        return MemberBlockItemSyntax(decl: variableDecl)
+    }
+
+    let structDecl = StructDeclSyntax(
+        modifiers: modifiers,
+        name: .identifier("Overrides"),
+        memberBlock: MemberBlockSyntax(
+            members: MemberBlockItemListSyntax(memberDecls)
+        )
+    )
+
+    return DeclSyntax(structDecl)
+}
+
+private func makeConvenienceInitDecl(model: DIContainerExpansionModel) -> DeclSyntax {
+    let modifiers = accessModifiers(model.accessLevel)
+    let inputMembers = model.inputMembers
+    var params: [FunctionParameterSyntax] = []
+
+    for member in inputMembers {
+        // All input params have a trailing comma because the closure param
+        // always follows them.
+        let param = FunctionParameterSyntax(
+            firstName: .identifier(member.name),
+            secondName: nil,
+            colon: .colonToken(),
+            type: member.type,
+            ellipsis: nil,
+            defaultValue: nil,
+            trailingComma: .commaToken()
+        )
+        params.append(param)
+    }
+
+    // Final unnamed trailing closure parameter:
+    //   _ applyOverrides: (inout Overrides) -> Void
+    let overridesClosureType = TypeSyntax(stringLiteral: "(inout Overrides) -> Void")
+    let closureParam = FunctionParameterSyntax(
+        firstName: .wildcardToken(),
+        secondName: .identifier("applyOverrides"),
+        colon: .colonToken(),
+        type: overridesClosureType,
+        ellipsis: nil,
+        defaultValue: nil,
+        trailingComma: nil
+    )
+    params.append(closureParam)
+
+    let signature = FunctionSignatureSyntax(
+        parameterClause: FunctionParameterClauseSyntax(parameters: FunctionParameterListSyntax(params))
+    )
+
+    var statements: [CodeBlockItemSyntax] = []
+
+    // var overrides = Overrides()
+    let makeOverrides = VariableDeclSyntax(
+        bindingSpecifier: .keyword(.var),
+        bindings: PatternBindingListSyntax([
+            PatternBindingSyntax(
+                pattern: IdentifierPatternSyntax(identifier: .identifier("overrides")),
+                initializer: InitializerClauseSyntax(
+                    value: FunctionCallExprSyntax(
+                        calledExpression: DeclReferenceExprSyntax(baseName: .identifier("Overrides")),
+                        leftParen: .leftParenToken(),
+                        arguments: LabeledExprListSyntax([]),
+                        rightParen: .rightParenToken()
+                    )
+                )
+            )
+        ])
+    )
+    statements.append(CodeBlockItemSyntax(item: .decl(DeclSyntax(makeOverrides))))
+
+    // applyOverrides(&overrides)
+    let applyCall = FunctionCallExprSyntax(
+        calledExpression: DeclReferenceExprSyntax(baseName: .identifier("applyOverrides")),
+        leftParen: .leftParenToken(),
+        arguments: LabeledExprListSyntax([
+            LabeledExprSyntax(
+                expression: InOutExprSyntax(
+                    expression: DeclReferenceExprSyntax(baseName: .identifier("overrides"))
+                )
+            )
+        ]),
+        rightParen: .rightParenToken()
+    )
+    statements.append(CodeBlockItemSyntax(item: .expr(ExprSyntax(applyCall))))
+
+    // self.init(<input args...>, <shared args...>, <transient args...>)
+    var callArgs: [LabeledExprSyntax] = []
+    let allForwardingMembers = inputMembers + model.sharedMembers + model.transientMembers
+    for (index, member) in allForwardingMembers.enumerated() {
+        let isLast = index == allForwardingMembers.count - 1
+        let valueExpr: ExprSyntax
+        if member.scope == .input {
+            // Input parameter forwarded from the outer init.
+            valueExpr = ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier(member.name)))
+        } else {
+            // shared / transient value pulled out of the overrides builder.
+            valueExpr = ExprSyntax(
+                MemberAccessExprSyntax(
+                    base: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("overrides"))),
+                    declName: DeclReferenceExprSyntax(baseName: .identifier(member.name))
+                )
+            )
+        }
+
+        callArgs.append(
+            LabeledExprSyntax(
+                label: .identifier(member.name),
+                colon: .colonToken(),
+                expression: valueExpr,
+                trailingComma: isLast ? nil : .commaToken()
+            )
+        )
+    }
+
+    let selfInitCall = FunctionCallExprSyntax(
+        calledExpression: ExprSyntax(
+            MemberAccessExprSyntax(
+                base: ExprSyntax(DeclReferenceExprSyntax(baseName: .keyword(.self))),
+                declName: DeclReferenceExprSyntax(baseName: .keyword(.`init`))
+            )
+        ),
+        leftParen: .leftParenToken(),
+        arguments: LabeledExprListSyntax(callArgs),
+        rightParen: .rightParenToken()
+    )
+    statements.append(CodeBlockItemSyntax(item: .expr(ExprSyntax(selfInitCall))))
+
+    let initDecl = InitializerDeclSyntax(
+        attributes: model.options.mainActor ? mainActorAttributeList() : AttributeListSyntax([]),
+        modifiers: modifiers,
+        signature: signature,
+        body: CodeBlockSyntax(statements: CodeBlockItemListSyntax(statements))
+    )
+
+    return DeclSyntax(initDecl)
+}
+
+private func makeWithOverridesMethods(model: DIContainerExpansionModel) -> [DeclSyntax] {
+    let candidates = overrideCandidateMembers(model)
+    guard !candidates.isEmpty else { return [] }
+
+    return [
+        makeWithOverridesMethod(model: model, isAsync: false, isThrowing: false),
+        makeWithOverridesMethod(model: model, isAsync: false, isThrowing: true),
+        makeWithOverridesMethod(model: model, isAsync: true, isThrowing: false),
+        makeWithOverridesMethod(model: model, isAsync: true, isThrowing: true),
+    ]
+}
+
+private func makeWithOverridesMethod(
+    model: DIContainerExpansionModel,
+    isAsync: Bool,
+    isThrowing: Bool
+) -> DeclSyntax {
+    let accessModifiers = accessModifiers(model.accessLevel)
+    var modifiers = accessModifiers
+    modifiers.append(DeclModifierSyntax(name: .keyword(.static)))
+
+    let inputMembers = model.inputMembers
+    var params: [FunctionParameterSyntax] = []
+
+    for member in inputMembers {
+        let param = FunctionParameterSyntax(
+            firstName: .identifier(member.name),
+            secondName: nil,
+            colon: .colonToken(),
+            type: member.type,
+            ellipsis: nil,
+            defaultValue: nil,
+            trailingComma: .commaToken()
+        )
+        params.append(param)
+    }
+
+    let applyOverridesParam = FunctionParameterSyntax(
+        firstName: .wildcardToken(),
+        secondName: .identifier("applyOverrides"),
+        colon: .colonToken(),
+        type: TypeSyntax(stringLiteral: "(inout Overrides) -> Void"),
+        ellipsis: nil,
+        defaultValue: nil,
+        trailingComma: .commaToken()
+    )
+    params.append(applyOverridesParam)
+
+    // operation: (Self) [async] [throws] -> T
+    var operationTypeDescription = "(Self) "
+    if isAsync { operationTypeDescription += "async " }
+    if isThrowing { operationTypeDescription += "throws " }
+    operationTypeDescription += "-> T"
+    let operationParam = FunctionParameterSyntax(
+        firstName: .identifier("operation"),
+        secondName: nil,
+        colon: .colonToken(),
+        type: TypeSyntax(stringLiteral: operationTypeDescription),
+        ellipsis: nil,
+        defaultValue: nil,
+        trailingComma: nil
+    )
+    params.append(operationParam)
+
+    // <T>
+    let genericParameterClause = GenericParameterClauseSyntax(
+        leftAngle: .leftAngleToken(),
+        parameters: GenericParameterListSyntax([
+            GenericParameterSyntax(name: .identifier("T"))
+        ]),
+        rightAngle: .rightAngleToken()
+    )
+
+    // `async throws` effects
+    var effectSpecifiers: FunctionEffectSpecifiersSyntax? = nil
+    if isAsync || isThrowing {
+        effectSpecifiers = FunctionEffectSpecifiersSyntax(
+            asyncSpecifier: isAsync ? .keyword(.async) : nil,
+            throwsClause: isThrowing
+                ? ThrowsClauseSyntax(throwsSpecifier: .keyword(.throws))
+                : nil
+        )
+    }
+
+    let returnClause = ReturnClauseSyntax(
+        arrow: .arrowToken(),
+        type: TypeSyntax(stringLiteral: "T")
+    )
+
+    let signature = FunctionSignatureSyntax(
+        parameterClause: FunctionParameterClauseSyntax(parameters: FunctionParameterListSyntax(params)),
+        effectSpecifiers: effectSpecifiers,
+        returnClause: returnClause
+    )
+
+    // Body: let container = Self(<inputs...>, applyOverrides)
+    //       return [try] [await] operation(container)
+    var statements: [CodeBlockItemSyntax] = []
+
+    var callArgs: [LabeledExprSyntax] = []
+    for member in inputMembers {
+        callArgs.append(
+            LabeledExprSyntax(
+                label: .identifier(member.name),
+                colon: .colonToken(),
+                expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier(member.name))),
+                trailingComma: .commaToken()
+            )
+        )
+    }
+    callArgs.append(
+        LabeledExprSyntax(
+            expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("applyOverrides")))
+        )
+    )
+
+    let selfCall = FunctionCallExprSyntax(
+        calledExpression: ExprSyntax(DeclReferenceExprSyntax(baseName: .keyword(.Self))),
+        leftParen: .leftParenToken(),
+        arguments: LabeledExprListSyntax(callArgs),
+        rightParen: .rightParenToken()
+    )
+
+    let containerDecl = VariableDeclSyntax(
+        bindingSpecifier: .keyword(.let),
+        bindings: PatternBindingListSyntax([
+            PatternBindingSyntax(
+                pattern: IdentifierPatternSyntax(identifier: .identifier("container")),
+                initializer: InitializerClauseSyntax(value: selfCall)
+            )
+        ])
+    )
+    statements.append(CodeBlockItemSyntax(item: .decl(DeclSyntax(containerDecl))))
+
+    let operationCall = FunctionCallExprSyntax(
+        calledExpression: DeclReferenceExprSyntax(baseName: .identifier("operation")),
+        leftParen: .leftParenToken(),
+        arguments: LabeledExprListSyntax([
+            LabeledExprSyntax(expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("container"))))
+        ]),
+        rightParen: .rightParenToken()
+    )
+    var returnExpr: ExprSyntax = ExprSyntax(operationCall)
+    if isAsync {
+        returnExpr = ExprSyntax(AwaitExprSyntax(expression: returnExpr))
+    }
+    if isThrowing {
+        returnExpr = ExprSyntax(TryExprSyntax(expression: returnExpr))
+    }
+
+    let returnStmt = ReturnStmtSyntax(expression: returnExpr)
+    statements.append(CodeBlockItemSyntax(item: .stmt(StmtSyntax(returnStmt))))
+
+    let funcDecl = FunctionDeclSyntax(
+        attributes: model.options.mainActor ? mainActorAttributeList() : AttributeListSyntax([]),
+        modifiers: modifiers,
+        name: .identifier("withOverrides"),
+        genericParameterClause: genericParameterClause,
+        signature: signature,
+        body: CodeBlockSyntax(statements: CodeBlockItemListSyntax(statements))
+    )
+
+    return DeclSyntax(funcDecl)
 }

--- a/Sources/InnoDIMacros/DIContainerCodeGenerator.swift
+++ b/Sources/InnoDIMacros/DIContainerCodeGenerator.swift
@@ -400,6 +400,7 @@ private func makeOverridesStructDecl(model: DIContainerExpansionModel) -> DeclSy
     let modifiers = accessModifiers(model.accessLevel)
     let memberDecls: [MemberBlockItemSyntax] = candidates.map { member in
         let variableDecl = VariableDeclSyntax(
+            modifiers: modifiers,
             bindingSpecifier: .keyword(.var),
             bindings: PatternBindingListSyntax([
                 PatternBindingSyntax(

--- a/Sources/InnoDIMacros/DIContainerMacro.swift
+++ b/Sources/InnoDIMacros/DIContainerMacro.swift
@@ -61,6 +61,16 @@ public struct DIContainerMacro: MemberMacro {
             return []
         }
 
-        return [DIContainerCodeGenerator.generateInit(for: model)]
+        if let conflict = DIContainerParser.findOverridesNameConflict(in: decl) {
+            context.diagnose(
+                Diagnostic(
+                    node: Syntax(conflict.node),
+                    message: SimpleDiagnostic.containerOverridesNameConflict(kind: conflict.kind)
+                )
+            )
+            return [DIContainerCodeGenerator.generateInit(for: model)]
+        }
+
+        return DIContainerCodeGenerator.generateAll(for: model)
     }
 }

--- a/Sources/InnoDIMacros/DIContainerMacro.swift
+++ b/Sources/InnoDIMacros/DIContainerMacro.swift
@@ -61,7 +61,8 @@ public struct DIContainerMacro: MemberMacro {
             return []
         }
 
-        if let conflict = DIContainerParser.findOverridesNameConflict(in: decl) {
+        let hasOverrideCandidates = !(model.sharedMembers.isEmpty && model.transientMembers.isEmpty)
+        if hasOverrideCandidates, let conflict = DIContainerParser.findOverridesNameConflict(in: decl) {
             context.diagnose(
                 Diagnostic(
                     node: Syntax(conflict.node),

--- a/Sources/InnoDIMacros/DIContainerParser.swift
+++ b/Sources/InnoDIMacros/DIContainerParser.swift
@@ -4,6 +4,37 @@ import SwiftSyntax
 import SwiftSyntaxMacros
 
 struct DIContainerParser {
+    struct OverridesNameConflict {
+        let node: any SyntaxProtocol
+        let kind: String
+    }
+
+    /// Scans the container body for a user declaration named `Overrides` that
+    /// would clash with the synthesized builder struct. Returns the offending
+    /// declaration along with its kind ("struct", "class", "typealias", etc.)
+    /// so callers can emit a clear warning.
+    static func findOverridesNameConflict(in decl: some DeclGroupSyntax) -> OverridesNameConflict? {
+        for member in decl.memberBlock.members {
+            let d = member.decl
+            if let s = d.as(StructDeclSyntax.self), s.name.text == "Overrides" {
+                return OverridesNameConflict(node: s, kind: "struct")
+            }
+            if let c = d.as(ClassDeclSyntax.self), c.name.text == "Overrides" {
+                return OverridesNameConflict(node: c, kind: "class")
+            }
+            if let e = d.as(EnumDeclSyntax.self), e.name.text == "Overrides" {
+                return OverridesNameConflict(node: e, kind: "enum")
+            }
+            if let a = d.as(ActorDeclSyntax.self), a.name.text == "Overrides" {
+                return OverridesNameConflict(node: a, kind: "actor")
+            }
+            if let t = d.as(TypeAliasDeclSyntax.self), t.name.text == "Overrides" {
+                return OverridesNameConflict(node: t, kind: "typealias")
+            }
+        }
+        return nil
+    }
+
     static func userDefinedInitializers(in decl: some DeclGroupSyntax) -> [InitializerDeclSyntax] {
         let bodyInitializers = decl.memberBlock.members.compactMap { $0.decl.as(InitializerDeclSyntax.self) }
 

--- a/Sources/InnoDIMacros/Diagnostics.swift
+++ b/Sources/InnoDIMacros/Diagnostics.swift
@@ -31,6 +31,7 @@ enum InnoDIDiagnosticCode: String {
     case containerDependencyCycle = "container.dependency-cycle"
     case containerMainActorConflict = "container.mainactor-conflict"
     case containerCustomInitUnsupported = "container.custom-init-unsupported"
+    case containerOverridesNameConflict = "container.overrides-name-conflict"
     case graphDependencyCycle = "graph.dependency-cycle"
     case graphAmbiguousContainerReference = "graph.ambiguous-container-reference"
 
@@ -43,7 +44,7 @@ enum InnoDIDiagnosticCode: String {
                 .provideFactoryConflict, .provideAsyncFactoryInvalidScope, .provideAsyncFactoryMustBeAsync,
                 .provideUnresolvedFactoryParameter, .provideUnavailableDependencyReference, .provideUnresolvedWithDependency,
                 .containerUnknownDependency, .containerDependencyCycle, .containerMainActorConflict,
-                .containerCustomInitUnsupported, .graphDependencyCycle,
+                .containerCustomInitUnsupported, .containerOverridesNameConflict, .graphDependencyCycle,
                 .graphAmbiguousContainerReference:
             return .validation
         }
@@ -209,6 +210,14 @@ extension SimpleDiagnostic {
         Self(
             "@DIContainer does not support user-defined init declarations in the annotated type or any extension. Remove the custom init and use the synthesized initializer, or switch to manual wiring.",
             code: .containerCustomInitUnsupported
+        )
+    }
+
+    static func containerOverridesNameConflict(kind: String) -> Self {
+        Self(
+            "A nested 'Overrides' \(kind) is already declared. InnoDI's @DIContainer would normally generate an Overrides builder, but the user declaration takes precedence. Rename the user type or skip InnoDI's override scaffolding.",
+            code: .containerOverridesNameConflict,
+            severity: .warning
         )
     }
 }

--- a/Tests/InnoDIMacrosTests/DiagnosticsTests.swift
+++ b/Tests/InnoDIMacrosTests/DiagnosticsTests.swift
@@ -30,6 +30,7 @@ struct DiagnosticsTests {
             .containerDependencyCycle,
             .containerMainActorConflict,
             .containerCustomInitUnsupported,
+            .containerOverridesNameConflict,
             .graphDependencyCycle,
             .graphAmbiguousContainerReference
         ]
@@ -65,6 +66,7 @@ struct DiagnosticsTests {
             (SimpleDiagnostic.containerDependencyCycle(path: "a -> b -> a"), MessageID(domain: "InnoDI.validation", id: "container.dependency-cycle")),
             (SimpleDiagnostic.containerMainActorConflict(actorName: "FeatureActor"), MessageID(domain: "InnoDI.validation", id: "container.mainactor-conflict")),
             (SimpleDiagnostic.containerCustomInitUnsupported(), MessageID(domain: "InnoDI.validation", id: "container.custom-init-unsupported")),
+            (SimpleDiagnostic.containerOverridesNameConflict(kind: "struct"), MessageID(domain: "InnoDI.validation", id: "container.overrides-name-conflict")),
             (SimpleDiagnostic("Graph cycle", code: .graphDependencyCycle), MessageID(domain: "InnoDI.validation", id: "graph.dependency-cycle")),
             (SimpleDiagnostic("Ambiguous reference", code: .graphAmbiguousContainerReference), MessageID(domain: "InnoDI.validation", id: "graph.ambiguous-container-reference"))
         ]

--- a/Tests/InnoDIMacrosTests/OverridesBuilderTests.swift
+++ b/Tests/InnoDIMacrosTests/OverridesBuilderTests.swift
@@ -1,0 +1,175 @@
+import InnoDITestSupport
+import SwiftDiagnostics
+import SwiftSyntaxMacros
+import Testing
+
+@testable import InnoDIMacros
+
+/// Snapshot matrix for the `@DIContainer` Overrides builder feature.
+///
+/// These tests pin the generated `struct Overrides`, convenience `init(_ applyOverrides:)`,
+/// and four `static withOverrides` effect overloads across the dimensions that
+/// drive the code path: input/shared/transient mix, async shared, MainActor
+/// propagation, public access, input-only skip, and user-defined `Overrides`
+/// name conflict.
+@Suite("@DIContainer Overrides builder")
+struct OverridesBuilderTests {
+    private static let macros: [String: any Macro.Type] = [
+        "DIContainer": DIContainerMacro.self,
+        "Provide": ProvideMacro.self,
+    ]
+
+    @Test("input + shared + transient mix generates full Overrides scaffolding")
+    func inputSharedTransientAll() {
+        assertMacroExpansionSnapshot(
+            """
+            @DIContainer
+            struct AppContainer {
+                @Provide(.input)
+                var userID: String
+
+                @Provide(.shared, factory: APIClient(), concrete: true)
+                var apiClient: APIClient
+
+                @Provide(.transient, factory: { ViewModel() }, concrete: true)
+                var viewModel: ViewModel
+            }
+            """,
+            matches: "inputSharedTransientAll",
+            macros: Self.macros
+        )
+    }
+
+    @Test("shared-only container: convenience init drops input params, keeps overrides")
+    func sharedOnly() {
+        assertMacroExpansionSnapshot(
+            """
+            @DIContainer
+            struct AppContainer {
+                @Provide(.shared, factory: APIClient(), concrete: true)
+                var apiClient: APIClient
+            }
+            """,
+            matches: "sharedOnly",
+            macros: Self.macros
+        )
+    }
+
+    @Test("transient-only container: Overrides uses T? (not closure)")
+    func transientOnly() {
+        assertMacroExpansionSnapshot(
+            """
+            @DIContainer
+            struct AppContainer {
+                @Provide(.transient, factory: { ViewModel() }, concrete: true)
+                var viewModel: ViewModel
+            }
+            """,
+            matches: "transientOnly",
+            macros: Self.macros
+        )
+    }
+
+    @Test("async shared override remains T? (not Task-wrapped)")
+    func asyncSharedOverride() {
+        assertMacroExpansionSnapshot(
+            """
+            @DIContainer
+            struct AppContainer {
+                @Provide(.input)
+                var config: Config
+
+                @Provide(.shared, asyncFactory: { (config: Config) async in Service(config: config) }, concrete: true)
+                var service: Service
+            }
+            """,
+            matches: "asyncSharedOverride",
+            macros: Self.macros
+        )
+    }
+
+    @Test("mainActor: true propagates @MainActor to convenience init and withOverrides")
+    func mainActorPropagation() {
+        assertMacroExpansionSnapshot(
+            """
+            @DIContainer(mainActor: true)
+            struct AppContainer {
+                @Provide(.input)
+                var userID: String
+
+                @Provide(.shared, factory: APIClient(), concrete: true)
+                var apiClient: APIClient
+            }
+            """,
+            matches: "mainActorPropagation",
+            macros: Self.macros
+        )
+    }
+
+    @Test("public container propagates public to Overrides + convenience init + withOverrides")
+    func publicContainer() {
+        assertMacroExpansionSnapshot(
+            """
+            @DIContainer
+            public struct AppContainer {
+                @Provide(.input)
+                var userID: String
+
+                @Provide(.shared, factory: APIClient(), concrete: true)
+                var apiClient: APIClient
+            }
+            """,
+            matches: "publicContainer",
+            macros: Self.macros
+        )
+    }
+
+    @Test("input-only container skips Overrides scaffolding (byte-identical to pre-J baseline)")
+    func inputOnlySkipsScaffolding() {
+        assertMacroExpansionSnapshot(
+            """
+            @DIContainer
+            struct AppContainer {
+                @Provide(.input)
+                var userID: String
+
+                @Provide(.input)
+                var baseURL: String
+            }
+            """,
+            matches: "inputOnlySkipsScaffolding",
+            macros: Self.macros
+        )
+    }
+
+    @Test("user-defined nested 'Overrides' suppresses synthesis with a warning diagnostic")
+    func userDefinedOverridesConflict() {
+        assertMacroExpansionSnapshot(
+            """
+            @DIContainer
+            struct AppContainer {
+                struct Overrides {
+                    var custom: String
+                }
+
+                @Provide(.input)
+                var userID: String
+
+                @Provide(.shared, factory: APIClient(), concrete: true)
+                var apiClient: APIClient
+            }
+            """,
+            matches: "userDefinedOverridesConflict",
+            diagnostics: [
+                DiagnosticSpec(
+                    id: MessageID(domain: "InnoDI.validation", id: "container.overrides-name-conflict"),
+                    message: "A nested 'Overrides' struct is already declared. InnoDI's @DIContainer would normally generate an Overrides builder, but the user declaration takes precedence. Rename the user type or skip InnoDI's override scaffolding.",
+                    line: 3,
+                    column: 5,
+                    severity: .warning
+                )
+            ],
+            macros: Self.macros
+        )
+    }
+}

--- a/Tests/InnoDIMacrosTests/OverridesBuilderTests.swift
+++ b/Tests/InnoDIMacrosTests/OverridesBuilderTests.swift
@@ -142,6 +142,25 @@ struct OverridesBuilderTests {
         )
     }
 
+    @Test("input-only container with user-defined Overrides skips scaffolding silently")
+    func inputOnlyUserDefinedOverridesSkipsConflictWarning() {
+        assertMacroExpansionSnapshot(
+            """
+            @DIContainer
+            struct AppContainer {
+                struct Overrides {
+                    var custom: String
+                }
+
+                @Provide(.input)
+                var userID: String
+            }
+            """,
+            matches: "inputOnlyUserDefinedOverridesSkipsConflictWarning",
+            macros: Self.macros
+        )
+    }
+
     @Test("user-defined nested 'Overrides' suppresses synthesis with a warning diagnostic")
     func userDefinedOverridesConflict() {
         assertMacroExpansionSnapshot(

--- a/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/anyProtocolSharedDependency.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/anyProtocolSharedDependency.swift
@@ -11,4 +11,34 @@ struct AppContainer {
     init(apiClient: (any APIClientProtocol)? = nil) {
         self._storage_apiClient = apiClient ?? APIClient()
     }
+
+    struct Overrides {
+        var apiClient: (any APIClientProtocol)? = nil
+    }
+
+    init(_ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(apiClient: overrides.apiClient)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(applyOverrides)
+        return try await operation(container)
+    }
 }

--- a/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/asyncSharedFactoryGeneratesTaskBackedInit.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/asyncSharedFactoryGeneratesTaskBackedInit.swift
@@ -29,4 +29,34 @@ struct AppContainer {
         self._storage_task_service = _task_service
         let _resolved_task_service = _task_service
     }
+
+    struct Overrides {
+        var service: Service? = nil
+    }
+
+    init(config: Config, _ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(config: config, service: overrides.service)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(config: config, applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(config: config, applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(config: config, applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(config: config, applyOverrides)
+        return try await operation(container)
+    }
 }

--- a/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/compositionSharedDependency.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/compositionSharedDependency.swift
@@ -11,4 +11,34 @@ struct AppContainer {
     init(apiClient: (APIClientProtocol & LoggerProtocol)? = nil) {
         self._storage_apiClient = apiClient ?? APIClient()
     }
+
+    struct Overrides {
+        var apiClient: (APIClientProtocol & LoggerProtocol)? = nil
+    }
+
+    init(_ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(apiClient: overrides.apiClient)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(applyOverrides)
+        return try await operation(container)
+    }
 }

--- a/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/concreteSharedDependencyWithOptIn.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/concreteSharedDependencyWithOptIn.swift
@@ -11,4 +11,34 @@ struct AppContainer {
     init(apiClient: APIClient? = nil) {
         self._storage_apiClient = apiClient ?? APIClient()
     }
+
+    struct Overrides {
+        var apiClient: APIClient? = nil
+    }
+
+    init(_ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(apiClient: overrides.apiClient)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(applyOverrides)
+        return try await operation(container)
+    }
 }

--- a/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/optionalAnyProtocolSharedDependency.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/optionalAnyProtocolSharedDependency.swift
@@ -11,4 +11,34 @@ struct AppContainer {
     init(apiClient: (any APIClientProtocol)?? = nil) {
         self._storage_apiClient = apiClient ?? APIClient()
     }
+
+    struct Overrides {
+        var apiClient: (any APIClientProtocol)?? = nil
+    }
+
+    init(_ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(apiClient: overrides.apiClient)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(applyOverrides)
+        return try await operation(container)
+    }
 }

--- a/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/reorderedFactoryParametersRemainValid.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/reorderedFactoryParametersRemainValid.swift
@@ -29,4 +29,34 @@ struct AppContainer {
                 Service(config: config, logger: logger)
             }(self._storage_logger, self._storage_config)
     }
+
+    struct Overrides {
+        var service: Service? = nil
+    }
+
+    init(config: Config, logger: Logger, _ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(config: config, logger: logger, service: overrides.service)
+    }
+
+    static func withOverrides<T>(config: Config, logger: Logger, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(config: config, logger: logger, applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(config: Config, logger: Logger, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(config: config, logger: logger, applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(config: Config, logger: Logger, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(config: config, logger: logger, applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(config: Config, logger: Logger, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(config: config, logger: logger, applyOverrides)
+        return try await operation(container)
+    }
 }

--- a/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/someProtocolSharedDependency.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/someProtocolSharedDependency.swift
@@ -11,4 +11,34 @@ struct AppContainer {
     init(apiClient: (some APIClientProtocol)? = nil) {
         self._storage_apiClient = apiClient ?? APIClient()
     }
+
+    struct Overrides {
+        var apiClient: (some APIClientProtocol)? = nil
+    }
+
+    init(_ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(apiClient: overrides.apiClient)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(applyOverrides)
+        return try await operation(container)
+    }
 }

--- a/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/stringLiteralTokensDoNotTriggerFalseDependencyCycles.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/stringLiteralTokensDoNotTriggerFalseDependencyCycles.swift
@@ -19,4 +19,35 @@ struct AppContainer {
         self._storage_a = a ?? ServiceA(name: "b")
         self._storage_b = b ?? ServiceB(name: "a")
     }
+
+    struct Overrides {
+        var a: ServiceA? = nil
+        var b: ServiceB? = nil
+    }
+
+    init(_ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(a: overrides.a, b: overrides.b)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(applyOverrides)
+        return try await operation(container)
+    }
 }

--- a/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/validateDAGFalseSkipsCycleValidation.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/validateDAGFalseSkipsCycleValidation.swift
@@ -29,4 +29,35 @@ struct AppContainer {
         self._override_serviceA = serviceA
         self._override_serviceB = serviceB
     }
+
+    struct Overrides {
+        var serviceA: ServiceA? = nil
+        var serviceB: ServiceB? = nil
+    }
+
+    init(_ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(serviceA: overrides.serviceA, serviceB: overrides.serviceB)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(applyOverrides)
+        return try await operation(container)
+    }
 }

--- a/Tests/InnoDIMacrosTests/__Snapshots__/OverridesBuilderTests/asyncSharedOverride.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/OverridesBuilderTests/asyncSharedOverride.swift
@@ -1,0 +1,62 @@
+
+struct AppContainer {
+    var config: Config {
+        get {
+            return _storage_config
+        }
+    }
+
+    private let _storage_config: Config
+    var service: Service {
+        get async {
+            return await _storage_task_service.value
+        }
+    }
+
+    private let _storage_task_service: Task<Service, Never>
+
+    init(config: Config, service: Service? = nil) {
+        self._storage_config = config
+        let _resolved_config = config
+        let _task_service = Task<Service, Never> {
+            if let override = service {
+                return override
+            }
+            return await { (config: Config) async in
+                Service(config: config)
+            }(_resolved_config)
+        }
+        self._storage_task_service = _task_service
+        let _resolved_task_service = _task_service
+    }
+
+    struct Overrides {
+        var service: Service? = nil
+    }
+
+    init(config: Config, _ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(config: config, service: overrides.service)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(config: config, applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(config: config, applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(config: config, applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(config: config, applyOverrides)
+        return try await operation(container)
+    }
+}

--- a/Tests/InnoDIMacrosTests/__Snapshots__/OverridesBuilderTests/inputOnlySkipsScaffolding.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/OverridesBuilderTests/inputOnlySkipsScaffolding.swift
@@ -1,0 +1,22 @@
+
+struct AppContainer {
+    var userID: String {
+        get {
+            return _storage_userID
+        }
+    }
+
+    private let _storage_userID: String
+    var baseURL: String {
+        get {
+            return _storage_baseURL
+        }
+    }
+
+    private let _storage_baseURL: String
+
+    init(userID: String, baseURL: String) {
+        self._storage_userID = userID
+        self._storage_baseURL = baseURL
+    }
+}

--- a/Tests/InnoDIMacrosTests/__Snapshots__/OverridesBuilderTests/inputOnlyUserDefinedOverridesSkipsConflictWarning.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/OverridesBuilderTests/inputOnlyUserDefinedOverridesSkipsConflictWarning.swift
@@ -1,0 +1,17 @@
+
+struct AppContainer {
+    struct Overrides {
+        var custom: String
+    }
+    var userID: String {
+        get {
+            return _storage_userID
+        }
+    }
+
+    private let _storage_userID: String
+
+    init(userID: String) {
+        self._storage_userID = userID
+    }
+}

--- a/Tests/InnoDIMacrosTests/__Snapshots__/OverridesBuilderTests/inputSharedTransientAll.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/OverridesBuilderTests/inputSharedTransientAll.swift
@@ -1,0 +1,66 @@
+
+struct AppContainer {
+    var userID: String {
+        get {
+            return _storage_userID
+        }
+    }
+
+    private let _storage_userID: String
+    var apiClient: APIClient {
+        get {
+            return _storage_apiClient
+        }
+    }
+
+    private let _storage_apiClient: APIClient
+    var viewModel: ViewModel {
+        get {
+            if let override = _override_viewModel {
+                return override
+            }
+            return {
+                ViewModel()
+            }()
+        }
+    }
+
+    private let _override_viewModel: ViewModel?
+
+    init(userID: String, apiClient: APIClient? = nil, viewModel: ViewModel? = nil) {
+        self._storage_userID = userID
+        self._storage_apiClient = apiClient ?? APIClient()
+        self._override_viewModel = viewModel
+    }
+
+    struct Overrides {
+        var apiClient: APIClient? = nil
+        var viewModel: ViewModel? = nil
+    }
+
+    init(userID: String, _ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(userID: userID, apiClient: overrides.apiClient, viewModel: overrides.viewModel)
+    }
+
+    static func withOverrides<T>(userID: String, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(userID: userID, applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(userID: String, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(userID: userID, applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(userID: String, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(userID: userID, applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(userID: String, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(userID: userID, applyOverrides)
+        return try await operation(container)
+    }
+}

--- a/Tests/InnoDIMacrosTests/__Snapshots__/OverridesBuilderTests/mainActorPropagation.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/OverridesBuilderTests/mainActorPropagation.swift
@@ -1,0 +1,52 @@
+
+struct AppContainer {
+    var userID: String {
+        get {
+            return _storage_userID
+        }
+    }
+
+    private let _storage_userID: String
+    var apiClient: APIClient {
+        get {
+            return _storage_apiClient
+        }
+    }
+
+    private let _storage_apiClient: APIClient
+
+    @MainActor init(userID: String, apiClient: APIClient? = nil) {
+        self._storage_userID = userID
+        self._storage_apiClient = apiClient ?? APIClient()
+    }
+
+    struct Overrides {
+        var apiClient: APIClient? = nil
+    }
+
+    @MainActor init(userID: String, _ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(userID: userID, apiClient: overrides.apiClient)
+    }
+
+    @MainActor static func withOverrides<T>(userID: String, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(userID: userID, applyOverrides)
+        return operation(container)
+    }
+
+    @MainActor static func withOverrides<T>(userID: String, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(userID: userID, applyOverrides)
+        return try operation(container)
+    }
+
+    @MainActor static func withOverrides<T>(userID: String, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(userID: userID, applyOverrides)
+        return await operation(container)
+    }
+
+    @MainActor static func withOverrides<T>(userID: String, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(userID: userID, applyOverrides)
+        return try await operation(container)
+    }
+}

--- a/Tests/InnoDIMacrosTests/__Snapshots__/OverridesBuilderTests/publicContainer.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/OverridesBuilderTests/publicContainer.swift
@@ -21,7 +21,7 @@ public struct AppContainer {
     }
 
     public struct Overrides {
-        var apiClient: APIClient? = nil
+        public var apiClient: APIClient? = nil
     }
 
     public init(userID: String, _ applyOverrides: (inout Overrides) -> Void) {

--- a/Tests/InnoDIMacrosTests/__Snapshots__/OverridesBuilderTests/publicContainer.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/OverridesBuilderTests/publicContainer.swift
@@ -1,0 +1,52 @@
+
+public struct AppContainer {
+    var userID: String {
+        get {
+            return _storage_userID
+        }
+    }
+
+    private let _storage_userID: String
+    var apiClient: APIClient {
+        get {
+            return _storage_apiClient
+        }
+    }
+
+    private let _storage_apiClient: APIClient
+
+    public init(userID: String, apiClient: APIClient? = nil) {
+        self._storage_userID = userID
+        self._storage_apiClient = apiClient ?? APIClient()
+    }
+
+    public struct Overrides {
+        var apiClient: APIClient? = nil
+    }
+
+    public init(userID: String, _ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(userID: userID, apiClient: overrides.apiClient)
+    }
+
+    public static func withOverrides<T>(userID: String, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(userID: userID, applyOverrides)
+        return operation(container)
+    }
+
+    public static func withOverrides<T>(userID: String, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(userID: userID, applyOverrides)
+        return try operation(container)
+    }
+
+    public static func withOverrides<T>(userID: String, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(userID: userID, applyOverrides)
+        return await operation(container)
+    }
+
+    public static func withOverrides<T>(userID: String, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(userID: userID, applyOverrides)
+        return try await operation(container)
+    }
+}

--- a/Tests/InnoDIMacrosTests/__Snapshots__/OverridesBuilderTests/sharedOnly.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/OverridesBuilderTests/sharedOnly.swift
@@ -1,0 +1,44 @@
+
+struct AppContainer {
+    var apiClient: APIClient {
+        get {
+            return _storage_apiClient
+        }
+    }
+
+    private let _storage_apiClient: APIClient
+
+    init(apiClient: APIClient? = nil) {
+        self._storage_apiClient = apiClient ?? APIClient()
+    }
+
+    struct Overrides {
+        var apiClient: APIClient? = nil
+    }
+
+    init(_ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(apiClient: overrides.apiClient)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(applyOverrides)
+        return try await operation(container)
+    }
+}

--- a/Tests/InnoDIMacrosTests/__Snapshots__/OverridesBuilderTests/transientOnly.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/OverridesBuilderTests/transientOnly.swift
@@ -1,0 +1,49 @@
+
+struct AppContainer {
+    var viewModel: ViewModel {
+        get {
+            if let override = _override_viewModel {
+                return override
+            }
+            return {
+                ViewModel()
+            }()
+        }
+    }
+
+    private let _override_viewModel: ViewModel?
+
+    init(viewModel: ViewModel? = nil) {
+        self._override_viewModel = viewModel
+    }
+
+    struct Overrides {
+        var viewModel: ViewModel? = nil
+    }
+
+    init(_ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(viewModel: overrides.viewModel)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(applyOverrides)
+        return try await operation(container)
+    }
+}

--- a/Tests/InnoDIMacrosTests/__Snapshots__/OverridesBuilderTests/userDefinedOverridesConflict.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/OverridesBuilderTests/userDefinedOverridesConflict.swift
@@ -1,0 +1,25 @@
+
+struct AppContainer {
+    struct Overrides {
+        var custom: String
+    }
+    var userID: String {
+        get {
+            return _storage_userID
+        }
+    }
+
+    private let _storage_userID: String
+    var apiClient: APIClient {
+        get {
+            return _storage_apiClient
+        }
+    }
+
+    private let _storage_apiClient: APIClient
+
+    init(userID: String, apiClient: APIClient? = nil) {
+        self._storage_userID = userID
+        self._storage_apiClient = apiClient ?? APIClient()
+    }
+}

--- a/Tests/InnoDIMacrosTests/__Snapshots__/ProvideMacroTests/asyncTransientFactoryGeneratesAsyncAccessor.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/ProvideMacroTests/asyncTransientFactoryGeneratesAsyncAccessor.swift
@@ -24,4 +24,34 @@ struct AppContainer {
         self._storage_apiClient = apiClient
         self._override_viewModel = viewModel
     }
+
+    struct Overrides {
+        var viewModel: ViewModel? = nil
+    }
+
+    init(apiClient: APIClient, _ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(apiClient: apiClient, viewModel: overrides.viewModel)
+    }
+
+    static func withOverrides<T>(apiClient: APIClient, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(apiClient: apiClient, applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(apiClient: APIClient, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(apiClient: apiClient, applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(apiClient: APIClient, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(apiClient: apiClient, applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(apiClient: APIClient, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(apiClient: apiClient, applyOverrides)
+        return try await operation(container)
+    }
 }

--- a/Tests/InnoDIMacrosTests/__Snapshots__/ProvideMacroTests/mainActorContainerAppliesMainActorToAccessor.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/ProvideMacroTests/mainActorContainerAppliesMainActorToAccessor.swift
@@ -14,4 +14,34 @@ struct AppContainer {
     @MainActor init(service: Service? = nil) {
         self._override_service = service
     }
+
+    struct Overrides {
+        var service: Service? = nil
+    }
+
+    @MainActor init(_ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(service: overrides.service)
+    }
+
+    @MainActor static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(applyOverrides)
+        return operation(container)
+    }
+
+    @MainActor static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(applyOverrides)
+        return try operation(container)
+    }
+
+    @MainActor static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(applyOverrides)
+        return await operation(container)
+    }
+
+    @MainActor static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(applyOverrides)
+        return try await operation(container)
+    }
 }

--- a/Tests/InnoDIMacrosTests/__Snapshots__/ProvideMacroTests/transientFactoryClosureInjectsAllDependenciesForMultipleParameters.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/ProvideMacroTests/transientFactoryClosureInjectsAllDependenciesForMultipleParameters.swift
@@ -32,4 +32,34 @@ struct AppContainer {
         self._storage_logger = logger
         self._override_viewModel = viewModel
     }
+
+    struct Overrides {
+        var viewModel: ViewModel? = nil
+    }
+
+    init(apiClient: APIClient, logger: Logger, _ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(apiClient: apiClient, logger: logger, viewModel: overrides.viewModel)
+    }
+
+    static func withOverrides<T>(apiClient: APIClient, logger: Logger, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(apiClient: apiClient, logger: logger, applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(apiClient: APIClient, logger: Logger, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(apiClient: apiClient, logger: logger, applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(apiClient: APIClient, logger: Logger, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(apiClient: apiClient, logger: logger, applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(apiClient: APIClient, logger: Logger, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(apiClient: apiClient, logger: logger, applyOverrides)
+        return try await operation(container)
+    }
 }

--- a/Tests/InnoDIMacrosTests/__Snapshots__/ProvideMacroTests/transientFactoryClosureInjectsDependenciesByParameterName.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/ProvideMacroTests/transientFactoryClosureInjectsDependenciesByParameterName.swift
@@ -24,4 +24,34 @@ struct AppContainer {
         self._storage_apiClient = apiClient
         self._override_viewModel = viewModel
     }
+
+    struct Overrides {
+        var viewModel: ViewModel? = nil
+    }
+
+    init(apiClient: APIClient, _ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(apiClient: apiClient, viewModel: overrides.viewModel)
+    }
+
+    static func withOverrides<T>(apiClient: APIClient, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(apiClient: apiClient, applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(apiClient: APIClient, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(apiClient: apiClient, applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(apiClient: APIClient, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(apiClient: apiClient, applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(apiClient: APIClient, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(apiClient: apiClient, applyOverrides)
+        return try await operation(container)
+    }
 }

--- a/Tests/InnoDIMacrosTests/__Snapshots__/ProvideMacroTests/transientFactoryClosureWithNoParametersDoesNotInjectDependencies.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/ProvideMacroTests/transientFactoryClosureWithNoParametersDoesNotInjectDependencies.swift
@@ -16,4 +16,34 @@ struct AppContainer {
     init(viewModel: ViewModel? = nil) {
         self._override_viewModel = viewModel
     }
+
+    struct Overrides {
+        var viewModel: ViewModel? = nil
+    }
+
+    init(_ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(viewModel: overrides.viewModel)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(_ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(applyOverrides)
+        return try await operation(container)
+    }
 }

--- a/Tests/InnoDIMacrosTests/__Snapshots__/ProvideMacroTests/transientTypeFactoryWithDependenciesUsesAccessorInjection.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/ProvideMacroTests/transientTypeFactoryWithDependenciesUsesAccessorInjection.swift
@@ -22,4 +22,34 @@ struct AppContainer {
         self._storage_config = config
         self._override_viewModel = viewModel
     }
+
+    struct Overrides {
+        var viewModel: ViewModel? = nil
+    }
+
+    init(config: Config, _ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(config: config, viewModel: overrides.viewModel)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(config: config, applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(config: config, applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(config: config, applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(config: config, applyOverrides)
+        return try await operation(container)
+    }
 }

--- a/Tests/InnoDIRuntimeTests/OverridesRuntimeTests.swift
+++ b/Tests/InnoDIRuntimeTests/OverridesRuntimeTests.swift
@@ -1,0 +1,129 @@
+import Testing
+
+import InnoDI
+
+// MARK: - Fixtures
+
+protocol APIClientProtocol: Sendable {
+    func tag() -> String
+}
+
+struct LiveAPIClient: APIClientProtocol {
+    func tag() -> String { "live" }
+}
+
+struct MockAPIClient: APIClientProtocol {
+    let value: String
+    func tag() -> String { value }
+}
+
+struct ViewModel: Sendable {
+    let id: String
+    let apiTag: String
+}
+
+@DIContainer
+struct RuntimeContainer {
+    @Provide(.input)
+    var userID: String
+
+    @Provide(.shared, factory: { LiveAPIClient() })
+    var apiClient: any APIClientProtocol
+
+    @Provide(.transient, factory: { (apiClient: any APIClientProtocol) in
+        ViewModel(id: "vm", apiTag: apiClient.tag())
+    }, concrete: true)
+    var viewModel: ViewModel
+}
+
+// MARK: - Runtime exercise
+
+/// End-to-end runtime tests for the `@DIContainer` Overrides builder: the
+/// convenience trailing-closure init and the four `withOverrides` effect
+/// overloads must funnel user overrides into the primary init correctly.
+///
+/// Compile-time correctness is covered by `OverridesBuilderTests` (snapshot
+/// matrix). These tests assert the *runtime* semantics: overrides actually
+/// land, defaults are honored when omitted, and every effect overload
+/// dispatches.
+@Suite("@DIContainer Overrides runtime")
+struct OverridesRuntimeTests {
+    @Test("Convenience init defaults to the live factory when no override is applied")
+    func defaultsWithoutOverride() {
+        let container = RuntimeContainer(userID: "u1") { _ in }
+        #expect(container.userID == "u1")
+        #expect(container.apiClient.tag() == "live")
+        #expect(container.viewModel.apiTag == "live")
+    }
+
+    @Test("Convenience init applies the shared override into the resolved accessor")
+    func sharedOverrideWins() {
+        let container = RuntimeContainer(userID: "u1") { overrides in
+            overrides.apiClient = MockAPIClient(value: "mock-shared")
+        }
+        #expect(container.apiClient.tag() == "mock-shared")
+        // The transient factory pulls the shared apiClient from the container,
+        // so the override propagates through to downstream dependencies.
+        #expect(container.viewModel.apiTag == "mock-shared")
+    }
+
+    @Test("Convenience init applies the transient override (stored value is returned each access)")
+    func transientOverrideIsStored() {
+        let fixed = ViewModel(id: "override", apiTag: "override-tag")
+        let container = RuntimeContainer(userID: "u1") { overrides in
+            overrides.viewModel = fixed
+        }
+        // `.transient` override is returned verbatim on every access.
+        #expect(container.viewModel.id == "override")
+        #expect(container.viewModel.id == "override")
+    }
+
+    @Test("withOverrides sync, non-throwing dispatches the operation closure")
+    func withOverridesSyncNonThrowing() {
+        let tag = RuntimeContainer.withOverrides(userID: "u1") { overrides in
+            overrides.apiClient = MockAPIClient(value: "sync")
+        } operation: { container in
+            container.apiClient.tag()
+        }
+        #expect(tag == "sync")
+    }
+
+    @Test("withOverrides sync, throwing rethrows from the operation closure")
+    func withOverridesSyncThrowing() throws {
+        struct E: Error {}
+
+        let tag = try RuntimeContainer.withOverrides(userID: "u1") { overrides in
+            overrides.apiClient = MockAPIClient(value: "sync-throws")
+        } operation: { container -> String in
+            container.apiClient.tag()
+        }
+        #expect(tag == "sync-throws")
+
+        #expect(throws: E.self) {
+            try RuntimeContainer.withOverrides(userID: "u1") { _ in
+            } operation: { _ -> String in
+                throw E()
+            }
+        }
+    }
+
+    @Test("withOverrides async, non-throwing awaits the operation closure")
+    func withOverridesAsyncNonThrowing() async {
+        let tag = await RuntimeContainer.withOverrides(userID: "u1") { overrides in
+            overrides.apiClient = MockAPIClient(value: "async")
+        } operation: { container in
+            await Task { container.apiClient.tag() }.value
+        }
+        #expect(tag == "async")
+    }
+
+    @Test("withOverrides async, throwing awaits + rethrows from the operation closure")
+    func withOverridesAsyncThrowing() async throws {
+        let tag = try await RuntimeContainer.withOverrides(userID: "u1") { overrides in
+            overrides.apiClient = MockAPIClient(value: "async-throws")
+        } operation: { container -> String in
+            try await Task { container.apiClient.tag() }.value
+        }
+        #expect(tag == "async-throws")
+    }
+}


### PR DESCRIPTION
## Summary

Closes the Top-1 testing-ergonomics gap identified in the post-PR-#17 comparison report. For any container with a `.shared` / `.transient` member, `@DIContainer` now synthesizes a **named override builder** on top of the existing positional-parameter init — so tests only restate the members they actually want to replace.

### Generated per container (always; opt-in flag intentionally not introduced)

1. **Primary `init`** — unchanged; every existing call site keeps working.
2. **Nested `struct Overrides`** — one optional stored property per `.shared`/`.transient` member, access-level mirrored.
3. **Convenience `init(<inputs…>, _ applyOverrides: (inout Overrides) -> Void)`** — trailing-closure ergonomics; propagates `@MainActor`.
4. **Four `static func withOverrides<T>`** effect overloads (sync / throws / async / async throws) — mirrors the `swift-dependencies` `withDependencies { } operation:` pattern.

Input-only containers skip the scaffolding silently. When the container already declares a nested `Overrides` type (struct/class/enum/actor/typealias), the new `container.overrides-name-conflict` **warning** fires and (2)–(4) are skipped — the primary init is unchanged.

### Usage

```swift
// Option A — convenience init with trailing closure
let container = AppContainer(baseURL: "https://test.example.com") {
    \$0.apiClient = MockAPIClient()
}

// Option B — scoped operation
let result = try await AppContainer.withOverrides(baseURL: "https://test.example.com") { overrides in
    overrides.apiClient = MockAPIClient()
} operation: { container in
    try await container.homeViewModel.load()
}
```

Shared overrides cascade — `.transient` factories pulling the shared member observe the mock. `.transient` overrides return the stored value verbatim on every access. Async `.shared` overrides stay `T?` (not `Task<T, …>?`).

### Key implementation notes

- `@attached(member, names:)` on `Sources/InnoDI/InnoDI.swift` was extended with `named(Overrides), named(withOverrides)` — the compiler otherwise rejects the synthesized decls at use sites. Documented in `CLAUDE.md` so this doesn't bite the next feature.
- New `InnoDIRuntimeTests` target depends only on `InnoDI` (no TestSupport, no direct macro imports) — exercises real macro output end-to-end.
- Name-conflict detection lives in `DIContainerParser.findOverridesNameConflict` and short-circuits inside `DIContainerMacro.expansion(...)` before `generateAll` runs.

### Commits

1. `feat(@DIContainer): generate Overrides builder, convenience init, withOverrides`
2. `test(macros): cover Overrides builder with 8 snapshots + diagnostic case`
3. `test(runtime): add InnoDIRuntimeTests target for end-to-end override coverage`
4. `docs: document the Overrides builder API across README/CLAUDE/ROADMAP`

## Test plan

- [x] `swift test` — 142 tests / 16 suites green
- [x] 8 new `OverridesBuilderTests` snapshots recorded (mixed / shared-only / transient-only / async shared / mainActor / public / input-only skip / user conflict)
- [x] Existing 9 DIContainerMacroTests + 6 ProvideMacroTests snapshots refreshed (builder block additions only; input-only scenarios remain byte-identical)
- [x] `OverridesRuntimeTests` — 7 e2e tests covering convenience-init defaults, `.shared` override + cascading, `.transient` override semantics, and all 4 `withOverrides` effect overloads
- [x] `DiagnosticsTests` — `container.overrides-name-conflict` added to validation-category and MessageID-stability matrices
- [ ] Reviewer: confirm snapshot diffs are limited to additive `struct Overrides { … }` / convenience init / `withOverrides` blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)