### PR TITLE
[codex] @SubContainer(bindings:)와 deferred wrapper semantic validation 추가

### DIFF
--- a/Sources/InnoDI/InnoDI.swift
+++ b/Sources/InnoDI/InnoDI.swift
@@ -257,11 +257,15 @@ public enum SubContainerScope {
 ///   no default because the two lifetimes have very different runtime
 ///   implications (cached vs fresh), and forcing the author to pick makes the
 ///   intent visible at every declaration site.
-/// - `with`: Optional keypath list used to restrict or reorder which parent
-///   members are forwarded to the child. Each `\.parentMember` keypath is
-///   passed positionally to the child init; the macro does not rewrite child
-///   parameter labels, so the order must still match the child's `.input`
-///   declaration order.
+/// - `with`: Optional keypath list used to restrict or reorder which same-name
+///   parent members are forwarded to the child. Each `\.parentMember` keypath
+///   is passed with the same label on the child side.
+/// - `bindings`: Optional explicit remapping tuples used when child `.input`
+///   labels differ from the parent member names. Each tuple spells
+///   `(child: \.childInput, parent: \.parentMember)`.
+///
+/// `with` and `bindings` are mutually exclusive. Use `with` for same-name
+/// subset/reorder shorthand, and `bindings` for rename-aware explicit wiring.
 ///
 /// ### Wiring
 /// The macro emits a parent-side property whose getter (for `.transient`) or
@@ -269,9 +273,10 @@ public enum SubContainerScope {
 /// `Child(config: self.config, apiClient: self.apiClient, …)`. When `with:`
 /// is empty the macro assumes each child `.input` parameter label matches a
 /// parent member name. When `with:` is provided, the listed parent members
-/// replace the auto-matched ones positionally. Any mismatch surfaces as a
-/// regular Swift compile error from the child's synthesized init — the macro
-/// does not pretend to verify the child's parameter list cross-file.
+/// replace the auto-matched set but keep their same-name labels. When
+/// `bindings:` is provided, each tuple rewrites the child label explicitly
+/// while reading from the selected parent member. Child-input verification is
+/// handled conservatively by the build-support validator across the module.
 ///
 /// ### Overrides
 /// `@DIContainer` extends its nested `Overrides` struct with two optional
@@ -284,18 +289,13 @@ public enum SubContainerScope {
 ///   convenience init (`overrides.featureOverrides = { $0.store = Mock() }`).
 ///
 /// Both slots are mutually exclusive: if the direct replacement is provided
-/// it wins; otherwise the chain closure (if any) is forwarded. The second
-/// slot is also a compile-time contract: because the parent's generated init
-/// and `Overrides` struct mention `<ChildContainer>.Overrides` in their type
-/// signatures, the child must emit that nested type even when you never set
-/// or call `<name>Overrides`. Input-only children do not emit `Overrides`, so
-/// a parent `@SubContainer` pointing at an input-only child fails to compile
-/// with the usual `type '<ChildContainer>' has no member 'Overrides'` error.
-/// Remedy: add at least one `.shared`, `.transient`, or `@SubContainer`
-/// member to the child so InnoDI emits `<ChildContainer>.Overrides`.
+/// it wins; otherwise the chain closure (if any) is forwarded. Input-only
+/// children synthesize an empty nested `Overrides` type so the chain closure
+/// remains source-compatible even when the child has nothing overrideable yet.
 @attached(peer, names: prefixed(_storage_sub_), prefixed(_override_sub_), prefixed(_override_sub_apply_), prefixed(_innoDISubBuild_))
 @attached(accessor)
 public macro SubContainer(
     scope: SubContainerScope,
-    with dependencies: [AnyKeyPath] = []
+    with dependencies: [AnyKeyPath] = [],
+    bindings: [(child: AnyKeyPath, parent: AnyKeyPath)] = []
 ) = #externalMacro(module: "InnoDIMacros", type: "SubContainerMacro")

--- a/Sources/InnoDIBuildSupport/ContainerSemanticBuildValidator.swift
+++ b/Sources/InnoDIBuildSupport/ContainerSemanticBuildValidator.swift
@@ -1,0 +1,615 @@
+import Foundation
+import InnoDICore
+import SwiftParser
+import SwiftSyntax
+
+package enum ContainerSemanticBuildValidator {
+    package static func validate(rootPath: String) throws -> ValidationIssueReport {
+        let rootURL = URL(fileURLWithPath: rootPath, isDirectory: true)
+        let sourceFiles = discoverValidationSourceFiles(rootPath: rootPath)
+
+        var collectorResults: [ContainerSemanticFileCollector] = []
+        for relativePath in sourceFiles {
+            let fileURL = rootURL.appendingPathComponent(relativePath)
+            let source = try String(contentsOf: fileURL, encoding: .utf8)
+            let syntax = Parser.parse(source: source)
+            let collector = ContainerSemanticFileCollector(
+                filePath: fileURL.path(percentEncoded: false),
+                syntax: syntax
+            )
+            collector.walk(syntax)
+            collectorResults.append(collector)
+        }
+
+        let nominalTypes = collectorResults.flatMap(\.nominalTypes)
+        let typeAliases = collectorResults.flatMap(\.typeAliases)
+        let containers = collectorResults.flatMap(\.containers)
+        let subContainers = collectorResults.flatMap(\.subContainers)
+        let wrapperParameters = collectorResults.flatMap(\.wrapperParameters)
+        let wrapperDeclarations = collectorResults.flatMap(\.wrapperDeclarations)
+        let wrapperAliases = collectorResults.flatMap(\.wrapperAliases)
+
+        let semanticResolver = SemanticResolverIndex(
+            nominalTypes: nominalTypes,
+            topLevelTypeAliases: typeAliases
+        )
+        let containerInputsByPath = Dictionary(uniqueKeysWithValues: containers.map { ($0.path, $0) })
+        let containerCandidatePaths = Set(containerInputsByPath.keys)
+        let wrapperDeclarationsByPath = Dictionary(uniqueKeysWithValues: wrapperDeclarations.map { ($0.path, $0) })
+        let wrapperAliasesByPath = Dictionary(uniqueKeysWithValues: wrapperAliases.map { ($0.path, $0) })
+
+        var issues: [ValidationIssue] = []
+
+        for subContainer in subContainers {
+            guard let childReference = subContainer.childReference else {
+                continue
+            }
+
+            let resolution = semanticResolver.resolvePath(
+                for: childReference,
+                candidatePaths: containerCandidatePaths
+            )
+            guard resolution.state == .resolved,
+                  let childPath = resolution.resolvedPath,
+                  let childContainer = containerInputsByPath[childPath] else {
+                continue
+            }
+
+            for binding in subContainer.bindings where !childContainer.inputMembers.contains(binding.childInputName) {
+                issues.append(
+                    ValidationIssue(
+                        code: "sub.unknown-child-input",
+                        severity: .error,
+                        message: "@SubContainer on '\(subContainer.memberName)' binds child input '\(binding.childInputName)', but '\(childContainer.displayName)' does not declare a matching .input member.",
+                        location: binding.childLocation,
+                        notes: [
+                            ValidationIssueNote(
+                                message: "child container '\(childContainer.path)' is declared here.",
+                                location: childContainer.location
+                            )
+                        ],
+                        remediation: "Rename the child keypath in bindings:, or add a matching @Provide(.input) member to '\(childContainer.displayName)'.",
+                        metadata: [
+                            "childContainerPath": childContainer.path,
+                            "parentContainerPath": subContainer.parentContainerPath
+                        ]
+                    )
+                )
+            }
+        }
+
+        for parameter in wrapperParameters {
+            if let aliasKind = resolveWrapperAliasKind(
+                for: parameter.headReference.displayPath,
+                aliasesByPath: wrapperAliasesByPath
+            ) {
+                let aliasRecord = wrapperAliasesByPath[parameter.headReference.displayPath]
+                issues.append(
+                    ValidationIssue(
+                        code: "provide.deferred-wrapper-alias-unsupported",
+                        severity: .error,
+                        message: "Factory parameter '\(parameter.parameterName)' for '\(parameter.memberName)' uses wrapper alias '\(parameter.headReference.displayPath)'. Wrapper aliases are not supported; spell `InnoDI.\(aliasKind.rawValue)<T>` directly.",
+                        location: parameter.location,
+                        notes: aliasRecord.map {
+                            [
+                                ValidationIssueNote(
+                                    message: "alias '\($0.path)' is declared here.",
+                                    location: $0.location
+                                )
+                            ]
+                        } ?? [],
+                        remediation: "Replace the alias use with `InnoDI.\(aliasKind.rawValue)<...>` in the factory parameter type annotation.",
+                        metadata: [
+                            "wrapperKind": aliasKind.rawValue,
+                            "writtenHead": parameter.headReference.displayPath
+                        ]
+                    )
+                )
+                continue
+            }
+
+            guard let writtenWrapperKind = parameter.writtenWrapperKind else {
+                continue
+            }
+
+            if canonicalWrapperKind(for: parameter.headReference) != nil {
+                continue
+            }
+
+            if let exactLocalWrapper = wrapperDeclarationsByPath[parameter.headReference.displayPath],
+               exactLocalWrapper.wrapperKind == writtenWrapperKind {
+                issues.append(
+                    ValidationIssue(
+                        code: "provide.deferred-wrapper-qualification-required",
+                        severity: .error,
+                        message: "Factory parameter '\(parameter.parameterName)' for '\(parameter.memberName)' must spell `InnoDI.\(writtenWrapperKind.rawValue)<T>` explicitly. `\(parameter.headReference.displayPath)` resolves to a same-module declaration and is ambiguous for macro expansion.",
+                        location: parameter.location,
+                        notes: [
+                            ValidationIssueNote(
+                                message: "same-module declaration '\(exactLocalWrapper.path)' is defined here.",
+                                location: exactLocalWrapper.location
+                            )
+                        ],
+                        remediation: "Replace `\(parameter.headReference.displayPath)<...>` with `InnoDI.\(writtenWrapperKind.rawValue)<...>` at the factory parameter site.",
+                        metadata: [
+                            "wrapperKind": writtenWrapperKind.rawValue,
+                            "writtenHead": parameter.headReference.displayPath
+                        ]
+                    )
+                )
+            }
+        }
+
+        issues.sort {
+            if $0.location.filePath != $1.location.filePath { return $0.location.filePath < $1.location.filePath }
+            if $0.location.line != $1.location.line { return $0.location.line < $1.location.line }
+            return $0.location.column < $1.location.column
+        }
+
+        return ValidationIssueReport(issues: issues)
+    }
+}
+
+private struct SemanticContainerRecord: Equatable {
+    let path: String
+    let displayName: String
+    let location: ValidationIssueLocation
+    let inputMembers: Set<String>
+}
+
+private struct SubContainerBindingValidationRecord: Equatable {
+    let childInputName: String
+    let parentMemberName: String
+    let childLocation: ValidationIssueLocation
+    let parentLocation: ValidationIssueLocation
+}
+
+private struct SemanticSubContainerRecord: Equatable {
+    let parentContainerPath: String
+    let memberName: String
+    let childReference: SemanticTypeReference?
+    let bindings: [SubContainerBindingValidationRecord]
+}
+
+private struct DeferredWrapperParameterRecord: Equatable {
+    let memberName: String
+    let parameterName: String
+    let writtenWrapperKind: DeferredDependencyWrapperKind?
+    let headReference: SemanticTypeReference
+    let location: ValidationIssueLocation
+}
+
+private struct WrapperDeclarationRecord: Equatable {
+    let path: String
+    let wrapperKind: DeferredDependencyWrapperKind
+    let location: ValidationIssueLocation
+}
+
+private struct WrapperAliasRecord: Equatable {
+    let path: String
+    let targetHeadReference: SemanticTypeReference
+    let location: ValidationIssueLocation
+}
+
+private final class ContainerSemanticFileCollector: SyntaxVisitor {
+    private let filePath: String
+    private let locationConverter: SourceLocationConverter
+    private var declarationStack: [String] = []
+    private var containerContextStack: [String?] = []
+    private var containerBuilders: [String: SemanticContainerBuilder] = [:]
+
+    private(set) var nominalTypes: [SemanticNominalTypeRecord] = []
+    private(set) var typeAliases: [SemanticTypeAliasRecord] = []
+    private(set) var subContainers: [SemanticSubContainerRecord] = []
+    private(set) var wrapperParameters: [DeferredWrapperParameterRecord] = []
+    private(set) var wrapperDeclarations: [WrapperDeclarationRecord] = []
+    private(set) var wrapperAliases: [WrapperAliasRecord] = []
+
+    var containers: [SemanticContainerRecord] {
+        containerBuilders.values
+            .map { builder in
+                SemanticContainerRecord(
+                    path: builder.path,
+                    displayName: builder.path.split(separator: ".").last.map(String.init) ?? builder.path,
+                    location: builder.location,
+                    inputMembers: builder.inputMembers
+                )
+            }
+            .sorted { $0.path < $1.path }
+    }
+
+    init(filePath: String, syntax: SourceFileSyntax) {
+        self.filePath = filePath
+        self.locationConverter = SourceLocationConverter(fileName: filePath, tree: syntax)
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+        visitNominal(node: Syntax(node), name: node.name.text, attributes: node.attributes)
+    }
+
+    override func visitPost(_ node: StructDeclSyntax) {
+        visitPostNominal()
+    }
+
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+        visitNominal(node: Syntax(node), name: node.name.text, attributes: node.attributes)
+    }
+
+    override func visitPost(_ node: ClassDeclSyntax) {
+        visitPostNominal()
+    }
+
+    override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
+        visitNominal(node: Syntax(node), name: node.name.text, attributes: node.attributes)
+    }
+
+    override func visitPost(_ node: ActorDeclSyntax) {
+        visitPostNominal()
+    }
+
+    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+        visitNominal(node: Syntax(node), name: node.name.text, attributes: node.attributes)
+    }
+
+    override func visitPost(_ node: EnumDeclSyntax) {
+        visitPostNominal()
+    }
+
+    override func visit(_ node: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
+        let components = declarationStack + [node.name.text]
+        let path = components.joined(separator: ".")
+        let location = sourceLocation(for: node.positionAfterSkippingLeadingTrivia)
+
+        if let targetReference = normalizedSemanticTypeReference(node.initializer.value) {
+            typeAliases.append(
+                SemanticTypeAliasRecord(
+                    path: path,
+                    components: components,
+                    target: targetReference
+                )
+            )
+        }
+
+        if let wrapperKind = directWrapperKind(named: node.name.text) {
+            wrapperDeclarations.append(
+                WrapperDeclarationRecord(
+                    path: path,
+                    wrapperKind: wrapperKind,
+                    location: location
+                )
+            )
+        }
+
+        if let targetHeadReference = genericTypeHeadReference(node.initializer.value) {
+            wrapperAliases.append(
+                WrapperAliasRecord(
+                    path: path,
+                    targetHeadReference: targetHeadReference,
+                    location: location
+                )
+            )
+        }
+
+        return .skipChildren
+    }
+
+    override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard let currentContainerPath = containerContextStack.last ?? nil,
+              isDirectMemberVariable(node),
+              let binding = validatedSingleBinding(node) else {
+            return .skipChildren
+        }
+
+        if let provideAttribute = findAttribute(named: "Provide", in: node.attributes) {
+            let provideArguments = parseProvideArguments(provideAttribute)
+            if provideArguments.scope == .input {
+                containerBuilders[currentContainerPath, default: SemanticContainerBuilder(
+                    path: currentContainerPath,
+                    location: sourceLocation(for: node.positionAfterSkippingLeadingTrivia)
+                )]
+                .inputMembers.insert(binding.name)
+            }
+
+            collectDeferredWrapperParameters(
+                from: provideArguments.factoryExpr?.as(ClosureExprSyntax.self),
+                memberName: binding.name
+            )
+            collectDeferredWrapperParameters(
+                from: provideArguments.asyncFactoryExpr?.as(ClosureExprSyntax.self),
+                memberName: binding.name
+            )
+        }
+
+        if let subContainerAttribute = findAttribute(named: "SubContainer", in: node.attributes),
+           let childType = binding.type {
+            let subArguments = parseSubContainerArguments(subContainerAttribute)
+            if !subArguments.bindings.isEmpty {
+                subContainers.append(
+                    SemanticSubContainerRecord(
+                        parentContainerPath: currentContainerPath,
+                        memberName: binding.name,
+                        childReference: normalizedSemanticTypeReference(childType),
+                        bindings: extractBindingValidationRecords(from: subContainerAttribute)
+                    )
+                )
+            }
+        }
+
+        return .skipChildren
+    }
+
+    private func visitNominal(
+        node: Syntax,
+        name: String,
+        attributes: AttributeListSyntax?
+    ) -> SyntaxVisitorContinueKind {
+        declarationStack.append(name)
+        let declarationPath = declarationStack.joined(separator: ".")
+        nominalTypes.append(
+            SemanticNominalTypeRecord(
+                path: declarationPath,
+                components: declarationStack
+            )
+        )
+
+        let location = sourceLocation(for: node.positionAfterSkippingLeadingTrivia)
+        if let wrapperKind = directWrapperKind(named: name) {
+            wrapperDeclarations.append(
+                WrapperDeclarationRecord(
+                    path: declarationPath,
+                    wrapperKind: wrapperKind,
+                    location: location
+                )
+            )
+        }
+
+        if containsDIContainerAttribute(attributes) {
+            containerBuilders[declarationPath] = SemanticContainerBuilder(
+                path: declarationPath,
+                location: location
+            )
+            containerContextStack.append(declarationPath)
+        } else {
+            containerContextStack.append(nil)
+        }
+
+        return .visitChildren
+    }
+
+    private func visitPostNominal() {
+        if !declarationStack.isEmpty {
+            declarationStack.removeLast()
+        }
+        if !containerContextStack.isEmpty {
+            containerContextStack.removeLast()
+        }
+    }
+
+    private func sourceLocation(for position: AbsolutePosition) -> ValidationIssueLocation {
+        let location = locationConverter.location(for: position)
+        return ValidationIssueLocation(
+            filePath: filePath,
+            line: location.line,
+            column: location.column
+        )
+    }
+
+    private func collectDeferredWrapperParameters(
+        from closure: ClosureExprSyntax?,
+        memberName: String
+    ) {
+        guard let closure,
+              let signature = closure.signature,
+              let parameterClause = signature.parameterClause,
+              case .parameterClause(let parameters) = parameterClause else {
+            return
+        }
+
+        for parameter in parameters.parameters {
+            let token = parameter.secondName ?? parameter.firstName
+            let parameterName = token.text
+            if parameterName == "_" {
+                continue
+            }
+
+            guard let parameterType = parameter.type,
+                  let headReference = genericTypeHeadReference(parameterType) else {
+                continue
+            }
+
+            wrapperParameters.append(
+                DeferredWrapperParameterRecord(
+                    memberName: memberName,
+                    parameterName: parameterName,
+                    writtenWrapperKind: deferredDependencyWrapperKind(for: parameterType),
+                    headReference: headReference,
+                    location: sourceLocation(for: token.positionAfterSkippingLeadingTrivia)
+                )
+            )
+        }
+    }
+
+    private func extractBindingValidationRecords(from attribute: AttributeSyntax) -> [SubContainerBindingValidationRecord] {
+        guard let arguments = attribute.arguments?.as(LabeledExprListSyntax.self) else {
+            return []
+        }
+
+        for argument in arguments where argument.label?.text == "bindings" {
+            guard let arrayExpr = argument.expression.as(ArrayExprSyntax.self) else {
+                return []
+            }
+
+            return arrayExpr.elements.compactMap { element in
+                guard let tupleExpr = element.expression.as(TupleExprSyntax.self) else {
+                    return nil
+                }
+
+                var childName: String?
+                var parentName: String?
+                var childLocation: ValidationIssueLocation?
+                var parentLocation: ValidationIssueLocation?
+
+                for tupleElement in tupleExpr.elements {
+                    guard let label = tupleElement.label?.text,
+                          let keyPath = tupleElement.expression.as(KeyPathExprSyntax.self),
+                          let property = keyPath.components.last?
+                            .component.as(KeyPathPropertyComponentSyntax.self)?
+                            .declName.baseName.text else {
+                        continue
+                    }
+
+                    switch label {
+                    case "child":
+                        childName = property
+                        childLocation = sourceLocation(for: keyPath.positionAfterSkippingLeadingTrivia)
+                    case "parent":
+                        parentName = property
+                        parentLocation = sourceLocation(for: keyPath.positionAfterSkippingLeadingTrivia)
+                    default:
+                        continue
+                    }
+                }
+
+                guard let childName, let parentName, let childLocation, let parentLocation else {
+                    return nil
+                }
+
+                return SubContainerBindingValidationRecord(
+                    childInputName: childName,
+                    parentMemberName: parentName,
+                    childLocation: childLocation,
+                    parentLocation: parentLocation
+                )
+            }
+        }
+
+        return []
+    }
+}
+
+private struct SemanticContainerBuilder {
+    let path: String
+    let location: ValidationIssueLocation
+    var inputMembers: Set<String> = []
+}
+
+private struct ValidatedVariableBinding {
+    let name: String
+    let type: TypeSyntax?
+}
+
+private func validatedSingleBinding(_ varDecl: VariableDeclSyntax) -> ValidatedVariableBinding? {
+    guard varDecl.bindings.count == 1,
+          let binding = varDecl.bindings.first,
+          let identifier = binding.pattern.as(IdentifierPatternSyntax.self) else {
+        return nil
+    }
+
+    return ValidatedVariableBinding(
+        name: identifier.identifier.text,
+        type: binding.typeAnnotation?.type
+    )
+}
+
+private func isDirectMemberVariable(_ node: VariableDeclSyntax) -> Bool {
+    node.parent?.is(MemberBlockItemSyntax.self) == true
+}
+
+private func containsDIContainerAttribute(_ attributes: AttributeListSyntax?) -> Bool {
+    guard let attributes else {
+        return false
+    }
+
+    for attribute in attributes {
+        guard let syntax = attribute.as(AttributeSyntax.self) else {
+            continue
+        }
+        if let identifier = syntax.attributeName.as(IdentifierTypeSyntax.self), identifier.name.text == "DIContainer" {
+            return true
+        }
+    }
+
+    return false
+}
+
+private func directWrapperKind(named name: String) -> DeferredDependencyWrapperKind? {
+    DeferredDependencyWrapperKind(rawValue: name)
+}
+
+private func canonicalWrapperKind(for reference: SemanticTypeReference) -> DeferredDependencyWrapperKind? {
+    guard reference.components.count == 2, reference.components.first == "InnoDI",
+          let last = reference.components.last else {
+        return nil
+    }
+    return DeferredDependencyWrapperKind(rawValue: last)
+}
+
+private func wrapperKindCandidate(for reference: SemanticTypeReference) -> DeferredDependencyWrapperKind? {
+    if let canonical = canonicalWrapperKind(for: reference) {
+        return canonical
+    }
+    guard let last = reference.components.last else {
+        return nil
+    }
+    return DeferredDependencyWrapperKind(rawValue: last)
+}
+
+private func resolveWrapperAliasKind(
+    for path: String,
+    aliasesByPath: [String: WrapperAliasRecord],
+    visited: Set<String> = []
+) -> DeferredDependencyWrapperKind? {
+    guard !visited.contains(path),
+          let aliasRecord = aliasesByPath[path] else {
+        return nil
+    }
+
+    if let canonicalKind = canonicalWrapperKind(for: aliasRecord.targetHeadReference) {
+        return canonicalKind
+    }
+
+    var nextVisited = visited
+    nextVisited.insert(path)
+    return resolveWrapperAliasKind(
+        for: aliasRecord.targetHeadReference.displayPath,
+        aliasesByPath: aliasesByPath,
+        visited: nextVisited
+    )
+}
+
+private func genericTypeHeadReference(_ type: TypeSyntax) -> SemanticTypeReference? {
+    if let attributed = type.as(AttributedTypeSyntax.self) {
+        return genericTypeHeadReference(attributed.baseType)
+    }
+
+    if let tuple = type.as(TupleTypeSyntax.self),
+       tuple.elements.count == 1,
+       let first = tuple.elements.first,
+       first.firstName == nil,
+       first.secondName == nil {
+        return genericTypeHeadReference(first.type)
+    }
+
+    if let identifier = type.as(IdentifierTypeSyntax.self) {
+        guard identifier.genericArgumentClause?.arguments.count == 1 else {
+            return nil
+        }
+        return SemanticTypeReference(
+            displayPath: identifier.name.text,
+            components: [identifier.name.text]
+        )
+    }
+
+    if let member = type.as(MemberTypeSyntax.self),
+       member.genericArgumentClause?.arguments.count == 1,
+       let base = normalizedSemanticTypeReference(member.baseType) {
+        let components = base.components + [member.name.text]
+        return SemanticTypeReference(
+            displayPath: components.joined(separator: "."),
+            components: components
+        )
+    }
+
+    return nil
+}

