### PR TITLE
[codex] ValidationCoordinator lock/backoff 견고화 및 test warning 정리

### DIFF
--- a/Sources/InnoDIBuildSupport/ValidationCoordinator.swift
+++ b/Sources/InnoDIBuildSupport/ValidationCoordinator.swift
@@ -63,7 +63,8 @@ package struct ValidationCoordinatorRuntime: Sendable {
         currentDate: Date.init,
         sleep: { Thread.sleep(forTimeInterval: $0) },
         currentProcessID: { getpid() },
-        processExists: validationProcessExists
+        processExists: validationProcessExists,
+        beforeStaleLockRemoval: { _ in }
     )
 
     package let monotonicNow: @Sendable () -> TimeInterval
@@ -71,19 +72,22 @@ package struct ValidationCoordinatorRuntime: Sendable {
     package let sleep: @Sendable (TimeInterval) -> Void
     package let currentProcessID: @Sendable () -> Int32
     package let processExists: @Sendable (Int32) -> Bool
+    package let beforeStaleLockRemoval: @Sendable (URL) -> Void
 
     package init(
         monotonicNow: @escaping @Sendable () -> TimeInterval,
         currentDate: @escaping @Sendable () -> Date,
         sleep: @escaping @Sendable (TimeInterval) -> Void,
         currentProcessID: @escaping @Sendable () -> Int32,
-        processExists: @escaping @Sendable (Int32) -> Bool
+        processExists: @escaping @Sendable (Int32) -> Bool,
+        beforeStaleLockRemoval: @escaping @Sendable (URL) -> Void = { _ in }
     ) {
         self.monotonicNow = monotonicNow
         self.currentDate = currentDate
         self.sleep = sleep
         self.currentProcessID = currentProcessID
         self.processExists = processExists
+        self.beforeStaleLockRemoval = beforeStaleLockRemoval
     }
 }
 
@@ -241,106 +245,124 @@ package enum ValidationCoordinator {
             return try finalizeOutcome(result: cachedResult, wasCached: true, sharedRunRecord: sharedRunRecord)
         }
 