--- a/Sources/InnoDIBuildSupport/ValidationCoordinator.swift
+++ b/Sources/InnoDIBuildSupport/ValidationCoordinator.swift
@@ -36,6 +36,12 @@ package struct SharedValidationRunRecord: Codable, Equatable, Sendable {
     package let issues: [ValidationIssue]
 }
 
+package let sharedRunCacheVersion = 1
+
+package func sharedRunCacheKey(for signature: String) -> String {
+    "shared-run-v\(sharedRunCacheVersion)-\(signature)"
+}
+
 package struct LiveValidationCommandRunner: ValidationCommandRunning {
     package init() {}
 
@@ -114,10 +120,11 @@ package enum ValidationCoordinator {
             stateDirectoryPath: stateDirectoryPath
         )
         let signature = signatureCollection.signature
+        let sharedRunKey = sharedRunCacheKey(for: signature)
         let signatureCollectionMilliseconds = validationElapsedMilliseconds(since: signatureCollectionStartTime)
-        let sharedRunDirectory = stateDirectoryURL.appendingPathComponent(signature, isDirectory: true)
+        let sharedRunDirectory = stateDirectoryURL.appendingPathComponent(sharedRunKey, isDirectory: true)
         try fileManager.createDirectory(at: sharedRunDirectory, withIntermediateDirectories: true)
-        try pruneSharedRunDirectories(keepingSignature: signature, in: stateDirectoryURL)
+        try pruneSharedRunDirectories(keepingDirectoryName: sharedRunKey, in: stateDirectoryURL)
 
         let resultURL = sharedRunDirectory.appendingPathComponent("result.json")
         let sharedRunRecordURL = sharedRunDirectory.appendingPathComponent("validation-metrics.json")
@@ -169,8 +176,10 @@ package enum ValidationCoordinator {
             )
         }
 
-        if let cachedResult = try loadCachedResult(at: resultURL) {
-            let sharedRunRecord = try loadSharedRunRecord(at: sharedRunRecordURL)
+        if let (cachedResult, sharedRunRecord) = loadCachedSharedRun(
+            resultURL: resultURL,
+            sharedRunRecordURL: sharedRunRecordURL
+        ) {
             return try finalizeOutcome(result: cachedResult, wasCached: true, sharedRunRecord: sharedRunRecord)
         }
 
@@ -178,8 +187,10 @@ package enum ValidationCoordinator {
             if let lockDescriptor = try acquireLock(at: lockURL) {
                 defer { releaseLock(descriptor: lockDescriptor, at: lockURL) }
 
-                if let cachedResult = try loadCachedResult(at: resultURL) {
-                    let sharedRunRecord = try loadSharedRunRecord(at: sharedRunRecordURL)
+                if let (cachedResult, sharedRunRecord) = loadCachedSharedRun(
+                    resultURL: resultURL,
+                    sharedRunRecordURL: sharedRunRecordURL
+                ) {
                     return try finalizeOutcome(result: cachedResult, wasCached: true, sharedRunRecord: sharedRunRecord)
                 }
 
@@ -253,21 +264,44 @@ package enum ValidationCoordinator {
                 return try finalizeOutcome(result: result, wasCached: false, sharedRunRecord: sharedRunRecord)
             }
 
-            if let cachedResult = try waitForCachedResult(resultURL: resultURL, lockURL: lockURL) {
-                let sharedRunRecord = try loadSharedRunRecord(at: sharedRunRecordURL)
+            if let (cachedResult, sharedRunRecord) = waitForCachedSharedRun(
+                resultURL: resultURL,
+                sharedRunRecordURL: sharedRunRecordURL,
+                lockURL: lockURL
+            ) {
                 return try finalizeOutcome(result: cachedResult, wasCached: true, sharedRunRecord: sharedRunRecord)
             }
         }
     }
 }
 
-private func loadCachedResult(at url: URL) throws -> ValidationCommandResult? {
+private func loadCachedSharedRun(
+    resultURL: URL,
+    sharedRunRecordURL: URL
+) -> (result: ValidationCommandResult, record: SharedValidationRunRecord)? {
+    guard
+        let result = loadCachedResult(at: resultURL),
+        let record = loadSharedRunRecord(at: sharedRunRecordURL)
+    else {
+        return nil
+    }
+
+    return (result, record)
+}
+
+private func loadCachedResult(at url: URL) -> ValidationCommandResult? {
     guard FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) else {
         return nil
     }
 
-    let data = try Data(contentsOf: url)
-    return try JSONDecoder().decode(ValidationCommandResult.self, from: data)
+    guard
+        let data = try? Data(contentsOf: url),
+        let result = try? JSONDecoder().decode(ValidationCommandResult.self, from: data)
+    else {
+        return nil
+    }
+
+    return result
 }
 
 private func persistResult(_ result: ValidationCommandResult, to url: URL) throws {
@@ -286,21 +320,19 @@ private func persistMetricsArtifact(_ artifact: ValidationMetricsArtifact, to ur
     try data.write(to: url, options: .atomic)
 }
 
-private func loadSharedRunRecord(at url: URL) throws -> SharedValidationRunRecord {
+private func loadSharedRunRecord(at url: URL) -> SharedValidationRunRecord? {
     guard FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) else {
-        return SharedValidationRunRecord(
-            liveRunMetrics: ValidationLiveRunMetrics(
-                customInitValidationMilliseconds: 0,
-                semanticValidationMilliseconds: 0,
-                dagValidationMilliseconds: 0
-            ),
-            reasonCodes: [],
-            issues: []
-        )
+        return nil
     }
 
-    let data = try Data(contentsOf: url)
-    return try JSONDecoder().decode(SharedValidationRunRecord.self, from: data)
+    guard
+        let data = try? Data(contentsOf: url),
+        let record = try? JSONDecoder().decode(SharedValidationRunRecord.self, from: data)
+    else {
+        return nil
+    }
+
+    return record
 }
 
 private func persistSharedRunRecord(_ record: SharedValidationRunRecord, to url: URL) throws {
@@ -332,7 +364,7 @@ private func releaseLock(descriptor: Int32, at url: URL) {
     try? FileManager.default.removeItem(at: url)
 }
 
-private func pruneSharedRunDirectories(keepingSignature signature: String, in stateDirectoryURL: URL) throws {
+private func pruneSharedRunDirectories(keepingDirectoryName directoryName: String, in stateDirectoryURL: URL) throws {
     let fileManager = FileManager.default
     let entries = try fileManager.contentsOfDirectory(
         at: stateDirectoryURL,
@@ -342,19 +374,26 @@ private func pruneSharedRunDirectories(keepingSignature signature: String, in st
 
     for entry in entries {
         let values = try entry.resourceValues(forKeys: [.isDirectoryKey])
-        guard values.isDirectory == true, entry.lastPathComponent != signature else {
+        guard values.isDirectory == true, entry.lastPathComponent != directoryName else {
             continue
         }
         try? fileManager.removeItem(at: entry)
     }
 }
 
-private func waitForCachedResult(resultURL: URL, lockURL: URL) throws -> ValidationCommandResult? {
+private func waitForCachedSharedRun(
+    resultURL: URL,
+    sharedRunRecordURL: URL,
+    lockURL: URL
+) -> (result: ValidationCommandResult, record: SharedValidationRunRecord)? {
     let timeoutDate = Date().addingTimeInterval(30)
 
     while Date() < timeoutDate {
-        if let cachedResult = try loadCachedResult(at: resultURL) {
-            return cachedResult
+        if let cachedSharedRun = loadCachedSharedRun(
+            resultURL: resultURL,
+            sharedRunRecordURL: sharedRunRecordURL
+        ) {
+            return cachedSharedRun
         }
 
         if !FileManager.default.fileExists(atPath: lockURL.path(percentEncoded: false)) {

--- a/Sources/InnoDIBuildSupport/ValidationCoordinator.swift
+++ b/Sources/InnoDIBuildSupport/ValidationCoordinator.swift
@@ -189,25 +189,40 @@ package enum ValidationCoordinator {
                 let customInitFailure = customInitValidation.asCommandResult()
                 let customInitValidationMilliseconds = validationElapsedMilliseconds(since: customInitStartTime)
 
+                let semanticValidationMilliseconds: Double
                 let dagValidationMilliseconds: Double
                 let liveRunReasonCodes: [ValidationReasonCode]
                 let issues: [ValidationIssue]
                 if let customInitFailure {
                     result = customInitFailure
+                    semanticValidationMilliseconds = 0
                     dagValidationMilliseconds = 0
                     liveRunReasonCodes = [.liveRunCustomInitFailure]
                     issues = customInitValidation.issues
                 } else {
-                    let dagValidationStartTime = validationNow()
-                    result = try runner.runValidationTool(toolPath: toolPath, rootPath: rootPath)
-                    dagValidationMilliseconds = validationElapsedMilliseconds(since: dagValidationStartTime)
-                    liveRunReasonCodes = [.liveRunDAGValidation]
-                    issues = []
+                    let semanticValidationStartTime = validationNow()
+                    let semanticValidation = try ContainerSemanticBuildValidator.validate(rootPath: rootPath)
+                    let semanticFailure = semanticValidation.asCommandResult()
+                    semanticValidationMilliseconds = validationElapsedMilliseconds(since: semanticValidationStartTime)
+
+                    if let semanticFailure {
+                        result = semanticFailure
+                        dagValidationMilliseconds = 0
+                        liveRunReasonCodes = [.liveRunSemanticFailure]
+                        issues = semanticValidation.issues
+                    } else {
+                        let dagValidationStartTime = validationNow()
+                        result = try runner.runValidationTool(toolPath: toolPath, rootPath: rootPath)
+                        dagValidationMilliseconds = validationElapsedMilliseconds(since: dagValidationStartTime)
+                        liveRunReasonCodes = [.liveRunSemanticValidation, .liveRunDAGValidation]
+                        issues = semanticValidation.issues
+                    }
                 }
 
                 let sharedRunRecord = SharedValidationRunRecord(
                     liveRunMetrics: ValidationLiveRunMetrics(
                         customInitValidationMilliseconds: customInitValidationMilliseconds,
+                        semanticValidationMilliseconds: semanticValidationMilliseconds,
                         dagValidationMilliseconds: dagValidationMilliseconds
                     ),
                     reasonCodes: liveRunReasonCodes,
@@ -276,6 +291,7 @@ private func loadSharedRunRecord(at url: URL) throws -> SharedValidationRunRecor
         return SharedValidationRunRecord(
             liveRunMetrics: ValidationLiveRunMetrics(
                 customInitValidationMilliseconds: 0,
+                semanticValidationMilliseconds: 0,
                 dagValidationMilliseconds: 0
             ),
             reasonCodes: [],

--- a/Sources/InnoDIBuildSupport/ValidationMetrics.swift
+++ b/Sources/InnoDIBuildSupport/ValidationMetrics.swift
@@ -8,6 +8,8 @@ package enum ValidationReasonCode: String, Codable, Equatable, Sendable {
     case cacheMissDeletedFile = "cache-miss-deleted-file"
     case cacheMissManifestVersion = "cache-miss-manifest-version"
     case liveRunCustomInitFailure = "live-run-custom-init-failure"
+    case liveRunSemanticValidation = "live-run-semantic-validation"
+    case liveRunSemanticFailure = "live-run-semantic-failure"
     case liveRunDAGValidation = "live-run-dag-validation"
 }
 
@@ -62,11 +64,12 @@ package struct ValidationInvocationMetrics: Codable, Equatable, Sendable {
 
 package struct ValidationLiveRunMetrics: Codable, Equatable, Sendable {
     package let customInitValidationMilliseconds: Double
+    package let semanticValidationMilliseconds: Double
     package let dagValidationMilliseconds: Double
 }
 
 package struct ValidationMetricsArtifact: Codable, Equatable, Sendable {
-    package static let currentVersion = 2
+    package static let currentVersion = 3
 
     package let version: Int
     package let signature: String
@@ -126,6 +129,7 @@ package enum ValidationLogging {
             "new-files=\(artifact.fileChanges.newFiles.count)",
             "deleted-files=\(artifact.fileChanges.deletedFiles.count)",
             "custom-init-ms=\(formatMilliseconds(artifact.liveRunMetrics.customInitValidationMilliseconds))",
+            "semantic-ms=\(formatMilliseconds(artifact.liveRunMetrics.semanticValidationMilliseconds))",
             "dag-ms=\(formatMilliseconds(artifact.liveRunMetrics.dagValidationMilliseconds))",
             "signature-ms=\(formatMilliseconds(artifact.invocationMetrics.signatureCollectionMilliseconds))",
             "total-ms=\(formatMilliseconds(artifact.invocationMetrics.totalCoordinatorMilliseconds))",
@@ -183,6 +187,7 @@ package enum ValidationLogging {
         lines.append("")
         lines.append("- Signature collection: `\(formatMilliseconds(artifact.invocationMetrics.signatureCollectionMilliseconds)) ms`")
         lines.append("- Custom init validation: `\(formatMilliseconds(artifact.liveRunMetrics.customInitValidationMilliseconds)) ms`")
+        lines.append("- Semantic validation: `\(formatMilliseconds(artifact.liveRunMetrics.semanticValidationMilliseconds)) ms`")
         lines.append("- DAG validation: `\(formatMilliseconds(artifact.liveRunMetrics.dagValidationMilliseconds)) ms`")
         lines.append("- Total coordinator: `\(formatMilliseconds(artifact.invocationMetrics.totalCoordinatorMilliseconds)) ms`")
         lines.append("")
@@ -234,6 +239,10 @@ private func reasonDescription(_ reason: ValidationReasonCode) -> String {
         return "The AST digest manifest version changed, so the cache was rebuilt from scratch."
     case .liveRunCustomInitFailure:
         return "The live validation run stopped after a structured cross-file custom init failure."
+    case .liveRunSemanticValidation:
+        return "The live validation run completed the semantic validator before DAG validation."
+    case .liveRunSemanticFailure:
+        return "The live validation run stopped after a structured semantic validation failure."
     case .liveRunDAGValidation:
         return "The live validation run executed the DAG validator."
     }

--- a/Sources/InnoDICore/Parsing.swift
+++ b/Sources/InnoDICore/Parsing.swift
@@ -95,6 +95,9 @@ public struct SubContainerAttributeInfo {
     /// Used to re-map parent members when child `.input` parameter names do
     /// not match the parent side by name.
     public let dependencies: [String]
+    /// Explicit child-input -> parent-member bindings passed via `bindings:`.
+    /// Used when the child `.input` label differs from the parent member name.
+    public let bindings: [SubContainerBindingArgument]
 
     /// Creates a parsed `@SubContainer` argument model.
     ///
@@ -106,11 +109,27 @@ public struct SubContainerAttributeInfo {
     public init(
         scope: SubContainerScopeValue?,
         scopeName: String?,
-        dependencies: [String]
+        dependencies: [String],
+        bindings: [SubContainerBindingArgument]
     ) {
         self.scope = scope
         self.scopeName = scopeName
         self.dependencies = dependencies
+        self.bindings = bindings
+    }
+}
+
+/// Parsed explicit child-input -> parent-member remapping from a
+/// `@SubContainer(bindings:)` tuple.
+public struct SubContainerBindingArgument: Equatable, Sendable {
+    /// Child `.input` member name taken from the tuple's `child:` keypath.
+    public let childName: String
+    /// Parent member name taken from the tuple's `parent:` keypath.
+    public let parentName: String
+
+    public init(childName: String, parentName: String) {
+        self.childName = childName
+        self.parentName = parentName
     }
 }
 
@@ -237,15 +256,50 @@ public func parseKeyPathArrayArgument(_ expression: ExprSyntax) -> [String] {
     guard let arrayExpr = expression.as(ArrayExprSyntax.self) else { return [] }
     var names: [String] = []
     for element in arrayExpr.elements {
-        guard let keyPath = element.expression.as(KeyPathExprSyntax.self),
-              let property = keyPath.components.last?
-                .component.as(KeyPathPropertyComponentSyntax.self)?
-                .declName.baseName.text else {
+        guard let property = finalKeyPathComponentName(from: element.expression) else {
             continue
         }
         names.append(property)
     }
     return names
+}
+
+/// Parses `bindings: [(child: \.foo, parent: \.bar)]` into semantic names.
+public func parseSubContainerBindingsArgument(_ expression: ExprSyntax) -> [SubContainerBindingArgument] {
+    guard let arrayExpr = expression.as(ArrayExprSyntax.self) else { return [] }
+    var bindings: [SubContainerBindingArgument] = []
+
+    for element in arrayExpr.elements {
+        guard let tupleExpr = element.expression.as(TupleExprSyntax.self) else {
+            continue
+        }
+
+        var childName: String?
+        var parentName: String?
+
+        for tupleElement in tupleExpr.elements {
+            guard let label = tupleElement.label?.text else { continue }
+            switch label {
+            case "child":
+                childName = finalKeyPathComponentName(from: tupleElement.expression)
+            case "parent":
+                parentName = finalKeyPathComponentName(from: tupleElement.expression)
+            default:
+                continue
+            }
+        }
+
+        if let childName, let parentName {
+            bindings.append(
+                SubContainerBindingArgument(
+                    childName: childName,
+                    parentName: parentName
+                )
+            )
+        }
+    }
+
+    return bindings
 }
 
 /// Parses the full argument list of a single `@SubContainer` attribute.
@@ -256,6 +310,7 @@ public func parseSubContainerArguments(_ attribute: AttributeSyntax) -> SubConta
     var scope: SubContainerScopeValue?
     var scopeName: String?
     var dependencies: [String] = []
+    var bindings: [SubContainerBindingArgument] = []
 
     if let arguments = attribute.arguments?.as(LabeledExprListSyntax.self) {
         for argument in arguments {
@@ -269,6 +324,8 @@ public func parseSubContainerArguments(_ attribute: AttributeSyntax) -> SubConta
                 }
             case "with":
                 dependencies = parseKeyPathArrayArgument(argument.expression)
+            case "bindings":
+                bindings = parseSubContainerBindingsArgument(argument.expression)
             default:
                 continue
             }
@@ -278,7 +335,8 @@ public func parseSubContainerArguments(_ attribute: AttributeSyntax) -> SubConta
     return SubContainerAttributeInfo(
         scope: scope,
         scopeName: scopeName,
-        dependencies: dependencies
+        dependencies: dependencies,
+        bindings: bindings
     )
 }
 
@@ -310,6 +368,15 @@ public func parseBoolLiteral(_ expr: ExprSyntax) -> Bool? {
         if reference.baseName.text == "false" { return false }
     }
     return nil
+}
+
+private func finalKeyPathComponentName(from expression: ExprSyntax) -> String? {
+    guard let keyPath = expression.as(KeyPathExprSyntax.self) else {
+        return nil
+    }
+    return keyPath.components.last?
+        .component.as(KeyPathPropertyComponentSyntax.self)?
+        .declName.baseName.text
 }
 
 public func parseDIContainerAttribute(_ attributes: AttributeListSyntax?) -> DIContainerAttributeInfo? {

--- a/Sources/InnoDIMacros/DIContainerCodeGenerator.swift
+++ b/Sources/InnoDIMacros/DIContainerCodeGenerator.swift
@@ -331,23 +331,35 @@ private func makeInitDecl(
             CodeBlockItemSyntax(item: .decl(letBinding(name: "_lazySelfForSub", value: "self")))
         )
         for member in subContainerMembers where member.scope == .transient {
-            let selectedNames = member.parentDependencies.isEmpty
-                ? autoWireParentMemberNames
-                : member.parentDependencies
             let childTypeDesc = member.type.trimmedDescription
-            let baseArgs = selectedNames
-                .map { "\($0): _lazySelfForSub.\($0)" }
-                .joined(separator: ", ")
-            let withApplyArgs = baseArgs.isEmpty ? "apply" : "\(baseArgs), apply"
+            let selectedArguments = resolvedSubContainerArguments(
+                member: member,
+                autoWireParentMemberNames: autoWireParentMemberNames
+            )
+            let baseInitializer = subContainerInitializerExpr(
+                childType: member.type,
+                argumentMappings: selectedArguments,
+                parentMemberBaseName: "_lazySelfForSub",
+                parentMemberPrefix: ""
+            )
+            let overrideInitializer = subContainerInitializerExpr(
+                childType: member.type,
+                argumentMappings: selectedArguments,
+                trailingOverrideExpression: ExprSyntax(
+                    DeclReferenceExprSyntax(baseName: .identifier("apply"))
+                ),
+                parentMemberBaseName: "_lazySelfForSub",
+                parentMemberPrefix: ""
+            )
             let assignStmt: CodeBlockItemSyntax = """
                 self._innoDISubBuild_\(raw: member.name) = { () -> \(raw: childTypeDesc) in
                     if let direct = _lazySelfForSub._override_sub_\(raw: member.name) {
                         return direct
                     }
                     if let apply = _lazySelfForSub._override_sub_apply_\(raw: member.name) {
-                        return \(raw: childTypeDesc)(\(raw: withApplyArgs))
+                        return \(overrideInitializer)
                     }
-                    return \(raw: childTypeDesc)(\(raw: baseArgs))
+                    return \(baseInitializer)
                 }
                 """
             statements.append(assignStmt)
@@ -1134,7 +1146,9 @@ private func subContainerSharedAssignmentExpr(
 private func subContainerInitializerExpr(
     childType: TypeSyntax,
     argumentMappings: [(childLabel: String, parentName: String)],
-    trailingOverrideExpression: ExprSyntax? = nil
+    trailingOverrideExpression: ExprSyntax? = nil,
+    parentMemberBaseName: String = "self",
+    parentMemberPrefix: String = "_storage_"
 ) -> ExprSyntax {
     let totalArgumentCount = argumentMappings.count + (trailingOverrideExpression == nil ? 0 : 1)
     var arguments: [LabeledExprSyntax] = argumentMappings.enumerated().map { index, mapping in
@@ -1143,7 +1157,10 @@ private func subContainerInitializerExpr(
         return LabeledExprSyntax(
             label: .identifier(mapping.childLabel),
             colon: .colonToken(),
-            expression: makeSelfMemberAccessExpr(name: "_storage_\(mapping.parentName)"),
+            expression: makeSelfMemberAccessExpr(
+                name: "\(parentMemberPrefix)\(mapping.parentName)",
+                baseName: parentMemberBaseName
+            ),
             trailingComma: isLast || totalArgumentCount == 0 ? nil : .commaToken()
         )
     }

--- a/Sources/InnoDIMacros/DIContainerCodeGenerator.swift
+++ b/Sources/InnoDIMacros/DIContainerCodeGenerator.swift
@@ -18,9 +18,10 @@ struct DIContainerCodeGenerator {
     /// Generates the full member set: primary init + (if applicable) `Overrides`
     /// struct + convenience init + 4 `withOverrides` effect overloads.
     ///
-    /// When the container has no `.shared`/`.transient` / `@SubContainer`
-    /// members, the overrides scaffolding is skipped silently — an empty
-    /// `Overrides` builder would only add autocomplete noise.
+    /// All `@DIContainer` types synthesize the overrides scaffolding unless a
+    /// user-defined nested `Overrides` type suppresses generation. Input-only
+    /// containers now receive an empty builder so parents can always forward
+    /// `@SubContainer` override closures into child containers.
     static func generateAll(for model: DIContainerExpansionModel) -> [DeclSyntax] {
         var decls: [DeclSyntax] = [generateInit(for: model)]
 
@@ -31,11 +32,7 @@ struct DIContainerCodeGenerator {
         // generated inline by `makeSubContainerInitStatements` — no extra
         // member-level decls are needed here.
 
-        guard let overridesStruct = makeOverridesStructDecl(model: model) else {
-            return decls
-        }
-
-        decls.append(overridesStruct)
+        decls.append(makeOverridesStructDecl(model: model))
         decls.append(makeConvenienceInitDecl(model: model))
         decls.append(contentsOf: makeWithOverridesMethods(model: model))
         return decls
@@ -634,10 +631,9 @@ private func overrideCandidateMembers(_ model: DIContainerExpansionModel) -> [Pr
     model.sharedMembers + model.transientMembers
 }
 
-private func makeOverridesStructDecl(model: DIContainerExpansionModel) -> DeclSyntax? {
+private func makeOverridesStructDecl(model: DIContainerExpansionModel) -> DeclSyntax {
     let candidates = overrideCandidateMembers(model)
     let subs = model.subContainerMembers
-    guard !candidates.isEmpty || !subs.isEmpty else { return nil }
 
     let modifiers = accessModifiers(model.accessLevel)
     var memberDecls: [MemberBlockItemSyntax] = candidates.map { member in
@@ -858,9 +854,6 @@ private func makeConvenienceInitDecl(model: DIContainerExpansionModel) -> DeclSy
 }
 
 private func makeWithOverridesMethods(model: DIContainerExpansionModel) -> [DeclSyntax] {
-    let candidates = overrideCandidateMembers(model)
-    guard !candidates.isEmpty || !model.subContainerMembers.isEmpty else { return [] }
-
     return [
         makeWithOverridesMethod(model: model, isAsync: false, isThrowing: false),
         makeWithOverridesMethod(model: model, isAsync: false, isThrowing: true),
@@ -1043,9 +1036,10 @@ private func makeSubContainerInitStatements(
     member: SubContainerMemberModel,
     autoWireParentMemberNames: [String]
 ) -> [CodeBlockItemSyntax] {
-    let selectedNames = member.parentDependencies.isEmpty
-        ? autoWireParentMemberNames
-        : member.parentDependencies
+    let selectedArguments = resolvedSubContainerArguments(
+        member: member,
+        autoWireParentMemberNames: autoWireParentMemberNames
+    )
 
     var stmts: [CodeBlockItemSyntax] = []
 
@@ -1053,7 +1047,7 @@ private func makeSubContainerInitStatements(
     case .shared:
         let ifChain = subContainerSharedAssignmentExpr(
             member: member,
-            selectedNames: selectedNames
+            selectedArguments: selectedArguments
         )
         stmts.append(CodeBlockItemSyntax(item: .stmt(StmtSyntax(ExpressionStmtSyntax(expression: ExprSyntax(ifChain))))))
 
@@ -1088,7 +1082,7 @@ private func makeSubContainerInitStatements(
 /// string-reparse fallback during macro expansion.
 private func subContainerSharedAssignmentExpr(
     member: SubContainerMemberModel,
-    selectedNames: [String]
+    selectedArguments: [(childLabel: String, parentName: String)]
 ) -> IfExprSyntax {
     let storageName = "_storage_sub_\(member.name)"
     let overrideParam = member.name
@@ -1103,7 +1097,7 @@ private func subContainerSharedAssignmentExpr(
         targetName: storageName,
         value: subContainerInitializerExpr(
             childType: member.type,
-            parentNames: selectedNames,
+            argumentMappings: selectedArguments,
             trailingOverrideExpression: ExprSyntax(
                 DeclReferenceExprSyntax(baseName: .identifier("apply"))
             )
@@ -1113,7 +1107,7 @@ private func subContainerSharedAssignmentExpr(
         targetName: storageName,
         value: subContainerInitializerExpr(
             childType: member.type,
-            parentNames: selectedNames
+            argumentMappings: selectedArguments
         )
     )
     let elseIfExpr = makeSubContainerOptionalBindingIfExpr(
@@ -1139,17 +1133,17 @@ private func subContainerSharedAssignmentExpr(
 
 private func subContainerInitializerExpr(
     childType: TypeSyntax,
-    parentNames: [String],
+    argumentMappings: [(childLabel: String, parentName: String)],
     trailingOverrideExpression: ExprSyntax? = nil
 ) -> ExprSyntax {
-    let totalArgumentCount = parentNames.count + (trailingOverrideExpression == nil ? 0 : 1)
-    var arguments: [LabeledExprSyntax] = parentNames.enumerated().map { index, parentName in
+    let totalArgumentCount = argumentMappings.count + (trailingOverrideExpression == nil ? 0 : 1)
+    var arguments: [LabeledExprSyntax] = argumentMappings.enumerated().map { index, mapping in
         let hasTrailingOverride = trailingOverrideExpression != nil
-        let isLast = index == parentNames.count - 1 && !hasTrailingOverride
+        let isLast = index == argumentMappings.count - 1 && !hasTrailingOverride
         return LabeledExprSyntax(
-            label: .identifier(parentName),
+            label: .identifier(mapping.childLabel),
             colon: .colonToken(),
-            expression: makeSelfMemberAccessExpr(name: "_storage_\(parentName)"),
+            expression: makeSelfMemberAccessExpr(name: "_storage_\(mapping.parentName)"),
             trailingComma: isLast || totalArgumentCount == 0 ? nil : .commaToken()
         )
     }
@@ -1172,6 +1166,24 @@ private func subContainerInitializerExpr(
         rightParen: .rightParenToken()
     )
     return ExprSyntax(call)
+}
+
+private func resolvedSubContainerArguments(
+    member: SubContainerMemberModel,
+    autoWireParentMemberNames: [String]
+) -> [(childLabel: String, parentName: String)] {
+    if !member.explicitBindings.isEmpty {
+        return member.explicitBindings.map { binding in
+            (childLabel: binding.childInputName, parentName: binding.parentMemberName)
+        }
+    }
+
+    let selectedNames = member.parentDependencies.isEmpty
+        ? autoWireParentMemberNames
+        : member.parentDependencies
+    return selectedNames.map { name in
+        (childLabel: name, parentName: name)
+    }
 }
 
 private func makeSubContainerOptionalBindingIfExpr(

--- a/Sources/InnoDIMacros/DIContainerMacro.swift
+++ b/Sources/InnoDIMacros/DIContainerMacro.swift
@@ -61,10 +61,7 @@ public struct DIContainerMacro: MemberMacro {
             return []
         }
 
-        let hasOverrideCandidates = !(model.sharedMembers.isEmpty
-            && model.transientMembers.isEmpty
-            && model.subContainerMembers.isEmpty)
-        if hasOverrideCandidates, let conflict = DIContainerParser.findOverridesNameConflict(in: decl) {
+        if let conflict = DIContainerParser.findOverridesNameConflict(in: decl) {
             context.diagnose(
                 Diagnostic(
                     node: Syntax(conflict.node),

--- a/Sources/InnoDIMacros/DIContainerModel.swift
+++ b/Sources/InnoDIMacros/DIContainerModel.swift
@@ -52,6 +52,13 @@ struct WithDependencyReference {
     let keyPath: KeyPathExprSyntax
 }
 
+struct SubContainerBindingReference {
+    let childInputName: String
+    let parentMemberName: String
+    let childKeyPath: KeyPathExprSyntax
+    let parentKeyPath: KeyPathExprSyntax
+}
+
 /// A member inside a `@DIContainer` annotated with `@SubContainer`. Parallel
 /// to `ProvideMemberModel` but carries sub-container-specific metadata: a
 /// scope that must be explicit (no default), and the ordered parent keypath
@@ -75,6 +82,9 @@ struct SubContainerMemberModel {
     /// Parent member names derived from `with: [\.foo, \.bar]`, in order.
     /// Empty when the author relied on automatic name matching.
     let parentDependencies: [String]
+    /// Explicit child `.input` -> parent member remapping from
+    /// `bindings: [(child: \.foo, parent: \.bar)]`.
+    let explicitBindings: [SubContainerBindingReference]
     /// Original key-path expressions from `with:`. Preserved so validation can
     /// point at the exact unknown parent member rather than the whole
     /// attribute.
@@ -88,6 +98,14 @@ struct SubContainerMemberModel {
 
     func parentKeyPathSyntax(for parentName: String) -> KeyPathExprSyntax? {
         parentDependencyReferences.first(where: { $0.name == parentName })?.keyPath
+    }
+
+    func childBindingKeyPathSyntax(for childInputName: String) -> KeyPathExprSyntax? {
+        explicitBindings.first(where: { $0.childInputName == childInputName })?.childKeyPath
+    }
+
+    func parentBindingKeyPathSyntax(for parentName: String) -> KeyPathExprSyntax? {
+        explicitBindings.first(where: { $0.parentMemberName == parentName })?.parentKeyPath
     }
 }
 

--- a/Sources/InnoDIMacros/DIContainerParser.swift
+++ b/Sources/InnoDIMacros/DIContainerParser.swift
@@ -121,6 +121,7 @@ struct DIContainerParser {
                 }
                 let subArgs = InnoDICore.parseSubContainerArguments(subAttribute)
                 let parentDependencyReferences = extractWithDependencyReferences(from: subAttribute)
+                let bindingReferences = extractSubContainerBindingReferences(from: subAttribute)
                 subContainerMembers.append(
                     SubContainerMemberModel(
                         name: validatedBinding.identifier.identifier.text,
@@ -129,6 +130,7 @@ struct DIContainerParser {
                         scopeName: subArgs.scopeName,
                         scopeExpressionSyntax: extractArgumentExpression(label: "scope", from: subAttribute),
                         parentDependencies: parentDependencyReferences.map(\.name),
+                        explicitBindings: bindingReferences,
                         parentDependencyReferences: parentDependencyReferences,
                         attribute: subAttribute,
                         bindingSyntax: validatedBinding.binding
@@ -376,6 +378,63 @@ private func extractWithDependencyReferences(from attribute: AttributeSyntax) ->
                 return nil
             }
             return WithDependencyReference(name: property, keyPath: keyPath)
+        }
+    }
+
+    return []
+}
+
+private func extractSubContainerBindingReferences(from attribute: AttributeSyntax) -> [SubContainerBindingReference] {
+    guard let arguments = attribute.arguments?.as(LabeledExprListSyntax.self) else {
+        return []
+    }
+
+    for argument in arguments where argument.label?.text == "bindings" {
+        guard let arrayExpr = argument.expression.as(ArrayExprSyntax.self) else {
+            return []
+        }
+
+        return arrayExpr.elements.compactMap { element in
+            guard let tupleExpr = element.expression.as(TupleExprSyntax.self) else {
+                return nil
+            }
+
+            var childName: String?
+            var parentName: String?
+            var childKeyPath: KeyPathExprSyntax?
+            var parentKeyPath: KeyPathExprSyntax?
+
+            for tupleElement in tupleExpr.elements {
+                guard let label = tupleElement.label?.text,
+                      let keyPath = tupleElement.expression.as(KeyPathExprSyntax.self),
+                      let property = keyPath.components.last?
+                        .component.as(KeyPathPropertyComponentSyntax.self)?
+                        .declName.baseName.text else {
+                    continue
+                }
+
+                switch label {
+                case "child":
+                    childName = property
+                    childKeyPath = keyPath
+                case "parent":
+                    parentName = property
+                    parentKeyPath = keyPath
+                default:
+                    continue
+                }
+            }
+
+            guard let childName, let parentName, let childKeyPath, let parentKeyPath else {
+                return nil
+            }
+
+            return SubContainerBindingReference(
+                childInputName: childName,
+                parentMemberName: parentName,
+                childKeyPath: childKeyPath,
+                parentKeyPath: parentKeyPath
+            )
         }
     }
 

--- a/Sources/InnoDIMacros/DIContainerValidator.swift
+++ b/Sources/InnoDIMacros/DIContainerValidator.swift
@@ -295,6 +295,32 @@ struct DIContainerValidator {
                 hadErrors = true
             }
 
+            if !sub.parentDependencies.isEmpty && !sub.explicitBindings.isEmpty {
+                context.diagnose(
+                    Diagnostic(
+                        node: Syntax(sub.attribute),
+                        message: SimpleDiagnostic.subBindingsConflictsWithWith(memberName: sub.name)
+                    )
+                )
+                hadErrors = true
+            }
+
+            var seenChildInputs: Set<String> = []
+            for binding in sub.explicitBindings {
+                if !seenChildInputs.insert(binding.childInputName).inserted {
+                    context.diagnose(
+                        Diagnostic(
+                            node: Syntax(binding.childKeyPath),
+                            message: SimpleDiagnostic.subDuplicateChildBinding(
+                                memberName: sub.name,
+                                childInputName: binding.childInputName
+                            )
+                        )
+                    )
+                    hadErrors = true
+                }
+            }
+
             // scope: is required and must parse as `.shared` / `.transient`.
             if sub.scope == nil {
                 if let scopeExpression = sub.scopeExpressionSyntax {
@@ -335,18 +361,40 @@ struct DIContainerValidator {
                 }
             }
 
+            for binding in sub.explicitBindings {
+                let parentName = binding.parentMemberName
+                if !knownParentMemberNames.contains(parentName) {
+                    context.diagnose(
+                        Diagnostic(
+                            node: Syntax(binding.parentKeyPath),
+                            message: SimpleDiagnostic.subUnknownParentMember(
+                                memberName: sub.name,
+                                parentMemberName: parentName
+                            )
+                        )
+                    )
+                    hadErrors = true
+                }
+            }
+
             // `.shared` sub-containers read parent members through private
             // `_storage_<name>` at init time, so `.transient` parents are
             // off-limits (no storage slot exists for them). When the author
             // relies on auto-matching we walk every parent member; with an
             // explicit `with:` list we check only those.
             guard sub.scope == .shared else { continue }
-            let wiredParents: [String] = sub.parentDependencies.isEmpty
-                ? model.members.map(\.name)
-                : sub.parentDependencies
+            let wiredParents: [String]
+            if !sub.explicitBindings.isEmpty {
+                wiredParents = sub.explicitBindings.map(\.parentMemberName)
+            } else if sub.parentDependencies.isEmpty {
+                wiredParents = model.members.map(\.name)
+            } else {
+                wiredParents = sub.parentDependencies
+            }
             for parentName in wiredParents where knownParentMemberNames.contains(parentName) {
                 if memberScopeByName[parentName] == .transient {
-                    let diagnosticNode = sub.parentKeyPathSyntax(for: parentName).map(Syntax.init)
+                    let diagnosticNode = sub.parentBindingKeyPathSyntax(for: parentName).map(Syntax.init)
+                        ?? sub.parentKeyPathSyntax(for: parentName).map(Syntax.init)
                         ?? Syntax(sub.attribute)
                     context.diagnose(
                         Diagnostic(

--- a/Sources/InnoDIMacros/Diagnostics.swift
+++ b/Sources/InnoDIMacros/Diagnostics.swift
@@ -46,6 +46,9 @@ enum InnoDIDiagnosticCode: String {
     case subConflictsWithProvide = "sub.conflicts-with-provide"
     case subOverridesNameConflict = "sub.overrides-name-conflict"
     case subUnknownParentMember = "sub.unknown-parent-member"
+    case subBindingsConflictsWithWith = "sub.bindings-conflicts-with-with"
+    case subDuplicateChildBinding = "sub.duplicate-child-binding"
+    case subUnknownChildInput = "sub.unknown-child-input"
     case subSharedParentMustNotBeTransient = "sub.shared-parent-must-not-be-transient"
 
     var category: InnoDIDiagnosticCategory {
@@ -63,7 +66,8 @@ enum InnoDIDiagnosticCode: String {
                 .containerCustomInitUnsupported, .containerOverridesNameConflict, .graphDependencyCycle,
                 .graphAmbiguousContainerReference,
                 .subScopeRequired, .subUnknownScope, .subConflictsWithProvide, .subOverridesNameConflict,
-                .subUnknownParentMember, .subSharedParentMustNotBeTransient:
+                .subUnknownParentMember, .subBindingsConflictsWithWith, .subDuplicateChildBinding,
+                .subUnknownChildInput, .subSharedParentMustNotBeTransient:
             return .validation
         }
     }
@@ -313,6 +317,31 @@ extension SimpleDiagnostic {
         Self(
             "@SubContainer on '\(memberName)' references parent member '\(parentMemberName)' via with:, but no such member exists. Only @Provide-annotated parent members can be passed to a child container.",
             code: .subUnknownParentMember
+        )
+    }
+
+    static func subBindingsConflictsWithWith(memberName: String) -> Self {
+        Self(
+            "@SubContainer on '\(memberName)' cannot use both with: and bindings:. Use with: for same-name subset/reorder wiring, or bindings: for explicit child-to-parent remapping.",
+            code: .subBindingsConflictsWithWith
+        )
+    }
+
+    static func subDuplicateChildBinding(memberName: String, childInputName: String) -> Self {
+        Self(
+            "@SubContainer on '\(memberName)' binds child input '\(childInputName)' more than once in bindings:. Each child input can appear at most once.",
+            code: .subDuplicateChildBinding
+        )
+    }
+
+    static func subUnknownChildInput(
+        memberName: String,
+        childInputName: String,
+        childContainerName: String
+    ) -> Self {
+        Self(
+            "@SubContainer on '\(memberName)' binds child input '\(childInputName)', but '\(childContainerName)' does not declare a matching .input member.",
+            code: .subUnknownChildInput
         )
     }
 

--- a/Tests/InnoDIBuildSupportTests/ValidationCoordinatorTests.swift
+++ b/Tests/InnoDIBuildSupportTests/ValidationCoordinatorTests.swift
@@ -613,6 +613,103 @@ struct ValidationCoordinatorTests {
         #expect(runner.invocationCount == 0)
     }
 
+    @Test("Legacy shared-run cache directories without a version salt are ignored")
+    func legacySharedRunCacheDirectoriesAreIgnored() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let signature = try collectValidationSignature(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false)
+        )
+        let legacyDirectory = fixture.stateURL.appendingPathComponent(signature, isDirectory: true)
+        try FileManager.default.createDirectory(at: legacyDirectory, withIntermediateDirectories: true)
+        try persistJSON(
+            ValidationCommandResult(exitCode: 0, stdout: "legacy\n", stderr: ""),
+            to: legacyDirectory.appendingPathComponent("result.json")
+        )
+        try persistJSON(
+            SharedValidationRunRecord(
+                liveRunMetrics: ValidationLiveRunMetrics(
+                    customInitValidationMilliseconds: 1,
+                    semanticValidationMilliseconds: 1,
+                    dagValidationMilliseconds: 1
+                ),
+                reasonCodes: [.liveRunSemanticValidation, .liveRunDAGValidation],
+                issues: []
+            ),
+            to: legacyDirectory.appendingPathComponent("validation-metrics.json")
+        )
+
+        let runner = MockValidationRunner(
+            results: [
+                ValidationCommandResult(exitCode: 0, stdout: "fresh\n", stderr: "")
+            ]
+        )
+
+        let outcome = try ValidationCoordinator.coordinate(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            toolPath: "/usr/bin/true",
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            outputDirectoryPath: fixture.outputAURL.path(percentEncoded: false),
+            runner: runner
+        )
+
+        #expect(outcome.wasCached == false)
+        #expect(outcome.result.stdout == "fresh\n")
+        #expect(outcome.metricsArtifact.reasonCodes.contains(.liveRunSemanticValidation))
+        #expect(runner.invocationCount == 1)
+        #expect(FileManager.default.fileExists(atPath: legacyDirectory.path(percentEncoded: false)) == false)
+    }
+
+    @Test("Corrupt current-version shared-run metrics fall back to a live validation run")
+    func corruptCurrentVersionSharedRunMetricsFallBackToLiveRun() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let signature = try collectValidationSignature(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false)
+        )
+        let sharedRunDirectory = fixture.stateURL.appendingPathComponent(
+            sharedRunCacheKey(for: signature),
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: sharedRunDirectory, withIntermediateDirectories: true)
+        try persistJSON(
+            ValidationCommandResult(exitCode: 0, stdout: "legacy\n", stderr: ""),
+            to: sharedRunDirectory.appendingPathComponent("result.json")
+        )
+        try Data("{\"liveRunMetrics\":{}}".utf8).write(
+            to: sharedRunDirectory.appendingPathComponent("validation-metrics.json"),
+            options: .atomic
+        )
+
+        let runner = MockValidationRunner(
+            results: [
+                ValidationCommandResult(exitCode: 0, stdout: "fresh\n", stderr: "")
+            ]
+        )
+
+        let outcome = try ValidationCoordinator.coordinate(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            toolPath: "/usr/bin/true",
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            outputDirectoryPath: fixture.outputAURL.path(percentEncoded: false),
+            runner: runner
+        )
+
+        #expect(outcome.wasCached == false)
+        #expect(outcome.result.stdout == "fresh\n")
+        #expect(outcome.metricsArtifact.reasonCodes.contains(.liveRunSemanticValidation))
+        #expect(runner.invocationCount == 1)
+
+        let repairedRecord = try loadSharedValidationRunRecord(
+            at: sharedRunDirectory.appendingPathComponent("validation-metrics.json")
+        )
+        #expect(repairedRecord.liveRunMetrics.semanticValidationMilliseconds >= 0)
+    }
+
     @Test("Failure result is reused for identical input signature")
     func failureResultIsReused() throws {
         let fixture = try makeFixture()
@@ -973,6 +1070,16 @@ private func loadDigestManifest(at url: URL) throws -> ValidationDigestManifest 
 private func loadMetricsArtifact(at url: URL) throws -> ValidationMetricsArtifact {
     let data = try Data(contentsOf: url)
     return try JSONDecoder().decode(ValidationMetricsArtifact.self, from: data)
+}
+
+private func loadSharedValidationRunRecord(at url: URL) throws -> SharedValidationRunRecord {
+    let data = try Data(contentsOf: url)
+    return try JSONDecoder().decode(SharedValidationRunRecord.self, from: data)
+}
+
+private func persistJSON<Value: Encodable>(_ value: Value, to url: URL) throws {
+    let data = try JSONEncoder().encode(value)
+    try data.write(to: url, options: .atomic)
 }
 
 private func makeFixture() throws -> FixturePaths {

--- a/Tests/InnoDIBuildSupportTests/ValidationCoordinatorTests.swift
+++ b/Tests/InnoDIBuildSupportTests/ValidationCoordinatorTests.swift
@@ -405,15 +405,212 @@ struct ValidationCoordinatorTests {
         #expect(secondArtifact.wasCached == true)
         #expect(firstArtifact.signatureMetrics.scannedFileCount == 1)
         #expect(firstArtifact.humanSummarySource == "dag-validation-summary.md")
+        #expect(firstArtifact.reasonCodes.contains(.liveRunSemanticValidation))
         #expect(firstArtifact.reasonCodes.contains(.liveRunDAGValidation))
+        #expect(firstArtifact.liveRunMetrics.semanticValidationMilliseconds >= 0)
         #expect(firstArtifact.fileChanges.newFiles == ["Feature.swift"])
         #expect(firstArtifact.fileChanges.reparsedFiles == ["Feature.swift"])
         #expect(firstSummary.contains("# InnoDI Validation Summary"))
         #expect(firstSummary.contains("cache-miss-new-file"))
+        #expect(firstSummary.contains("live-run-semantic-validation"))
+        #expect(firstSummary.contains("Semantic validation"))
         #expect(firstSummary.contains("### Reparsed files"))
         #expect(firstSummary.contains("`Feature.swift`"))
+        #expect(first.verboseSummary?.contains("semantic-ms=") == true)
         #expect(first.verboseSummary?.contains("[InnoDI]") == true)
         #expect(second.verboseSummary == nil)
+    }
+
+    @Test("Semantic validation fails on same-module Lazy and Provider collisions before DAG runner executes")
+    func semanticValidationFailsOnLocalWrapperCollisions() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        try """
+        struct Config {}
+        struct Service {}
+        struct Lazy<T> {}
+        struct Provider<T> {}
+
+        @DIContainer
+        struct AppContainer {
+            @Provide(.shared, factory: { (lazyConfig: Lazy<Config>, serviceProvider: Provider<Service>) in
+                Service()
+            }, concrete: true)
+            var service: Service
+        }
+        """.write(
+            to: fixture.rootURL.appendingPathComponent("SemanticWrappers.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let runner = MockValidationRunner(
+            results: [
+                ValidationCommandResult(exitCode: 0, stdout: "unexpected\n", stderr: "")
+            ]
+        )
+
+        let outcome = try ValidationCoordinator.coordinate(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            toolPath: "/usr/bin/true",
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            outputDirectoryPath: fixture.outputAURL.path(percentEncoded: false),
+            runner: runner
+        )
+
+        #expect(outcome.result.exitCode == 1)
+        #expect(outcome.result.stderr.contains("provide.deferred-wrapper-qualification-required"))
+        #expect(outcome.metricsArtifact.reasonCodes.contains(.liveRunSemanticFailure))
+        #expect(outcome.metricsArtifact.issues.count == 2)
+        #expect(outcome.metricsArtifact.liveRunMetrics.semanticValidationMilliseconds >= 0)
+        #expect(outcome.metricsArtifact.liveRunMetrics.dagValidationMilliseconds == 0)
+        #expect(outcome.metricsArtifact.issues.contains { $0.metadata["writtenHead"] == "Lazy" })
+        #expect(outcome.metricsArtifact.issues.contains { $0.metadata["writtenHead"] == "Provider" })
+        #expect(runner.invocationCount == 0)
+    }
+
+    @Test("Semantic validation rejects wrapper aliases before DAG runner executes")
+    func semanticValidationRejectsWrapperAliases() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        try """
+        struct Config {}
+        struct Service {}
+        typealias DeferredLazy<T> = InnoDI.Lazy<T>
+        typealias DeferredProvider<T> = InnoDI.Provider<T>
+
+        @DIContainer
+        struct AppContainer {
+            @Provide(.shared, factory: { (lazyConfig: DeferredLazy<Config>, serviceProvider: DeferredProvider<Service>) in
+                Service()
+            }, concrete: true)
+            var service: Service
+        }
+        """.write(
+            to: fixture.rootURL.appendingPathComponent("SemanticWrapperAliases.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let runner = MockValidationRunner(
+            results: [
+                ValidationCommandResult(exitCode: 0, stdout: "unexpected\n", stderr: "")
+            ]
+        )
+
+        let outcome = try ValidationCoordinator.coordinate(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            toolPath: "/usr/bin/true",
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            outputDirectoryPath: fixture.outputAURL.path(percentEncoded: false),
+            runner: runner
+        )
+
+        #expect(outcome.result.exitCode == 1)
+        #expect(outcome.result.stderr.contains("provide.deferred-wrapper-alias-unsupported"))
+        #expect(outcome.metricsArtifact.reasonCodes.contains(.liveRunSemanticFailure))
+        #expect(outcome.metricsArtifact.issues.count == 2)
+        #expect(outcome.metricsArtifact.issues.contains { $0.metadata["writtenHead"] == "DeferredLazy" })
+        #expect(outcome.metricsArtifact.issues.contains { $0.metadata["writtenHead"] == "DeferredProvider" })
+        #expect(runner.invocationCount == 0)
+    }
+
+    @Test("Qualified InnoDI deferred wrappers pass semantic validation and reach the DAG runner")
+    func qualifiedDeferredWrappersPassSemanticValidation() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        try """
+        struct Config {}
+        struct Service {}
+
+        @DIContainer
+        struct AppContainer {
+            @Provide(.shared, factory: { (lazyConfig: InnoDI.Lazy<Config>, serviceProvider: InnoDI.Provider<Service>) in
+                Service()
+            }, concrete: true)
+            var service: Service
+        }
+        """.write(
+            to: fixture.rootURL.appendingPathComponent("QualifiedDeferredWrappers.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let runner = MockValidationRunner(
+            results: [
+                ValidationCommandResult(exitCode: 0, stdout: "DAG validation passed.\n", stderr: "")
+            ]
+        )
+
+        let outcome = try ValidationCoordinator.coordinate(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            toolPath: "/usr/bin/true",
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            outputDirectoryPath: fixture.outputAURL.path(percentEncoded: false),
+            runner: runner
+        )
+
+        #expect(outcome.result.exitCode == 0)
+        #expect(outcome.metricsArtifact.reasonCodes.contains(.liveRunSemanticValidation))
+        #expect(outcome.metricsArtifact.reasonCodes.contains(.liveRunDAGValidation))
+        #expect(outcome.metricsArtifact.issues.isEmpty)
+        #expect(runner.invocationCount == 1)
+    }
+
+    @Test("Semantic validation rejects bindings: that target an unknown child input")
+    func semanticValidationRejectsUnknownChildInputBinding() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        try """
+        struct AppConfig {}
+
+        @DIContainer
+        struct FeatureContainer {
+            @Provide(.input)
+            var config: AppConfig
+        }
+
+        @DIContainer
+        struct AppContainer {
+            @Provide(.input)
+            var appConfig: AppConfig
+
+            @SubContainer(
+                scope: .shared,
+                bindings: [(child: \\FeatureContainer.missing, parent: \\AppContainer.appConfig)]
+            )
+            var feature: FeatureContainer
+        }
+        """.write(
+            to: fixture.rootURL.appendingPathComponent("UnknownChildInputBinding.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let runner = MockValidationRunner(
+            results: [
+                ValidationCommandResult(exitCode: 0, stdout: "unexpected\n", stderr: "")
+            ]
+        )
+
+        let outcome = try ValidationCoordinator.coordinate(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            toolPath: "/usr/bin/true",
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            outputDirectoryPath: fixture.outputAURL.path(percentEncoded: false),
+            runner: runner
+        )
+
+        #expect(outcome.result.exitCode == 1)
+        #expect(outcome.result.stderr.contains("sub.unknown-child-input"))
+        #expect(outcome.metricsArtifact.reasonCodes.contains(.liveRunSemanticFailure))
+        #expect(outcome.metricsArtifact.issues.count == 1)
+        #expect(outcome.metricsArtifact.issues.first?.metadata["childContainerPath"] == "FeatureContainer")
+        #expect(runner.invocationCount == 0)
     }
 
     @Test("Failure result is reused for identical input signature")

--- a/Tests/InnoDIMacrosTests/DIContainerMacroTests.swift
+++ b/Tests/InnoDIMacrosTests/DIContainerMacroTests.swift
@@ -1569,6 +1569,46 @@ struct DIContainerMacroTests {
         )
     }
 
+    @Test("`.shared` sub-container supports explicit child/parent input remapping via bindings:")
+    func subContainerSharedExplicitBindings() {
+        assertMacroExpansionSnapshot(
+            """
+            @DIContainer
+            struct AppContainer {
+                @Provide(.input) var config: AppConfig
+
+                @SubContainer(
+                    scope: .shared,
+                    bindings: [(child: \\.featureConfig, parent: \\.config)]
+                )
+                var feature: FeatureBindingsContainer
+            }
+            """,
+            matches: "subContainerSharedExplicitBindings",
+            macros: Self.macros
+        )
+    }
+
+    @Test("`.transient` sub-container supports explicit child/parent input remapping via bindings:")
+    func subContainerTransientExplicitBindings() {
+        assertMacroExpansionSnapshot(
+            """
+            @DIContainer
+            struct AppContainer {
+                @Provide(.input) var config: AppConfig
+
+                @SubContainer(
+                    scope: .transient,
+                    bindings: [(child: \\.featureConfig, parent: \\.config)]
+                )
+                var feature: FeatureBindingsContainer
+            }
+            """,
+            matches: "subContainerTransientExplicitBindings",
+            macros: Self.macros
+        )
+    }
+
     @Test("Container with only @SubContainer still generates init and Overrides")
     func subContainerOnlyParentGeneratesInitAndOverrides() {
         assertMacroExpansionSnapshot(
@@ -1580,6 +1620,55 @@ struct DIContainerMacroTests {
             }
             """,
             matches: "subContainerOnlyParentGeneratesInitAndOverrides",
+            macros: Self.macros
+        )
+    }
+
+    @Test("@SubContainer with both with: and bindings: emits sub.bindings-conflicts-with-with")
+    func subContainerBindingsConflictWithWithDiagnoses() {
+        assertMacroExpansionDiagnosticCodes(
+            """
+            @DIContainer
+            struct AppContainer {
+                @Provide(.input) var config: AppConfig
+
+                @SubContainer(
+                    scope: .shared,
+                    with: [\\.config],
+                    bindings: [(child: \\.featureConfig, parent: \\.config)]
+                )
+                var feature: FeatureBindingsContainer
+            }
+            """,
+            expectedCodes: [
+                MessageID(domain: "InnoDI.validation", id: "sub.bindings-conflicts-with-with")
+            ],
+            macros: Self.macros
+        )
+    }
+
+    @Test("@SubContainer duplicate child bindings emit sub.duplicate-child-binding")
+    func subContainerDuplicateChildBindingDiagnoses() {
+        assertMacroExpansionDiagnosticCodes(
+            """
+            @DIContainer
+            struct AppContainer {
+                @Provide(.input) var config: AppConfig
+                @Provide(.input) var fallbackConfig: AppConfig
+
+                @SubContainer(
+                    scope: .shared,
+                    bindings: [
+                        (child: \\.featureConfig, parent: \\.config),
+                        (child: \\.featureConfig, parent: \\.fallbackConfig)
+                    ]
+                )
+                var feature: FeatureBindingsContainer
+            }
+            """,
+            expectedCodes: [
+                MessageID(domain: "InnoDI.validation", id: "sub.duplicate-child-binding")
+            ],
             macros: Self.macros
         )
     }
@@ -1598,6 +1687,28 @@ struct DIContainerMacroTests {
                 MessageID(domain: "SwiftSyntaxMacroExpansion", id: "accessorMacroOnVariableWithMultipleBindings"),
                 MessageID(domain: "SwiftSyntaxMacroExpansion", id: "peerMacroOnVariableWithMultipleBindings"),
                 MessageID(domain: "InnoDI.usage", id: "sub.single-binding")
+            ],
+            macros: Self.macros
+        )
+    }
+
+    @Test("@SubContainer bindings: with an unknown parent member emits sub.unknown-parent-member")
+    func subContainerBindingsUnknownParentMemberDiagnoses() {
+        assertMacroExpansionDiagnosticCodes(
+            """
+            @DIContainer
+            struct AppContainer {
+                @Provide(.input) var config: AppConfig
+
+                @SubContainer(
+                    scope: .shared,
+                    bindings: [(child: \\.featureConfig, parent: \\.missing)]
+                )
+                var feature: FeatureBindingsContainer
+            }
+            """,
+            expectedCodes: [
+                MessageID(domain: "InnoDI.validation", id: "sub.unknown-parent-member")
             ],
             macros: Self.macros
         )
@@ -1830,6 +1941,31 @@ struct DIContainerMacroTests {
 
                 @SubContainer(scope: .shared)
                 var feature: FeatureContainer
+            }
+            """,
+            expectedCodes: [
+                MessageID(domain: "InnoDI.validation", id: "sub.shared-parent-must-not-be-transient")
+            ],
+            macros: Self.macros
+        )
+    }
+
+    @Test("`.shared` sub bindings: must not target a `.transient` parent member")
+    func subContainerBindingsSharedParentMustNotBeTransientDiagnoses() {
+        assertMacroExpansionDiagnosticCodes(
+            """
+            @DIContainer
+            struct AppContainer {
+                @Provide(.input) var config: AppConfig
+
+                @Provide(.transient, factory: { (config: AppConfig) in Request(config: config) }, concrete: true)
+                var request: Request
+
+                @SubContainer(
+                    scope: .shared,
+                    bindings: [(child: \\.featureRequest, parent: \\.request)]
+                )
+                var feature: FeatureBindingsContainer
             }
             """,
             expectedCodes: [

--- a/Tests/InnoDIMacrosTests/OverridesBuilderTests.swift
+++ b/Tests/InnoDIMacrosTests/OverridesBuilderTests.swift
@@ -10,8 +10,8 @@ import Testing
 /// These tests pin the generated `struct Overrides`, convenience `init(_ applyOverrides:)`,
 /// and four `static withOverrides` effect overloads across the dimensions that
 /// drive the code path: input/shared/transient mix, async shared, MainActor
-/// propagation, public access, input-only skip, and user-defined `Overrides`
-/// name conflict.
+/// propagation, public access, input-only scaffolding, and user-defined
+/// `Overrides` name conflict.
 @Suite("@DIContainer Overrides builder")
 struct OverridesBuilderTests {
     private static let macros: [String: any Macro.Type] = [
@@ -124,7 +124,7 @@ struct OverridesBuilderTests {
         )
     }
 
-    @Test("input-only container skips Overrides scaffolding (byte-identical to pre-J baseline)")
+    @Test("input-only container now generates empty Overrides scaffolding")
     func inputOnlySkipsScaffolding() {
         assertMacroExpansionSnapshot(
             """
@@ -142,7 +142,7 @@ struct OverridesBuilderTests {
         )
     }
 
-    @Test("input-only container with user-defined Overrides skips scaffolding silently")
+    @Test("input-only container with user-defined Overrides emits the same warning diagnostic")
     func inputOnlyUserDefinedOverridesSkipsConflictWarning() {
         assertMacroExpansionSnapshot(
             """
@@ -157,6 +157,15 @@ struct OverridesBuilderTests {
             }
             """,
             matches: "inputOnlyUserDefinedOverridesSkipsConflictWarning",
+            diagnostics: [
+                DiagnosticSpec(
+                    id: MessageID(domain: "InnoDI.validation", id: "container.overrides-name-conflict"),
+                    message: "A nested 'Overrides' struct is already declared. InnoDI's @DIContainer would normally generate an Overrides builder, but the user declaration takes precedence. Rename the user type or skip InnoDI's override scaffolding.",
+                    line: 3,
+                    column: 5,
+                    severity: .warning
+                )
+            ],
             macros: Self.macros
         )
     }

--- a/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/constrainedExtensionsAreExcluded.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/constrainedExtensionsAreExcluded.swift
@@ -11,6 +11,35 @@ struct AppContainer<T> {
     init(config: Config) {
         self._storage_config = config
     }
+
+    struct Overrides {
+    }
+
+    init(config: Config, _ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(config: config)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(config: config, applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(config: config, applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(config: config, applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(config: config, applyOverrides)
+        return try await operation(container)
+    }
 }
 
 extension AppContainer where T: Sendable {

--- a/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/customInitInOtherSameFileExtensionDoesNotTriggerRejection.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/customInitInOtherSameFileExtensionDoesNotTriggerRejection.swift
@@ -11,6 +11,35 @@ struct AppContainer {
     init(config: Config) {
         self._storage_config = config
     }
+
+    struct Overrides {
+    }
+
+    init(config: Config, _ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(config: config)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(config: config, applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(config: config, applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(config: config, applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(config: config, applyOverrides)
+        return try await operation(container)
+    }
 }
 
 struct Helper {

--- a/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/genericArgumentExtensionsAreExcluded.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/genericArgumentExtensionsAreExcluded.swift
@@ -11,6 +11,35 @@ struct AppContainer<T> {
     init(config: Config) {
         self._storage_config = config
     }
+
+    struct Overrides {
+    }
+
+    init(config: Config, _ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(config: config)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(config: config, applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(config: config, applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(config: config, applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(config: config, applyOverrides)
+        return try await operation(container)
+    }
 }
 
 extension AppContainer<String> {

--- a/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/mainActorContainerGeneratesMainActorInit.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/mainActorContainerGeneratesMainActorInit.swift
@@ -11,4 +11,33 @@ struct AppContainer {
     @MainActor init(config: Config) {
         self._storage_config = config
     }
+
+    struct Overrides {
+    }
+
+    @MainActor init(config: Config, _ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(config: config)
+    }
+
+    @MainActor static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(config: config, applyOverrides)
+        return operation(container)
+    }
+
+    @MainActor static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(config: config, applyOverrides)
+        return try operation(container)
+    }
+
+    @MainActor static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(config: config, applyOverrides)
+        return await operation(container)
+    }
+
+    @MainActor static func withOverrides<T>(config: Config, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(config: config, applyOverrides)
+        return try await operation(container)
+    }
 }

--- a/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/subContainerSharedExplicitBindings.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/subContainerSharedExplicitBindings.swift
@@ -1,0 +1,65 @@
+
+struct AppContainer {
+    var config: AppConfig {
+        get {
+            return _storage_config
+        }
+    }
+
+    private let _storage_config: AppConfig
+    var feature: FeatureBindingsContainer {
+        get {
+            return _storage_sub_feature
+        }
+    }
+
+    private let _storage_sub_feature: FeatureBindingsContainer
+
+    private let _override_sub_feature: FeatureBindingsContainer?
+
+    private let _override_sub_apply_feature: ((inout FeatureBindingsContainer.Overrides) -> Void)?
+
+    init(config: AppConfig, feature: FeatureBindingsContainer? = nil, featureOverrides: ((inout FeatureBindingsContainer.Overrides) -> Void)? = nil) {
+        self._storage_config = config
+        if let direct = feature {
+            self._storage_sub_feature = direct
+         } else if let apply = featureOverrides {
+            self._storage_sub_feature = FeatureBindingsContainer(featureConfig: self._storage_config, apply)
+         } else {
+            self._storage_sub_feature = FeatureBindingsContainer(featureConfig: self._storage_config)
+        }
+        self._override_sub_feature = feature
+        self._override_sub_apply_feature = featureOverrides
+    }
+
+    struct Overrides {
+        var feature: FeatureBindingsContainer? = nil
+        var featureOverrides: ((inout FeatureBindingsContainer.Overrides) -> Void)? = nil
+    }
+
+    init(config: AppConfig, _ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(config: config, feature: overrides.feature, featureOverrides: overrides.featureOverrides)
+    }
+
+    static func withOverrides<T>(config: AppConfig, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(config: config, applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(config: AppConfig, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(config: config, applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(config: AppConfig, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(config: config, applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(config: AppConfig, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(config: config, applyOverrides)
+        return try await operation(container)
+    }
+}

--- a/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/subContainerTransientExplicitBindings.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/subContainerTransientExplicitBindings.swift
@@ -1,0 +1,70 @@
+
+struct AppContainer {
+    var config: AppConfig {
+        get {
+            return _storage_config
+        }
+    }
+
+    private let _storage_config: AppConfig
+    var feature: FeatureBindingsContainer {
+        get {
+            return _innoDISubBuild_feature()
+        }
+    }
+
+    private let _override_sub_feature: FeatureBindingsContainer?
+
+    private let _override_sub_apply_feature: ((inout FeatureBindingsContainer.Overrides) -> Void)?
+
+    private var _innoDISubBuild_feature: () -> FeatureBindingsContainer = {
+        fatalError("_innoDISubBuild_feature invoked before the generated init populated it. This should be unreachable — report as an InnoDI bug.")
+    }
+
+    init(config: AppConfig, feature: FeatureBindingsContainer? = nil, featureOverrides: ((inout FeatureBindingsContainer.Overrides) -> Void)? = nil) {
+        self._storage_config = config
+        self._override_sub_feature = feature
+        self._override_sub_apply_feature = featureOverrides
+        let _lazySelfForSub = self
+        self._innoDISubBuild_feature = { () -> FeatureBindingsContainer in
+            if let direct = _lazySelfForSub._override_sub_feature {
+                return direct
+            }
+            if let apply = _lazySelfForSub._override_sub_apply_feature {
+                return FeatureBindingsContainer(config: _lazySelfForSub.config, apply)
+            }
+            return FeatureBindingsContainer(config: _lazySelfForSub.config)
+        }
+    }
+
+    struct Overrides {
+        var feature: FeatureBindingsContainer? = nil
+        var featureOverrides: ((inout FeatureBindingsContainer.Overrides) -> Void)? = nil
+    }
+
+    init(config: AppConfig, _ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(config: config, feature: overrides.feature, featureOverrides: overrides.featureOverrides)
+    }
+
+    static func withOverrides<T>(config: AppConfig, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(config: config, applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(config: AppConfig, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(config: config, applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(config: AppConfig, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(config: config, applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(config: AppConfig, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(config: config, applyOverrides)
+        return try await operation(container)
+    }
+}

--- a/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/subContainerTransientExplicitBindings.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/DIContainerMacroTests/subContainerTransientExplicitBindings.swift
@@ -31,9 +31,9 @@ struct AppContainer {
                 return direct
             }
             if let apply = _lazySelfForSub._override_sub_apply_feature {
-                return FeatureBindingsContainer(config: _lazySelfForSub.config, apply)
+                return FeatureBindingsContainer(featureConfig: _lazySelfForSub.config, apply)
             }
-            return FeatureBindingsContainer(config: _lazySelfForSub.config)
+            return FeatureBindingsContainer(featureConfig: _lazySelfForSub.config)
         }
     }
 

--- a/Tests/InnoDIMacrosTests/__Snapshots__/OverridesBuilderTests/inputOnlySkipsScaffolding.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/OverridesBuilderTests/inputOnlySkipsScaffolding.swift
@@ -19,4 +19,33 @@ struct AppContainer {
         self._storage_userID = userID
         self._storage_baseURL = baseURL
     }
+
+    struct Overrides {
+    }
+
+    init(userID: String, baseURL: String, _ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(userID: userID, baseURL: baseURL)
+    }
+
+    static func withOverrides<T>(userID: String, baseURL: String, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(userID: userID, baseURL: baseURL, applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(userID: String, baseURL: String, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(userID: userID, baseURL: baseURL, applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(userID: String, baseURL: String, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(userID: userID, baseURL: baseURL, applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(userID: String, baseURL: String, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(userID: userID, baseURL: baseURL, applyOverrides)
+        return try await operation(container)
+    }
 }

--- a/Tests/InnoDIMacrosTests/__Snapshots__/SnapshotSmokeTests/inputOnlyContainer.swift
+++ b/Tests/InnoDIMacrosTests/__Snapshots__/SnapshotSmokeTests/inputOnlyContainer.swift
@@ -11,4 +11,33 @@ struct AppContainer {
     init(baseURL: String) {
         self._storage_baseURL = baseURL
     }
+
+    struct Overrides {
+    }
+
+    init(baseURL: String, _ applyOverrides: (inout Overrides) -> Void) {
+        var overrides = Overrides()
+        applyOverrides(&overrides)
+        self.init(baseURL: baseURL)
+    }
+
+    static func withOverrides<T>(baseURL: String, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) -> T) -> T {
+        let container = Self(baseURL: baseURL, applyOverrides)
+        return operation(container)
+    }
+
+    static func withOverrides<T>(baseURL: String, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) throws -> T) throws -> T {
+        let container = Self(baseURL: baseURL, applyOverrides)
+        return try operation(container)
+    }
+
+    static func withOverrides<T>(baseURL: String, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async -> T) async -> T {
+        let container = Self(baseURL: baseURL, applyOverrides)
+        return await operation(container)
+    }
+
+    static func withOverrides<T>(baseURL: String, _ applyOverrides: (inout Overrides) -> Void, operation: (Self) async throws -> T) async throws -> T {
+        let container = Self(baseURL: baseURL, applyOverrides)
+        return try await operation(container)
+    }
 }

--- a/Tests/InnoDIRuntimeTests/SubContainerRuntimeTests.swift
+++ b/Tests/InnoDIRuntimeTests/SubContainerRuntimeTests.swift
@@ -60,6 +60,35 @@ struct RuntimeParentWithSubsetContainer {
     var child: RuntimeSubsetChildContainer
 }
 
+@DIContainer
+struct RuntimeBindingsChildContainer {
+    @Provide(.input) var featureConfig: RuntimeParentConfig
+}
+
+@DIContainer
+struct RuntimeParentWithBindingsContainer {
+    @Provide(.input) var config: RuntimeParentConfig
+
+    @SubContainer(
+        scope: .shared,
+        bindings: [(child: \RuntimeBindingsChildContainer.featureConfig, parent: \RuntimeParentWithBindingsContainer.config)]
+    )
+    var child: RuntimeBindingsChildContainer
+}
+
+@DIContainer
+struct RuntimeInputOnlyChildContainer {
+    @Provide(.input) var config: RuntimeParentConfig
+}
+
+@DIContainer
+struct RuntimeParentWithInputOnlyChildContainer {
+    @Provide(.input) var config: RuntimeParentConfig
+
+    @SubContainer(scope: .shared)
+    var child: RuntimeInputOnlyChildContainer
+}
+
 // Override tests need deterministic mock identity so reference comparisons
 // read naturally.
 
@@ -128,6 +157,14 @@ struct SubContainerRuntimeTests {
         #expect(parent.child.config == RuntimeParentConfig(endpoint: "subset"))
     }
 
+    @Test("bindings: remaps parent and child labels explicitly")
+    func bindingsRemapParentAndChildLabels() {
+        let parent = RuntimeParentWithBindingsContainer(
+            config: RuntimeParentConfig(endpoint: "bindings")
+        )
+        #expect(parent.child.featureConfig == RuntimeParentConfig(endpoint: "bindings"))
+    }
+
     // MARK: - Overrides builder integration
 
     @Test("Overrides.feature fully replaces the child container")
@@ -185,5 +222,32 @@ struct SubContainerRuntimeTests {
             container.feature.store.tag
         }
         #expect(tag == "scoped-override")
+    }
+
+    @Test("input-only child sub-containers still support direct replacement")
+    func inputOnlyChildDirectReplacementStillWorks() {
+        let replacement = RuntimeInputOnlyChildContainer(
+            config: RuntimeParentConfig(endpoint: "replacement")
+        )
+        let parent = RuntimeParentWithInputOnlyChildContainer(
+            config: RuntimeParentConfig(endpoint: "ignored")
+        ) {
+            $0.child = replacement
+        }
+        #expect(parent.child.config == RuntimeParentConfig(endpoint: "replacement"))
+    }
+
+    @Test("input-only child featureOverrides closures compile and execute as no-ops")
+    func inputOnlyChildOverrideClosureCompilesAndExecutes() {
+        var didApply = false
+        let parent = RuntimeParentWithInputOnlyChildContainer(
+            config: RuntimeParentConfig(endpoint: "input-only")
+        ) {
+            $0.childOverrides = { _ in
+                didApply = true
+            }
+        }
+        #expect(didApply)
+        #expect(parent.child.config == RuntimeParentConfig(endpoint: "input-only"))
     }
 }

--- a/Tests/InnoDIRuntimeTests/SubContainerRuntimeTests.swift
+++ b/Tests/InnoDIRuntimeTests/SubContainerRuntimeTests.swift
@@ -77,6 +77,17 @@ struct RuntimeParentWithBindingsContainer {
 }
 
 @DIContainer
+struct RuntimeParentWithTransientBindingsContainer {
+    @Provide(.input) var config: RuntimeParentConfig
+
+    @SubContainer(
+        scope: .transient,
+        bindings: [(child: \RuntimeBindingsChildContainer.featureConfig, parent: \RuntimeParentWithTransientBindingsContainer.config)]
+    )
+    var child: RuntimeBindingsChildContainer
+}
+
+@DIContainer
 struct RuntimeInputOnlyChildContainer {
     @Provide(.input) var config: RuntimeParentConfig
 }
@@ -111,6 +122,25 @@ struct OverrideParentContainer {
 
     @SubContainer(scope: .shared)
     var feature: OverrideCapableChild
+}
+
+@DIContainer
+struct OverrideTransientBindingsChild {
+    @Provide(.input) var featureConfig: RuntimeParentConfig
+
+    @Provide(.shared, factory: OverrideChildStore(tag: "default"), concrete: true)
+    var store: OverrideChildStore
+}
+
+@DIContainer
+struct OverrideTransientBindingsParentContainer {
+    @Provide(.input) var config: RuntimeParentConfig
+
+    @SubContainer(
+        scope: .transient,
+        bindings: [(child: \OverrideTransientBindingsChild.featureConfig, parent: \OverrideTransientBindingsParentContainer.config)]
+    )
+    var feature: OverrideTransientBindingsChild
 }
 
 @Suite("SubContainer runtime (Phase M)")
@@ -163,6 +193,14 @@ struct SubContainerRuntimeTests {
             config: RuntimeParentConfig(endpoint: "bindings")
         )
         #expect(parent.child.featureConfig == RuntimeParentConfig(endpoint: "bindings"))
+    }
+
+    @Test("`.transient` bindings: remap parent and child labels explicitly")
+    func transientBindingsRemapParentAndChildLabels() {
+        let parent = RuntimeParentWithTransientBindingsContainer(
+            config: RuntimeParentConfig(endpoint: "transient-bindings")
+        )
+        #expect(parent.child.featureConfig == RuntimeParentConfig(endpoint: "transient-bindings"))
     }
 
     // MARK: - Overrides builder integration
@@ -222,6 +260,40 @@ struct SubContainerRuntimeTests {
             container.feature.store.tag
         }
         #expect(tag == "scoped-override")
+    }
+
+    @Test("Remapped transient child overrides still apply to the child convenience init")
+    func transientBindingsOverrideChainUsesRemappedInputs() {
+        let parent = OverrideTransientBindingsParentContainer(
+            config: RuntimeParentConfig(endpoint: "transient-override")
+        ) {
+            $0.featureOverrides = { childOv in
+                childOv.store = OverrideChildStore(tag: "transient-chain")
+            }
+        }
+        let child = parent.feature
+        #expect(child.featureConfig == RuntimeParentConfig(endpoint: "transient-override"))
+        #expect(child.store.tag == "transient-chain")
+    }
+
+    @Test("Direct replacement still wins over childOverrides for remapped transient children")
+    func transientBindingsDirectReplacementWinsOverChain() {
+        let replacement = OverrideTransientBindingsChild(
+            featureConfig: RuntimeParentConfig(endpoint: "replacement"),
+            store: OverrideChildStore(tag: "transient-direct")
+        )
+        let parent = OverrideTransientBindingsParentContainer(
+            config: RuntimeParentConfig(endpoint: "ignored")
+        ) {
+            $0.feature = replacement
+            $0.featureOverrides = { childOv in
+                childOv.store = OverrideChildStore(tag: "transient-chain-should-not-win")
+            }
+        }
+
+        let child = parent.feature
+        #expect(child.featureConfig == RuntimeParentConfig(endpoint: "replacement"))
+        #expect(child.store.tag == "transient-direct")
     }
 
     @Test("input-only child sub-containers still support direct replacement")


### PR DESCRIPTION
## 변경 내용
- `@SubContainer`에 `bindings:` 인자를 추가해 child input과 parent member 간 explicit remapping을 지원했습니다.
- input-only `@DIContainer`도 항상 빈 `Overrides`와 convenience init, `withOverrides` 오버로드를 합성하도록 변경했습니다.
- build-support 단계에 `ContainerSemanticBuildValidator`를 추가해 `Lazy` / `Provider`의 same-module 이름 충돌과 alias 오용을 fail-fast로 검증하도록 했습니다.
- 관련 macro/runtime/build-support 테스트와 snapshot을 함께 보강했습니다.

## 왜 필요한가
- child와 parent의 input label이 다를 때 기존 `with:`만으로는 선언적으로 연결할 수 없었습니다.
- input-only child는 sub-container override 체인에 들어갈 때 scaffolding이 빠져 실제 도입 시 제약이 있었습니다.
- deferred wrapper 감지가 written-name 텍스트 매칭에 의존해 같은 모듈의 `Lazy` / `Provider` 선언이나 alias가 있을 때 조용히 오동작할 여지가 있었습니다.

## 영향
- `with:`는 기존처럼 same-name subset/reorder shorthand로 유지되고, remapping은 `bindings:`로 명시적으로 표현됩니다.
- `.shared` sub-container에서 `bindings.parent`가 `.transient`를 가리키는 경우도 기존 제약과 동일하게 진단합니다.
- bare `Lazy<T>` / `Provider<T>`가 same-module 선언과 충돌하면 `InnoDI.Lazy<T>` / `InnoDI.Provider<T>`로 qualification을 요구합니다.
- `InnoDI.Lazy` / `InnoDI.Provider`에 대한 typealias는 더 이상 허용하지 않고 직접 표기를 요구합니다.

## 검증
- `swift test`