-        let lockAcquisitionDeadline = runtime.monotonicNow() + lockPolicy.maxWaitSeconds
-        var backoffSeconds = lockPolicy.initialBackoffSeconds
-        var recoveredStaleLock = false
-
-        while runtime.monotonicNow() < lockAcquisitionDeadline {
+        func executeLockedValidation(
+            descriptor lockDescriptor: Int32,
+            recoveredStaleLock: Bool
+        ) throws -> ValidationExecutionOutcome {
             let lockMetadata = ValidationCoordinatorLockMetadata(
                 pid: runtime.currentProcessID(),
                 createdAt: runtime.currentDate().timeIntervalSince1970
             )
 
-            if let lockDescriptor = try acquireLock(at: lockURL) {
-                do {
-                    try persistLockMetadata(lockMetadata, descriptor: lockDescriptor, path: lockURL.path(percentEncoded: false))
-                } catch {
-                    releaseLock(descriptor: lockDescriptor, at: lockURL)
-                    throw error
-                }
-                defer { releaseLock(descriptor: lockDescriptor, at: lockURL) }
+            do {
+                try persistLockMetadata(lockMetadata, descriptor: lockDescriptor, path: lockURL.path(percentEncoded: false))
+            } catch {
+                releaseLock(descriptor: lockDescriptor, at: lockURL)
+                throw error
+            }
+            defer { releaseLock(descriptor: lockDescriptor, at: lockURL) }
 
-                if let (cachedResult, sharedRunRecord) = loadCachedSharedRun(
-                    resultURL: resultURL,
-                    sharedRunRecordURL: sharedRunRecordURL
-                ) {
-                    return try finalizeOutcome(result: cachedResult, wasCached: true, sharedRunRecord: sharedRunRecord)
-                }
-
-                let result: ValidationCommandResult
-                let customInitStartTime = validationNow()
-                let customInitValidation = try CustomInitBuildValidator.validate(rootPath: rootPath)
-                let customInitFailure = customInitValidation.asCommandResult()
-                let customInitValidationMilliseconds = validationElapsedMilliseconds(since: customInitStartTime)
-
-                let semanticValidationMilliseconds: Double
-                let dagValidationMilliseconds: Double
-                var liveRunReasonCodes: [ValidationReasonCode] = recoveredStaleLock
-                    ? [.staleLockRecovered]
-                    : []
-                let issues: [ValidationIssue]
-                if let customInitFailure {
-                    result = customInitFailure
-                    semanticValidationMilliseconds = 0
-                    dagValidationMilliseconds = 0
-                    liveRunReasonCodes.append(.liveRunCustomInitFailure)
-                    issues = customInitValidation.issues
-                } else {
-                    let semanticValidationStartTime = validationNow()
-                    let semanticValidation = try ContainerSemanticBuildValidator.validate(rootPath: rootPath)
-                    let semanticFailure = semanticValidation.asCommandResult()
-                    semanticValidationMilliseconds = validationElapsedMilliseconds(since: semanticValidationStartTime)
-
-                    if let semanticFailure {
-                        result = semanticFailure
-                        dagValidationMilliseconds = 0
-                        liveRunReasonCodes.append(.liveRunSemanticFailure)
-                        issues = semanticValidation.issues
-                    } else {
-                        let dagValidationStartTime = validationNow()
-                        result = try runner.runValidationTool(toolPath: toolPath, rootPath: rootPath)
-                        dagValidationMilliseconds = validationElapsedMilliseconds(since: dagValidationStartTime)
-                        liveRunReasonCodes.append(.liveRunSemanticValidation)
-                        liveRunReasonCodes.append(.liveRunDAGValidation)
-                        issues = semanticValidation.issues
-                    }
-                }
-
-                let sharedRunRecord = SharedValidationRunRecord(
-                    liveRunMetrics: ValidationLiveRunMetrics(
-                        customInitValidationMilliseconds: customInitValidationMilliseconds,
-                        semanticValidationMilliseconds: semanticValidationMilliseconds,
-                        dagValidationMilliseconds: dagValidationMilliseconds
-                    ),
-                    reasonCodes: liveRunReasonCodes,
-                    issues: issues
-                )
-                try persistSharedRunRecord(sharedRunRecord, to: sharedRunRecordURL)
-                try persistResult(result, to: resultURL)
-                let sharedArtifact = ValidationMetricsArtifact(
-                    signature: signature,
-                    wasCached: false,
-                    resultExitCode: result.exitCode,
-                    reasonCodes: Array(Set(signatureCollection.reasonCodes + liveRunReasonCodes)).sorted { $0.rawValue < $1.rawValue },
-                    signatureMetrics: signatureCollection.metrics,
-                    fileChanges: signatureCollection.fileChanges,
-                    invocationMetrics: ValidationInvocationMetrics(
-                        signatureCollectionMilliseconds: signatureCollectionMilliseconds,
-                        totalCoordinatorMilliseconds: validationElapsedMilliseconds(since: coordinatorStartTime)
-                    ),
-                    liveRunMetrics: sharedRunRecord.liveRunMetrics,
-                    issues: issues,
-                    humanSummarySource: "validation-summary.md"
-                )
-                try persistSummaryReport(
-                    ValidationLogging.renderMarkdownSummary(for: sharedArtifact),
-                    to: sharedSummaryURL
-                )
-
-                return try finalizeOutcome(result: result, wasCached: false, sharedRunRecord: sharedRunRecord)
+            if let (cachedResult, sharedRunRecord) = loadCachedSharedRun(
+                resultURL: resultURL,
+                sharedRunRecordURL: sharedRunRecordURL
+            ) {
+                return try finalizeOutcome(result: cachedResult, wasCached: true, sharedRunRecord: sharedRunRecord)
             }
 
-            if recoverStaleLockIfNeeded(
+            let result: ValidationCommandResult
+            let customInitStartTime = validationNow()
+            let customInitValidation = try CustomInitBuildValidator.validate(rootPath: rootPath)
+            let customInitFailure = customInitValidation.asCommandResult()
+            let customInitValidationMilliseconds = validationElapsedMilliseconds(since: customInitStartTime)
+
+            let semanticValidationMilliseconds: Double
+            let dagValidationMilliseconds: Double
+            var liveRunReasonCodes: [ValidationReasonCode] = recoveredStaleLock
+                ? [.staleLockRecovered]
+                : []
+            let issues: [ValidationIssue]
+            if let customInitFailure {
+                result = customInitFailure
+                semanticValidationMilliseconds = 0
+                dagValidationMilliseconds = 0
+                liveRunReasonCodes.append(.liveRunCustomInitFailure)
+                issues = customInitValidation.issues
+            } else {
+                let semanticValidationStartTime = validationNow()
+                let semanticValidation = try ContainerSemanticBuildValidator.validate(rootPath: rootPath)
+                let semanticFailure = semanticValidation.asCommandResult()
+                semanticValidationMilliseconds = validationElapsedMilliseconds(since: semanticValidationStartTime)
+
+                if let semanticFailure {
+                    result = semanticFailure
+                    dagValidationMilliseconds = 0
+                    liveRunReasonCodes.append(.liveRunSemanticFailure)
+                    issues = semanticValidation.issues
+                } else {
+                    let dagValidationStartTime = validationNow()
+                    result = try runner.runValidationTool(toolPath: toolPath, rootPath: rootPath)
+                    dagValidationMilliseconds = validationElapsedMilliseconds(since: dagValidationStartTime)
+                    liveRunReasonCodes.append(.liveRunSemanticValidation)
+                    liveRunReasonCodes.append(.liveRunDAGValidation)
+                    issues = semanticValidation.issues
+                }
+            }
+
+            let sharedRunRecord = SharedValidationRunRecord(
+                liveRunMetrics: ValidationLiveRunMetrics(
+                    customInitValidationMilliseconds: customInitValidationMilliseconds,
+                    semanticValidationMilliseconds: semanticValidationMilliseconds,
+                    dagValidationMilliseconds: dagValidationMilliseconds
+                ),
+                reasonCodes: liveRunReasonCodes,
+                issues: issues
+            )
+            try persistSharedRunRecord(sharedRunRecord, to: sharedRunRecordURL)
+            try persistResult(result, to: resultURL)
+            let sharedArtifact = ValidationMetricsArtifact(
+                signature: signature,
+                wasCached: false,
+                resultExitCode: result.exitCode,
+                reasonCodes: Array(Set(signatureCollection.reasonCodes + liveRunReasonCodes)).sorted { $0.rawValue < $1.rawValue },
+                signatureMetrics: signatureCollection.metrics,
+                fileChanges: signatureCollection.fileChanges,
+                invocationMetrics: ValidationInvocationMetrics(
+                    signatureCollectionMilliseconds: signatureCollectionMilliseconds,
+                    totalCoordinatorMilliseconds: validationElapsedMilliseconds(since: coordinatorStartTime)
+                ),
+                liveRunMetrics: sharedRunRecord.liveRunMetrics,
+                issues: issues,
+                humanSummarySource: "validation-summary.md"
+            )
+            try persistSummaryReport(
+                ValidationLogging.renderMarkdownSummary(for: sharedArtifact),
+                to: sharedSummaryURL
+            )
+
+            return try finalizeOutcome(result: result, wasCached: false, sharedRunRecord: sharedRunRecord)
+        }
+
+        func acquireAndExecuteLiveValidation(recoveredStaleLock: Bool) throws -> ValidationExecutionOutcome? {
+            guard let lockDescriptor = try acquireLock(at: lockURL) else {
+                return nil
+            }
+
+            return try executeLockedValidation(
+                descriptor: lockDescriptor,
+                recoveredStaleLock: recoveredStaleLock
+            )
+        }
+
+        let lockAcquisitionDeadline = runtime.monotonicNow() + lockPolicy.maxWaitSeconds
+        var backoffSeconds = lockPolicy.initialBackoffSeconds
+        var recoveredStaleLock = false
+
+        while runtime.monotonicNow() < lockAcquisitionDeadline {
+            if let outcome = try acquireAndExecuteLiveValidation(recoveredStaleLock: recoveredStaleLock) {
+                return outcome
+            }
+
+            if try recoverStaleLockIfNeeded(
                 at: lockURL,
                 staleLockAgeSeconds: lockPolicy.staleLockAgeSeconds,
                 runtime: runtime
@@ -365,6 +387,32 @@ package enum ValidationCoordinator {
             let delaySeconds = min(backoffSeconds, remainingWait)
             runtime.sleep(delaySeconds)
             backoffSeconds = min(backoffSeconds * 2, lockPolicy.maxBackoffSeconds)
+        }
+
+        if let (cachedResult, sharedRunRecord) = loadCachedSharedRun(
+            resultURL: resultURL,
+            sharedRunRecordURL: sharedRunRecordURL
+        ) {
+            return try finalizeOutcome(result: cachedResult, wasCached: true, sharedRunRecord: sharedRunRecord)
+        }
+
+        if try recoverStaleLockIfNeeded(
+            at: lockURL,
+            staleLockAgeSeconds: lockPolicy.staleLockAgeSeconds,
+            runtime: runtime
+        ) {
+            recoveredStaleLock = true
+        }
+
+        if let (cachedResult, sharedRunRecord) = loadCachedSharedRun(
+            resultURL: resultURL,
+            sharedRunRecordURL: sharedRunRecordURL
+        ) {
+            return try finalizeOutcome(result: cachedResult, wasCached: true, sharedRunRecord: sharedRunRecord)
+        }
+
+        if let outcome = try acquireAndExecuteLiveValidation(recoveredStaleLock: recoveredStaleLock) {
+            return outcome
         }
 
         let timeoutReasonCodes: [ValidationReasonCode] = recoveredStaleLock
@@ -531,9 +579,19 @@ private func recoverStaleLockIfNeeded(
     at url: URL,
     staleLockAgeSeconds: TimeInterval,
     runtime: ValidationCoordinatorRuntime
-) -> Bool {
+) throws -> Bool {
     let fileManager = FileManager.default
     let path = url.path(percentEncoded: false)
+
+    guard fileManager.fileExists(atPath: path) else {
+        return false
+    }
+
+    let recoveryTokenURL = url.appendingPathExtension("recovering")
+    guard let recoveryDescriptor = try acquireLock(at: recoveryTokenURL) else {
+        return false
+    }
+    defer { releaseLock(descriptor: recoveryDescriptor, at: recoveryTokenURL) }
 
     guard fileManager.fileExists(atPath: path) else {
         return false
@@ -543,6 +601,7 @@ private func recoverStaleLockIfNeeded(
         guard runtime.processExists(metadata.pid) == false else {
             return false
         }
+        runtime.beforeStaleLockRemoval(url)
         try? fileManager.removeItem(at: url)
         return fileManager.fileExists(atPath: path) == false
     }
@@ -554,6 +613,7 @@ private func recoverStaleLockIfNeeded(
         return false
     }
 
+    runtime.beforeStaleLockRemoval(url)
     try? fileManager.removeItem(at: url)
     return fileManager.fileExists(atPath: path) == false
 }

--- a/Sources/InnoDIBuildSupport/ValidationCoordinator.swift
+++ b/Sources/InnoDIBuildSupport/ValidationCoordinator.swift
@@ -36,6 +36,62 @@ package struct SharedValidationRunRecord: Codable, Equatable, Sendable {
     package let issues: [ValidationIssue]
 }
 
+package struct ValidationCoordinatorLockPolicy: Sendable {
+    package static let `default` = Self()
+
+    package let maxWaitSeconds: TimeInterval
+    package let staleLockAgeSeconds: TimeInterval
+    package let initialBackoffSeconds: TimeInterval
+    package let maxBackoffSeconds: TimeInterval
+
+    package init(
+        maxWaitSeconds: TimeInterval = 30,
+        staleLockAgeSeconds: TimeInterval = 30,
+        initialBackoffSeconds: TimeInterval = 0.05,
+        maxBackoffSeconds: TimeInterval = 0.5
+    ) {
+        self.maxWaitSeconds = maxWaitSeconds
+        self.staleLockAgeSeconds = staleLockAgeSeconds
+        self.initialBackoffSeconds = initialBackoffSeconds
+        self.maxBackoffSeconds = maxBackoffSeconds
+    }
+}
+
+package struct ValidationCoordinatorRuntime: Sendable {
+    package static let live = Self(
+        monotonicNow: validationNow,
+        currentDate: Date.init,
+        sleep: { Thread.sleep(forTimeInterval: $0) },
+        currentProcessID: { getpid() },
+        processExists: validationProcessExists
+    )
+
+    package let monotonicNow: @Sendable () -> TimeInterval
+    package let currentDate: @Sendable () -> Date
+    package let sleep: @Sendable (TimeInterval) -> Void
+    package let currentProcessID: @Sendable () -> Int32
+    package let processExists: @Sendable (Int32) -> Bool
+
+    package init(
+        monotonicNow: @escaping @Sendable () -> TimeInterval,
+        currentDate: @escaping @Sendable () -> Date,
+        sleep: @escaping @Sendable (TimeInterval) -> Void,
+        currentProcessID: @escaping @Sendable () -> Int32,
+        processExists: @escaping @Sendable (Int32) -> Bool
+    ) {
+        self.monotonicNow = monotonicNow
+        self.currentDate = currentDate
+        self.sleep = sleep
+        self.currentProcessID = currentProcessID
+        self.processExists = processExists
+    }
+}
+
+package struct ValidationCoordinatorLockMetadata: Codable, Equatable, Sendable {
+    package let pid: Int32
+    package let createdAt: TimeInterval
+}
+
 package let sharedRunCacheVersion = 1
 
 package func sharedRunCacheKey(for signature: String) -> String {
@@ -104,7 +160,9 @@ package enum ValidationCoordinator {
         stateDirectoryPath: String,
         outputDirectoryPath: String,
         runner: Runner,
-        verboseLoggingEnabled: Bool = ValidationLogging.isVerboseEnabled()
+        verboseLoggingEnabled: Bool = ValidationLogging.isVerboseEnabled(),
+        lockPolicy: ValidationCoordinatorLockPolicy = .default,
+        runtime: ValidationCoordinatorRuntime = .live
     ) throws -> ValidationExecutionOutcome {
         let coordinatorStartTime = validationNow()
         let fileManager = FileManager.default
@@ -183,8 +241,23 @@ package enum ValidationCoordinator {
             return try finalizeOutcome(result: cachedResult, wasCached: true, sharedRunRecord: sharedRunRecord)
         }
 
-        while true {
+        let lockAcquisitionDeadline = runtime.monotonicNow() + lockPolicy.maxWaitSeconds
+        var backoffSeconds = lockPolicy.initialBackoffSeconds
+        var recoveredStaleLock = false
+
+        while runtime.monotonicNow() < lockAcquisitionDeadline {
+            let lockMetadata = ValidationCoordinatorLockMetadata(
+                pid: runtime.currentProcessID(),
+                createdAt: runtime.currentDate().timeIntervalSince1970
+            )
+
             if let lockDescriptor = try acquireLock(at: lockURL) {
+                do {
+                    try persistLockMetadata(lockMetadata, descriptor: lockDescriptor, path: lockURL.path(percentEncoded: false))
+                } catch {
+                    releaseLock(descriptor: lockDescriptor, at: lockURL)
+                    throw error
+                }
                 defer { releaseLock(descriptor: lockDescriptor, at: lockURL) }
 
                 if let (cachedResult, sharedRunRecord) = loadCachedSharedRun(
@@ -202,13 +275,15 @@ package enum ValidationCoordinator {
 
                 let semanticValidationMilliseconds: Double
                 let dagValidationMilliseconds: Double
-                let liveRunReasonCodes: [ValidationReasonCode]
+                var liveRunReasonCodes: [ValidationReasonCode] = recoveredStaleLock
+                    ? [.staleLockRecovered]
+                    : []
                 let issues: [ValidationIssue]
                 if let customInitFailure {
                     result = customInitFailure
                     semanticValidationMilliseconds = 0
                     dagValidationMilliseconds = 0
-                    liveRunReasonCodes = [.liveRunCustomInitFailure]
+                    liveRunReasonCodes.append(.liveRunCustomInitFailure)
                     issues = customInitValidation.issues
                 } else {
                     let semanticValidationStartTime = validationNow()
@@ -219,13 +294,14 @@ package enum ValidationCoordinator {
                     if let semanticFailure {
                         result = semanticFailure
                         dagValidationMilliseconds = 0
-                        liveRunReasonCodes = [.liveRunSemanticFailure]
+                        liveRunReasonCodes.append(.liveRunSemanticFailure)
                         issues = semanticValidation.issues
                     } else {
                         let dagValidationStartTime = validationNow()
                         result = try runner.runValidationTool(toolPath: toolPath, rootPath: rootPath)
                         dagValidationMilliseconds = validationElapsedMilliseconds(since: dagValidationStartTime)
-                        liveRunReasonCodes = [.liveRunSemanticValidation, .liveRunDAGValidation]
+                        liveRunReasonCodes.append(.liveRunSemanticValidation)
+                        liveRunReasonCodes.append(.liveRunDAGValidation)
                         issues = semanticValidation.issues
                     }
                 }
@@ -264,14 +340,55 @@ package enum ValidationCoordinator {
                 return try finalizeOutcome(result: result, wasCached: false, sharedRunRecord: sharedRunRecord)
             }
 
-            if let (cachedResult, sharedRunRecord) = waitForCachedSharedRun(
+            if recoverStaleLockIfNeeded(
+                at: lockURL,
+                staleLockAgeSeconds: lockPolicy.staleLockAgeSeconds,
+                runtime: runtime
+            ) {
+                recoveredStaleLock = true
+                backoffSeconds = lockPolicy.initialBackoffSeconds
+                continue
+            }
+
+            if let (cachedResult, sharedRunRecord) = loadCachedSharedRun(
                 resultURL: resultURL,
-                sharedRunRecordURL: sharedRunRecordURL,
-                lockURL: lockURL
+                sharedRunRecordURL: sharedRunRecordURL
             ) {
                 return try finalizeOutcome(result: cachedResult, wasCached: true, sharedRunRecord: sharedRunRecord)
             }
+
+            let remainingWait = lockAcquisitionDeadline - runtime.monotonicNow()
+            guard remainingWait > 0 else {
+                break
+            }
+
+            let delaySeconds = min(backoffSeconds, remainingWait)
+            runtime.sleep(delaySeconds)
+            backoffSeconds = min(backoffSeconds * 2, lockPolicy.maxBackoffSeconds)
         }
+
+        let timeoutReasonCodes: [ValidationReasonCode] = recoveredStaleLock
+            ? [.staleLockRecovered, .lockContentionTimeout]
+            : [.lockContentionTimeout]
+        let timeoutRecord = SharedValidationRunRecord(
+            liveRunMetrics: ValidationLiveRunMetrics(
+                customInitValidationMilliseconds: 0,
+                semanticValidationMilliseconds: 0,
+                dagValidationMilliseconds: 0
+            ),
+            reasonCodes: timeoutReasonCodes,
+            issues: []
+        )
+        let timeoutResult = ValidationCommandResult(
+            exitCode: 1,
+            stdout: "",
+            stderr: "Timed out waiting for validation coordinator lock at '\(lockURL.path(percentEncoded: false))' after \(formatSeconds(lockPolicy.maxWaitSeconds))s.\n"
+        )
+        return try finalizeOutcome(
+            result: timeoutResult,
+            wasCached: false,
+            sharedRunRecord: timeoutRecord
+        )
     }
 }
 
@@ -359,6 +476,35 @@ private func acquireLock(at url: URL) throws -> Int32? {
     throw POSIXLockError(code: errno, path: path)
 }
 
+private func persistLockMetadata(
+    _ metadata: ValidationCoordinatorLockMetadata,
+    descriptor: Int32,
+    path: String
+) throws {
+    let data = try JSONEncoder().encode(metadata)
+    let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: false)
+    do {
+        try handle.truncate(atOffset: 0)
+        try handle.seek(toOffset: 0)
+        try handle.write(contentsOf: data)
+        try handle.synchronize()
+    } catch {
+        throw ValidationCoordinatorIOError(path: path, operation: "write lock metadata", underlying: error)
+    }
+}
+
+private func loadLockMetadata(at url: URL) -> ValidationCoordinatorLockMetadata? {
+    guard
+        let data = try? Data(contentsOf: url),
+        let metadata = try? JSONDecoder().decode(ValidationCoordinatorLockMetadata.self, from: data),
+        metadata.pid > 0
+    else {
+        return nil
+    }
+
+    return metadata
+}
+
 private func releaseLock(descriptor: Int32, at url: URL) {
     close(descriptor)
     try? FileManager.default.removeItem(at: url)
@@ -381,29 +527,48 @@ private func pruneSharedRunDirectories(keepingDirectoryName directoryName: Strin
     }
 }
 
-private func waitForCachedSharedRun(
-    resultURL: URL,
-    sharedRunRecordURL: URL,
-    lockURL: URL
-) -> (result: ValidationCommandResult, record: SharedValidationRunRecord)? {
-    let timeoutDate = Date().addingTimeInterval(30)
+private func recoverStaleLockIfNeeded(
+    at url: URL,
+    staleLockAgeSeconds: TimeInterval,
+    runtime: ValidationCoordinatorRuntime
+) -> Bool {
+    let fileManager = FileManager.default
+    let path = url.path(percentEncoded: false)
 
-    while Date() < timeoutDate {
-        if let cachedSharedRun = loadCachedSharedRun(
-            resultURL: resultURL,
-            sharedRunRecordURL: sharedRunRecordURL
-        ) {
-            return cachedSharedRun
-        }
-
-        if !FileManager.default.fileExists(atPath: lockURL.path(percentEncoded: false)) {
-            return nil
-        }
-
-        Thread.sleep(forTimeInterval: 0.05)
+    guard fileManager.fileExists(atPath: path) else {
+        return false
     }
 
-    return nil
+    if let metadata = loadLockMetadata(at: url) {
+        guard runtime.processExists(metadata.pid) == false else {
+            return false
+        }
+        try? fileManager.removeItem(at: url)
+        return fileManager.fileExists(atPath: path) == false
+    }
+
+    guard
+        let ageSeconds = lockFileAgeSeconds(at: path, now: runtime.currentDate()),
+        ageSeconds >= staleLockAgeSeconds
+    else {
+        return false
+    }
+
+    try? fileManager.removeItem(at: url)
+    return fileManager.fileExists(atPath: path) == false
+}
+
+private func lockFileAgeSeconds(at path: String, now: Date) -> TimeInterval? {
+    guard let attributes = try? FileManager.default.attributesOfItem(atPath: path) else {
+        return nil
+    }
+
+    let referenceDate = (attributes[.modificationDate] as? Date) ?? (attributes[.creationDate] as? Date)
+    guard let referenceDate else {
+        return nil
+    }
+
+    return max(0, now.timeIntervalSince(referenceDate))
 }
 
 private struct POSIXLockError: LocalizedError {
@@ -412,6 +577,16 @@ private struct POSIXLockError: LocalizedError {
 
     var errorDescription: String? {
         "Failed to acquire validation lock at '\(path)' (errno: \(code))."
+    }
+}
+
+private struct ValidationCoordinatorIOError: LocalizedError {
+    let path: String
+    let operation: String
+    let underlying: Error
+
+    var errorDescription: String? {
+        "Failed to \(operation) at '\(path)': \(underlying.localizedDescription)"
     }
 }
 
@@ -434,6 +609,23 @@ private final class LockedDataBuffer: @unchecked Sendable {
         storage.append(chunk)
         lock.unlock()
     }
+}
+
+private func validationProcessExists(_ pid: Int32) -> Bool {
+    guard pid > 0 else {
+        return false
+    }
+
+    let result = kill(pid, 0)
+    if result == 0 {
+        return true
+    }
+
+    return errno == EPERM
+}
+
+private func formatSeconds(_ value: TimeInterval) -> String {
+    String(format: "%.2f", value)
 }
 
 private func installReadHandler(on handle: FileHandle, buffer: LockedDataBuffer) {

--- a/Sources/InnoDIBuildSupport/ValidationMetrics.swift
+++ b/Sources/InnoDIBuildSupport/ValidationMetrics.swift
@@ -7,6 +7,8 @@ package enum ValidationReasonCode: String, Codable, Equatable, Sendable {
     case cacheMissNewFile = "cache-miss-new-file"
     case cacheMissDeletedFile = "cache-miss-deleted-file"
     case cacheMissManifestVersion = "cache-miss-manifest-version"
+    case staleLockRecovered = "stale-lock-recovered"
+    case lockContentionTimeout = "lock-contention-timeout"
     case liveRunCustomInitFailure = "live-run-custom-init-failure"
     case liveRunSemanticValidation = "live-run-semantic-validation"
     case liveRunSemanticFailure = "live-run-semantic-failure"
@@ -237,6 +239,10 @@ private func reasonDescription(_ reason: ValidationReasonCode) -> String {
         return "A previously cached Swift source file disappeared and forced a signature recomputation."
     case .cacheMissManifestVersion:
         return "The AST digest manifest version changed, so the cache was rebuilt from scratch."
+    case .staleLockRecovered:
+        return "A stale validation coordinator lock was detected and removed before the live run continued."
+    case .lockContentionTimeout:
+        return "The validation coordinator timed out waiting for an active lock to clear."
     case .liveRunCustomInitFailure:
         return "The live validation run stopped after a structured cross-file custom init failure."
     case .liveRunSemanticValidation:

--- a/Tests/InnoDIBuildSupportTests/ValidationCoordinatorTests.swift
+++ b/Tests/InnoDIBuildSupportTests/ValidationCoordinatorTests.swift
@@ -710,6 +710,170 @@ struct ValidationCoordinatorTests {
         #expect(repairedRecord.liveRunMetrics.semanticValidationMilliseconds >= 0)
     }
 
+    @Test("Dead-owner lock files are recovered before live validation continues")
+    func deadOwnerLockIsRecoveredBeforeLiveValidation() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let signature = try collectValidationSignature(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false)
+        )
+        let sharedRunDirectory = fixture.stateURL.appendingPathComponent(
+            sharedRunCacheKey(for: signature),
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: sharedRunDirectory, withIntermediateDirectories: true)
+
+        let clock = ManualValidationCoordinatorClock(
+            startUptime: 100,
+            startDate: Date(timeIntervalSince1970: 10_000)
+        )
+        try persistJSON(
+            ValidationCoordinatorLockMetadata(
+                pid: 1111,
+                createdAt: clock.currentDate.addingTimeInterval(-120).timeIntervalSince1970
+            ),
+            to: sharedRunDirectory.appendingPathComponent("lock")
+        )
+
+        let runner = MockValidationRunner(
+            results: [
+                ValidationCommandResult(exitCode: 0, stdout: "DAG validation passed.\n", stderr: "")
+            ]
+        )
+
+        let outcome = try ValidationCoordinator.coordinate(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            toolPath: "/usr/bin/true",
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            outputDirectoryPath: fixture.outputAURL.path(percentEncoded: false),
+            runner: runner,
+            lockPolicy: .default,
+            runtime: makeTestRuntime(clock: clock, currentPID: 4242, activePIDs: [4242])
+        )
+
+        #expect(outcome.result.exitCode == 0)
+        #expect(outcome.metricsArtifact.reasonCodes.contains(.staleLockRecovered))
+        #expect(outcome.metricsArtifact.reasonCodes.contains(.liveRunDAGValidation))
+        #expect(runner.invocationCount == 1)
+        #expect(clock.sleptDurations.isEmpty)
+    }
+
+    @Test("Corrupt legacy lock files older than the stale threshold are recovered")
+    func corruptLegacyLockFileIsRecovered() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let signature = try collectValidationSignature(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false)
+        )
+        let sharedRunDirectory = fixture.stateURL.appendingPathComponent(
+            sharedRunCacheKey(for: signature),
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: sharedRunDirectory, withIntermediateDirectories: true)
+
+        let clock = ManualValidationCoordinatorClock(
+            startUptime: 50,
+            startDate: Date(timeIntervalSince1970: 20_000)
+        )
+        let lockURL = sharedRunDirectory.appendingPathComponent("lock")
+        try Data("legacy-lock".utf8).write(to: lockURL, options: .atomic)
+        try touch(lockURL, modifiedAt: clock.currentDate.addingTimeInterval(-120))
+
+        let runner = MockValidationRunner(
+            results: [
+                ValidationCommandResult(exitCode: 0, stdout: "DAG validation passed.\n", stderr: "")
+            ]
+        )
+
+        let outcome = try ValidationCoordinator.coordinate(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            toolPath: "/usr/bin/true",
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            outputDirectoryPath: fixture.outputAURL.path(percentEncoded: false),
+            runner: runner,
+            lockPolicy: .default,
+            runtime: makeTestRuntime(clock: clock, currentPID: 4242, activePIDs: [4242])
+        )
+
+        #expect(outcome.result.exitCode == 0)
+        #expect(outcome.metricsArtifact.reasonCodes.contains(.staleLockRecovered))
+        #expect(runner.invocationCount == 1)
+        #expect(clock.sleptDurations.isEmpty)
+    }
+
+    @Test("Active locks time out predictably instead of retrying indefinitely")
+    func activeLockTimesOutPredictably() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let signature = try collectValidationSignature(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false)
+        )
+        let sharedRunDirectory = fixture.stateURL.appendingPathComponent(
+            sharedRunCacheKey(for: signature),
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: sharedRunDirectory, withIntermediateDirectories: true)
+
+        let clock = ManualValidationCoordinatorClock(
+            startUptime: 10,
+            startDate: Date(timeIntervalSince1970: 30_000)
+        )
+        try persistJSON(
+            ValidationCoordinatorLockMetadata(
+                pid: 1111,
+                createdAt: clock.currentDate.timeIntervalSince1970
+            ),
+            to: sharedRunDirectory.appendingPathComponent("lock")
+        )
+
+        let runner = MockValidationRunner(
+            results: [
+                ValidationCommandResult(exitCode: 0, stdout: "unexpected\n", stderr: "")
+            ]
+        )
+        let policy = ValidationCoordinatorLockPolicy(
+            maxWaitSeconds: 0.3,
+            staleLockAgeSeconds: 0.1,
+            initialBackoffSeconds: 0.05,
+            maxBackoffSeconds: 0.2
+        )
+
+        let outcome = try ValidationCoordinator.coordinate(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            toolPath: "/usr/bin/true",
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            outputDirectoryPath: fixture.outputAURL.path(percentEncoded: false),
+            runner: runner,
+            lockPolicy: policy,
+            runtime: makeTestRuntime(clock: clock, currentPID: 4242, activePIDs: [1111, 4242])
+        )
+
+        let summary = try String(
+            contentsOf: fixture.outputAURL.appendingPathComponent("dag-validation-summary.md"),
+            encoding: .utf8
+        )
+
+        #expect(outcome.wasCached == false)
+        #expect(outcome.result.exitCode == 1)
+        #expect(outcome.result.stderr.contains("Timed out waiting for validation coordinator lock"))
+        #expect(outcome.metricsArtifact.reasonCodes.contains(.lockContentionTimeout))
+        #expect(outcome.metricsArtifact.issues.isEmpty)
+        #expect(outcome.metricsArtifact.liveRunMetrics.customInitValidationMilliseconds == 0)
+        #expect(outcome.metricsArtifact.liveRunMetrics.semanticValidationMilliseconds == 0)
+        #expect(outcome.metricsArtifact.liveRunMetrics.dagValidationMilliseconds == 0)
+        #expect(summary.contains("lock-contention-timeout"))
+        #expect(summary.contains("timed out waiting for an active lock"))
+        #expect(clock.sleptDurations.count == 3)
+        #expect(clock.totalSlept >= policy.maxWaitSeconds)
+        #expect(runner.invocationCount == 0)
+    }
+
     @Test("Failure result is reused for identical input signature")
     func failureResultIsReused() throws {
         let fixture = try makeFixture()
@@ -1146,6 +1310,62 @@ private func makeTemporaryRoot() throws -> URL {
 
 private func touch(_ url: URL, modifiedAt: Date) throws {
     try FileManager.default.setAttributes([.modificationDate: modifiedAt], ofItemAtPath: url.path(percentEncoded: false))
+}
+
+private func makeTestRuntime(
+    clock: ManualValidationCoordinatorClock,
+    currentPID: Int32,
+    activePIDs: Set<Int32>
+) -> ValidationCoordinatorRuntime {
+    ValidationCoordinatorRuntime(
+        monotonicNow: { clock.monotonicNow },
+        currentDate: { clock.currentDate },
+        sleep: { interval in clock.sleep(interval) },
+        currentProcessID: { currentPID },
+        processExists: { activePIDs.contains($0) }
+    )
+}
+
+private final class ManualValidationCoordinatorClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var uptime: TimeInterval
+    private var date: Date
+    private var recordedSleeps: [TimeInterval] = []
+
+    init(startUptime: TimeInterval, startDate: Date) {
+        self.uptime = startUptime
+        self.date = startDate
+    }
+
+    var monotonicNow: TimeInterval {
+        lock.lock()
+        defer { lock.unlock() }
+        return uptime
+    }
+
+    var currentDate: Date {
+        lock.lock()
+        defer { lock.unlock() }
+        return date
+    }
+
+    var sleptDurations: [TimeInterval] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedSleeps
+    }
+
+    var totalSlept: TimeInterval {
+        sleptDurations.reduce(0, +)
+    }
+
+    func sleep(_ interval: TimeInterval) {
+        lock.lock()
+        uptime += interval
+        date = date.addingTimeInterval(interval)
+        recordedSleeps.append(interval)
+        lock.unlock()
+    }
 }
 
 private final class MockValidationRunner: ValidationCommandRunning, @unchecked Sendable {

--- a/Tests/InnoDIBuildSupportTests/ValidationCoordinatorTests.swift
+++ b/Tests/InnoDIBuildSupportTests/ValidationCoordinatorTests.swift
@@ -3,6 +3,7 @@ import InnoDICore
 import SwiftParser
 import SwiftSyntax
 import Testing
+import Dispatch
 
 @testable import InnoDIBuildSupport
 
@@ -754,8 +755,8 @@ struct ValidationCoordinatorTests {
         )
 
         #expect(outcome.result.exitCode == 0)
-        #expect(outcome.metricsArtifact.reasonCodes.contains(.staleLockRecovered))
-        #expect(outcome.metricsArtifact.reasonCodes.contains(.liveRunDAGValidation))
+        #expect(outcome.metricsArtifact.reasonCodes.contains(ValidationReasonCode.staleLockRecovered))
+        #expect(outcome.metricsArtifact.reasonCodes.contains(ValidationReasonCode.liveRunDAGValidation))
         #expect(runner.invocationCount == 1)
         #expect(clock.sleptDurations.isEmpty)
     }
@@ -800,9 +801,200 @@ struct ValidationCoordinatorTests {
         )
 
         #expect(outcome.result.exitCode == 0)
-        #expect(outcome.metricsArtifact.reasonCodes.contains(.staleLockRecovered))
+        #expect(outcome.metricsArtifact.reasonCodes.contains(ValidationReasonCode.staleLockRecovered))
         #expect(runner.invocationCount == 1)
         #expect(clock.sleptDurations.isEmpty)
+    }
+
+    @Test("Stale-lock recovery is serialized before a fresh live lock is acquired")
+    func staleLockRecoveryIsSerializedBeforeFreshLiveLock() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let signature = try collectValidationSignature(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false)
+        )
+        let sharedRunDirectory = fixture.stateURL.appendingPathComponent(
+            sharedRunCacheKey(for: signature),
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: sharedRunDirectory, withIntermediateDirectories: true)
+
+        let lockURL = sharedRunDirectory.appendingPathComponent("lock")
+        try persistJSON(
+            ValidationCoordinatorLockMetadata(
+                pid: 1111,
+                createdAt: Date().addingTimeInterval(-120).timeIntervalSince1970
+            ),
+            to: lockURL
+        )
+
+        let recoveryPointReached = LockedFlag()
+        let allowRecovery = DispatchSemaphore(value: 0)
+        let runner = MockValidationRunner(
+            results: [
+                ValidationCommandResult(exitCode: 0, stdout: "DAG validation passed.\n", stderr: "")
+            ],
+            delay: 0.2
+        )
+        let policy = ValidationCoordinatorLockPolicy(
+            maxWaitSeconds: 1,
+            staleLockAgeSeconds: 0.1,
+            initialBackoffSeconds: 0.01,
+            maxBackoffSeconds: 0.05
+        )
+
+        let runtimeA = ValidationCoordinatorRuntime(
+            monotonicNow: validationNow,
+            currentDate: Date.init,
+            sleep: { Thread.sleep(forTimeInterval: $0) },
+            currentProcessID: { 2001 },
+            processExists: { [2001, 2002].contains($0) },
+            beforeStaleLockRemoval: { _ in
+                recoveryPointReached.markTrue()
+                _ = allowRecovery.wait(timeout: .now() + .seconds(1))
+            }
+        )
+        let runtimeB = ValidationCoordinatorRuntime(
+            monotonicNow: validationNow,
+            currentDate: Date.init,
+            sleep: { Thread.sleep(forTimeInterval: $0) },
+            currentProcessID: { 2002 },
+            processExists: { [2001, 2002].contains($0) }
+        )
+
+        let outcomes = try await withThrowingTaskGroup(of: ValidationExecutionOutcome.self) { group in
+            group.addTask {
+                try ValidationCoordinator.coordinate(
+                    rootPath: fixture.rootURL.path(percentEncoded: false),
+                    toolPath: "/usr/bin/true",
+                    stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+                    outputDirectoryPath: fixture.outputAURL.path(percentEncoded: false),
+                    runner: runner,
+                    lockPolicy: policy,
+                    runtime: runtimeA
+                )
+            }
+
+            for _ in 0..<100 {
+                if recoveryPointReached.isSet {
+                    break
+                }
+                try await Task.sleep(for: .milliseconds(10))
+            }
+
+            #expect(recoveryPointReached.isSet)
+
+            group.addTask {
+                try ValidationCoordinator.coordinate(
+                    rootPath: fixture.rootURL.path(percentEncoded: false),
+                    toolPath: "/usr/bin/true",
+                    stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+                    outputDirectoryPath: fixture.outputBURL.path(percentEncoded: false),
+                    runner: runner,
+                    lockPolicy: policy,
+                    runtime: runtimeB
+                )
+            }
+
+            try await Task.sleep(for: .milliseconds(50))
+            allowRecovery.signal()
+
+            var collected: [ValidationExecutionOutcome] = []
+            for try await result in group {
+                collected.append(result)
+            }
+            return collected
+        }
+
+        #expect(outcomes.count == 2)
+        #expect(runner.invocationCount == 1)
+        #expect(outcomes.contains { !$0.wasCached })
+        #expect(outcomes.contains { $0.wasCached })
+        #expect(outcomes.allSatisfy { $0.result.exitCode == 0 })
+        #expect(outcomes.allSatisfy { $0.metricsArtifact.reasonCodes.contains(ValidationReasonCode.staleLockRecovered) })
+        #expect(FileManager.default.fileExists(atPath: lockURL.appendingPathExtension("recovering").path(percentEncoded: false)) == false)
+    }
+
+    @Test("Terminal reconciliation returns a cached result written during the final backoff")
+    func terminalReconciliationReturnsCachedResultWrittenDuringFinalBackoff() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.rootURL) }
+
+        let signature = try collectValidationSignature(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false)
+        )
+        let sharedRunDirectory = fixture.stateURL.appendingPathComponent(
+            sharedRunCacheKey(for: signature),
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: sharedRunDirectory, withIntermediateDirectories: true)
+
+        let policy = ValidationCoordinatorLockPolicy(
+            maxWaitSeconds: 0.3,
+            staleLockAgeSeconds: 0.1,
+            initialBackoffSeconds: 0.05,
+            maxBackoffSeconds: 0.2
+        )
+        let cachedResult = ValidationCommandResult(exitCode: 0, stdout: "cached\n", stderr: "")
+        let cachedRecord = SharedValidationRunRecord(
+            liveRunMetrics: ValidationLiveRunMetrics(
+                customInitValidationMilliseconds: 1,
+                semanticValidationMilliseconds: 2,
+                dagValidationMilliseconds: 3
+            ),
+            reasonCodes: [.liveRunSemanticValidation, .liveRunDAGValidation],
+            issues: []
+        )
+        let lockURL = sharedRunDirectory.appendingPathComponent("lock")
+        try persistJSON(
+            ValidationCoordinatorLockMetadata(
+                pid: 1111,
+                createdAt: Date(timeIntervalSince1970: 30_000).timeIntervalSince1970
+            ),
+            to: lockURL
+        )
+
+        let cacheWriteState = SleepThresholdState(threshold: policy.maxWaitSeconds)
+        let clock = ManualValidationCoordinatorClock(
+            startUptime: 10,
+            startDate: Date(timeIntervalSince1970: 30_000),
+            onSleep: { interval in
+                guard cacheWriteState.shouldTrigger(afterSleeping: interval) else {
+                    return
+                }
+
+                try! persistJSON(cachedRecord, to: sharedRunDirectory.appendingPathComponent("validation-metrics.json"))
+                try! persistJSON(cachedResult, to: sharedRunDirectory.appendingPathComponent("result.json"))
+                try? FileManager.default.removeItem(at: lockURL)
+            }
+        )
+
+        let runner = MockValidationRunner(
+            results: [
+                ValidationCommandResult(exitCode: 0, stdout: "unexpected\n", stderr: "")
+            ]
+        )
+
+        let outcome = try ValidationCoordinator.coordinate(
+            rootPath: fixture.rootURL.path(percentEncoded: false),
+            toolPath: "/usr/bin/true",
+            stateDirectoryPath: fixture.stateURL.path(percentEncoded: false),
+            outputDirectoryPath: fixture.outputAURL.path(percentEncoded: false),
+            runner: runner,
+            lockPolicy: policy,
+            runtime: makeTestRuntime(clock: clock, currentPID: 4242, activePIDs: [1111, 4242])
+        )
+
+        #expect(outcome.wasCached == true)
+        #expect(outcome.result == cachedResult)
+        #expect(outcome.metricsArtifact.reasonCodes.contains(ValidationReasonCode.liveRunSemanticValidation))
+        #expect(outcome.metricsArtifact.reasonCodes.contains(ValidationReasonCode.liveRunDAGValidation))
+        #expect(outcome.metricsArtifact.reasonCodes.contains(ValidationReasonCode.lockContentionTimeout) == false)
+        #expect(clock.sleptDurations.count == 3)
+        #expect(runner.invocationCount == 0)
     }
 
     @Test("Active locks time out predictably instead of retrying indefinitely")
@@ -862,7 +1054,7 @@ struct ValidationCoordinatorTests {
         #expect(outcome.wasCached == false)
         #expect(outcome.result.exitCode == 1)
         #expect(outcome.result.stderr.contains("Timed out waiting for validation coordinator lock"))
-        #expect(outcome.metricsArtifact.reasonCodes.contains(.lockContentionTimeout))
+        #expect(outcome.metricsArtifact.reasonCodes.contains(ValidationReasonCode.lockContentionTimeout))
         #expect(outcome.metricsArtifact.issues.isEmpty)
         #expect(outcome.metricsArtifact.liveRunMetrics.customInitValidationMilliseconds == 0)
         #expect(outcome.metricsArtifact.liveRunMetrics.semanticValidationMilliseconds == 0)
@@ -1315,24 +1507,32 @@ private func touch(_ url: URL, modifiedAt: Date) throws {
 private func makeTestRuntime(
     clock: ManualValidationCoordinatorClock,
     currentPID: Int32,
-    activePIDs: Set<Int32>
+    activePIDs: Set<Int32>,
+    beforeStaleLockRemoval: @escaping @Sendable (URL) -> Void = { _ in }
 ) -> ValidationCoordinatorRuntime {
     ValidationCoordinatorRuntime(
         monotonicNow: { clock.monotonicNow },
         currentDate: { clock.currentDate },
         sleep: { interval in clock.sleep(interval) },
         currentProcessID: { currentPID },
-        processExists: { activePIDs.contains($0) }
+        processExists: { activePIDs.contains($0) },
+        beforeStaleLockRemoval: beforeStaleLockRemoval
     )
 }
 
 private final class ManualValidationCoordinatorClock: @unchecked Sendable {
     private let lock = NSLock()
+    private let onSleep: (@Sendable (TimeInterval) -> Void)?
     private var uptime: TimeInterval
     private var date: Date
     private var recordedSleeps: [TimeInterval] = []
 
-    init(startUptime: TimeInterval, startDate: Date) {
+    init(
+        startUptime: TimeInterval,
+        startDate: Date,
+        onSleep: (@Sendable (TimeInterval) -> Void)? = nil
+    ) {
+        self.onSleep = onSleep
         self.uptime = startUptime
         self.date = startDate
     }
@@ -1364,7 +1564,51 @@ private final class ManualValidationCoordinatorClock: @unchecked Sendable {
         uptime += interval
         date = date.addingTimeInterval(interval)
         recordedSleeps.append(interval)
+        let onSleep = self.onSleep
         lock.unlock()
+
+        onSleep?(interval)
+    }
+}
+
+private final class LockedFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = false
+
+    var isSet: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+
+    func markTrue() {
+        lock.lock()
+        value = true
+        lock.unlock()
+    }
+}
+
+private final class SleepThresholdState: @unchecked Sendable {
+    private let lock = NSLock()
+    private let threshold: TimeInterval
+    private var totalSlept: TimeInterval = 0
+    private var didTrigger = false
+
+    init(threshold: TimeInterval) {
+        self.threshold = threshold
+    }
+
+    func shouldTrigger(afterSleeping interval: TimeInterval) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        totalSlept += interval
+        guard didTrigger == false, totalSlept >= threshold else {
+            return false
+        }
+
+        didTrigger = true
+        return true
     }
 }
 

--- a/Tests/InnoDIRuntimeTests/OverridesRuntimeTests.swift
+++ b/Tests/InnoDIRuntimeTests/OverridesRuntimeTests.swift
@@ -92,7 +92,7 @@ struct OverridesRuntimeTests {
     func withOverridesSyncThrowing() throws {
         struct E: Error {}
 
-        let tag = try RuntimeContainer.withOverrides(userID: "u1") { overrides in
+        let tag = RuntimeContainer.withOverrides(userID: "u1") { overrides in
             overrides.apiClient = MockAPIClient(value: "sync-throws")
         } operation: { container -> String in
             container.apiClient.tag()
@@ -122,7 +122,7 @@ struct OverridesRuntimeTests {
         let tag = try await RuntimeContainer.withOverrides(userID: "u1") { overrides in
             overrides.apiClient = MockAPIClient(value: "async-throws")
         } operation: { container -> String in
-            try await Task { container.apiClient.tag() }.value
+            await Task { container.apiClient.tag() }.value
         }
         #expect(tag == "async-throws")
     }


### PR DESCRIPTION
## 요약
- ValidationCoordinator의 lock 획득 경로에 stale lock 복구, bounded retry/backoff, deterministic timeout failure를 추가했습니다.
- lock metadata(pid, createdAt)를 기록하고 dead-owner / legacy lock recovery를 지원합니다.
- OverridesRuntimeTests의 불필요한 `try` 2건을 제거했습니다.

## 주요 변경
- `ValidationCoordinatorLockPolicy`, `ValidationCoordinatorRuntime`, `ValidationCoordinatorLockMetadata` 추가
- stale lock recovery 및 lock contention timeout reason code 추가
- lock contention timeout 시 metrics/summary/stamp를 포함한 명시적 failure outcome 반환
- ValidationCoordinator 테스트에 stale lock / legacy lock / active lock timeout 회귀 추가

## 검증
- `swift test --package-path /Users/changwoo.son/Developer/InnoSquad/InnoDI --filter ValidationCoordinatorTests`
- `swift test --package-path /Users/changwoo.son/Developer/InnoSquad/InnoDI --filter OverridesRuntimeTests`
- `swift test --package-path /Users/changwoo.son/Developer/InnoSquad/InnoDI`
