### PR TITLE
feat(macros): warn when closure params use a Lazy/Provider typealias (Phase N-4)

### DIFF
--- a/Sources/InnoDIMacros/DIContainerValidator.swift
+++ b/Sources/InnoDIMacros/DIContainerValidator.swift
@@ -424,6 +424,58 @@ struct DIContainerValidator {
             }
         }
 
+        // Phase N-4 — warn when a closure parameter uses a typealias that
+        // aliases `Lazy<T>` or `Provider<T>`. The macro resolves deferred
+        // wrapper kinds from written syntax, so typealiased spellings fall
+        // through to `.hard` silently. This check collects same-file
+        // typealiases and flags any closure parameter whose bare identifier
+        // matches one of them. Cross-file aliases stay invisible.
+        //
+        // Anchor selection: we need any member's attribute syntax to walk up
+        // to `SourceFileSyntax`. An empty container returns early in
+        // `DIContainerMacro.expansion` before reaching the validator, so
+        // reaching this point with both collections empty is impossible.
+        let aliasAnchor: Syntax? = model.members.first.map { Syntax($0.attribute) }
+            ?? model.subContainerMembers.first.map { Syntax($0.attribute) }
+        if let anchor = aliasAnchor {
+            let aliases = collectLazyProviderAliases(anchoredBy: anchor)
+            if !aliases.isEmpty {
+                for member in model.members {
+                    for reference in member.closureParameterReferences {
+                        guard reference.kind == .hard else { continue }
+                        guard let aliasedKind = aliasedDeferredWrapperKind(
+                            for: reference.type,
+                            aliases: aliases
+                        ) else { continue }
+                        let aliasName = reference.type?
+                            .trimmedDescription ?? reference.name
+                        switch aliasedKind {
+                        case .lazy:
+                            context.diagnose(
+                                Diagnostic(
+                                    node: Syntax(reference.token),
+                                    message: SimpleDiagnostic.provideLazyAliased(
+                                        parameterName: reference.name,
+                                        aliasName: aliasName
+                                    )
+                                )
+                            )
+                        case .provider:
+                            context.diagnose(
+                                Diagnostic(
+                                    node: Syntax(reference.token),
+                                    message: SimpleDiagnostic.provideProviderAliased(
+                                        parameterName: reference.name,
+                                        aliasName: aliasName
+                                    )
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
         // Phase N-3 — warn when the child container has no overrideable
         // members. The parent's generated `<name>Overrides` slot references
         // `<Child>.Overrides`, which the child's macro only synthesizes if it

--- a/Sources/InnoDIMacros/DILazyProviderAliasCheck.swift
+++ b/Sources/InnoDIMacros/DILazyProviderAliasCheck.swift
@@ -1,0 +1,125 @@
+//
+//  DILazyProviderAliasCheck.swift
+//  InnoDIMacros
+//
+//  Phase N-4 — warns when a closure parameter types a `typealias` that
+//  aliases `Lazy<T>` or `Provider<T>`.
+//
+//  The macro resolves deferred-wrapper kinds purely from written syntax
+//  (see `DeferredDependencyWrappers.deferredDependencyWrapperKind`), so an
+//  alias like `typealias L = InnoDI.Lazy<Foo>` is silently treated as a
+//  hard edge. That means a cycle users thought they broke with `Lazy<T>`
+//  can still trigger `container.dependency-cycle`, and a Provider-aliased
+//  target escapes the `.transient`-scope rule. Emitting a warning lets
+//  authors catch the mistake before the surprising diagnostic (or the
+//  even more surprising runtime behavior) bites.
+//
+//  Detection is best-effort: we walk the parent source file for
+//  `typealias` declarations whose right-hand side reduces to
+//  `Lazy<...>` / `Provider<...>` (bare or qualified `InnoDI.Lazy<...>` /
+//  `InnoDI.Provider<...>`). Cross-file aliases stay invisible and are
+//  skipped silently.
+//
+
+import InnoDICore
+import SwiftSyntax
+
+internal struct LazyProviderAliasMap {
+    let lazyAliases: Set<String>
+    let providerAliases: Set<String>
+
+    var isEmpty: Bool { lazyAliases.isEmpty && providerAliases.isEmpty }
+}
+
+internal func collectLazyProviderAliases(anchoredBy syntax: Syntax) -> LazyProviderAliasMap {
+    guard let sourceFile = sourceFileSyntax(containing: syntax) else {
+        return LazyProviderAliasMap(lazyAliases: [], providerAliases: [])
+    }
+
+    var lazyAliases: Set<String> = []
+    var providerAliases: Set<String> = []
+
+    // NOTE: only source-file-top-level `typealias` decls are collected.
+    // Nested alias chains (`typealias A = Lazy<T>; typealias B = A`) are
+    // deliberately not followed — we only flag the leaf-RHS that we can
+    // statically recognize as `Lazy<...>` / `Provider<...>`. Typealiases
+    // inside type bodies and cross-file aliases are also invisible,
+    // consistent with the rest of the macro's "best-effort, same-file"
+    // detection contract.
+    for statement in sourceFile.statements {
+        guard case let .decl(decl) = statement.item,
+              let typealiasDecl = decl.as(TypeAliasDeclSyntax.self) else {
+            continue
+        }
+
+        let rhs = typealiasDecl.initializer.value
+        if let kind = deferredDependencyWrapperKind(for: rhs) {
+            let aliasName = typealiasDecl.name.text
+            switch kind {
+            case .lazy:
+                lazyAliases.insert(aliasName)
+            case .provider:
+                providerAliases.insert(aliasName)
+            }
+        }
+    }
+
+    return LazyProviderAliasMap(lazyAliases: lazyAliases, providerAliases: providerAliases)
+}
+
+/// Returns the deferred-wrapper kind a factory parameter *would* have been
+/// classified as, had the macro been able to resolve the alias. Used only
+/// for emitting the warning — does NOT change edge classification downstream.
+///
+/// Only identifiers that are exact alias matches (bare `IdentifierTypeSyntax`)
+/// are reported. Qualified `Module.Alias<T>` uses stay outside the warning
+/// surface since they already force the author to think about module names.
+internal func aliasedDeferredWrapperKind(
+    for type: TypeSyntax?,
+    aliases: LazyProviderAliasMap
+) -> DeferredDependencyWrapperKind? {
+    guard let type, !aliases.isEmpty else { return nil }
+
+    // Only interested in plain `IdentifierTypeSyntax` names. If the macro
+    // already recognized the type as Lazy/Provider, `deferredDependencyWrapperKind`
+    // returns non-nil and we do not want to warn.
+    if deferredDependencyWrapperKind(for: type) != nil {
+        return nil
+    }
+
+    // Accepts both non-generic aliases (`typealias FooLazy = Lazy<Foo>` used
+    // as `FooLazy`) and generic aliases (`typealias L<T> = Lazy<T>` used as
+    // `L<Foo>`). Both spell the alias name at the leading identifier.
+    let normalized = stripAttributesAndTuples(type)
+    guard let identifier = normalized.as(IdentifierTypeSyntax.self) else {
+        return nil
+    }
+    let name = identifier.name.text
+
+    if aliases.lazyAliases.contains(name) {
+        return .lazy
+    }
+    if aliases.providerAliases.contains(name) {
+        return .provider
+    }
+    return nil
+}
+
+/// Strips attribute wrappers (`@escaping`, etc.) and single-element tuples
+/// around the written type. Intentionally does NOT strip optional wrappers
+/// (`T?`, `T!`, `Optional<T>`): `Lazy<T>?` is already rejected upstream by
+/// `deferredDependencyWrapperKind`, and applying the alias warning to
+/// optional aliases would be noise on an already-niche shape.
+private func stripAttributesAndTuples(_ type: TypeSyntax) -> TypeSyntax {
+    if let attributed = type.as(AttributedTypeSyntax.self) {
+        return stripAttributesAndTuples(attributed.baseType)
+    }
+    if let tuple = type.as(TupleTypeSyntax.self),
+       tuple.elements.count == 1,
+       let first = tuple.elements.first,
+       first.firstName == nil,
+       first.secondName == nil {
+        return stripAttributesAndTuples(first.type)
+    }
+    return type
+}

--- a/Sources/InnoDIMacros/Diagnostics.swift
+++ b/Sources/InnoDIMacros/Diagnostics.swift
@@ -51,6 +51,8 @@ enum InnoDIDiagnosticCode: String {
     case subUnknownChildInput = "sub.unknown-child-input"
     case subSharedParentMustNotBeTransient = "sub.shared-parent-must-not-be-transient"
     case subChildOverridesMissing = "sub.child-overrides-missing"
+    case provideLazyAliased = "provide.lazy-aliased"
+    case provideProviderAliased = "provide.provider-aliased"
     case swiftUIFeatureRootWithoutSubContainer = "swiftui.feature-root-without-subcontainer"
     case swiftUIFeatureRootDuplicateDefault = "swiftui.feature-root-duplicate-default"
     case swiftUIFeatureRootHelperNameConflict = "swiftui.feature-root-helper-name-conflict"
@@ -81,6 +83,7 @@ enum InnoDIDiagnosticCode: String {
                 .subUnknownParentMember, .subBindingsConflictsWithWith, .subDuplicateChildBinding,
                 .subUnknownChildInput, .subSharedParentMustNotBeTransient,
                 .subChildOverridesMissing,
+                .provideLazyAliased, .provideProviderAliased,
                 .swiftUIFeatureRootWithoutSubContainer, .swiftUIFeatureRootDuplicateDefault,
                 .swiftUIFeatureRootInvalidAlias,
                 .swiftUIFeatureRootHelperNameConflict, .swiftUIEnvironmentBridgeUnknownMember,
@@ -462,6 +465,28 @@ extension SimpleDiagnostic {
         Self(
             "@SubContainer '\(memberName)' targets '\(childContainerName)', which has no .shared, .transient, or @SubContainer members. The generated '\(memberName)Overrides' slot references '\(childContainerName).Overrides', which is not synthesized by the child macro for input-only containers. Remove the @SubContainer, or add at least one override-generating member to '\(childContainerName)'.",
             code: .subChildOverridesMissing,
+            severity: .warning
+        )
+    }
+
+    static func provideLazyAliased(
+        parameterName: String,
+        aliasName: String
+    ) -> Self {
+        Self(
+            "Spell 'Lazy<T>' (or 'InnoDI.Lazy<T>') directly — the macro cannot follow typealiases, so parameter '\(parameterName)' typed '\(aliasName)' is treated as a hard edge and participates in cycle detection.",
+            code: .provideLazyAliased,
+            severity: .warning
+        )
+    }
+
+    static func provideProviderAliased(
+        parameterName: String,
+        aliasName: String
+    ) -> Self {
+        Self(
+            "Spell 'Provider<T>' (or 'InnoDI.Provider<T>') directly — the macro cannot follow typealiases, so parameter '\(parameterName)' typed '\(aliasName)' is treated as a hard edge and loses the '.transient'-target rule plus the cycle-detection exemption.",
+            code: .provideProviderAliased,
             severity: .warning
         )
     }

--- a/Tests/InnoDIMacrosTests/DIContainerMacroTests.swift
+++ b/Tests/InnoDIMacrosTests/DIContainerMacroTests.swift
@@ -2377,6 +2377,146 @@ struct DIContainerMacroTests {
         #expect(!context.diagnostics.contains { $0.diagnosticID == unexpectedID })
     }
 
+    // Phase N-4 — `provide.lazy-aliased` / `provide.provider-aliased` warn
+    // when a closure parameter uses a typealias that aliases `Lazy<T>` /
+    // `Provider<T>`. Same parent-detachment caveat as N-3.
+    @Test("Closure parameter using a Lazy typealias emits the lazy-aliased warning")
+    func lazyAliasedParameterWarns() throws {
+        let source = """
+        typealias SomeLazy<T> = InnoDI.Lazy<T>
+
+        @DIContainer
+        struct AppContainer {
+            @Provide(.shared, factory: { (b: SomeLazy<CoordinatorB>) in CoordinatorA(b: b) })
+            var a: CoordinatorA
+
+            @Provide(.shared, factory: { (a: CoordinatorA) in CoordinatorB(a: a) })
+            var b: CoordinatorB
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let decl = parsed.statements.first(where: { $0.item.is(StructDeclSyntax.self) })?
+                .item.as(StructDeclSyntax.self),
+              let attr = decl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse AppContainer with sibling typealias")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        _ = try DIContainerMacro.expansion(of: attr, providingMembersOf: decl, in: context)
+
+        let expectedID = MessageID(
+            domain: "InnoDI.validation",
+            id: "provide.lazy-aliased"
+        )
+        #expect(context.diagnostics.contains {
+            $0.diagnosticID == expectedID
+        })
+    }
+
+    @Test("Non-generic typealias for Lazy also emits the lazy-aliased warning")
+    func nonGenericLazyAliasParameterWarns() throws {
+        let source = """
+        struct Foo {}
+        typealias FooLazy = InnoDI.Lazy<Foo>
+
+        @DIContainer
+        struct AppContainer {
+            @Provide(.input) var foo: Foo
+            @Provide(.shared, factory: { (b: FooLazy) in Service(fooProvider: b) })
+            var service: Service
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let decl = parsed.statements.first(where: {
+                  $0.item.as(StructDeclSyntax.self)?.name.text == "AppContainer"
+              })?.item.as(StructDeclSyntax.self),
+              let attr = decl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse AppContainer with non-generic FooLazy alias")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        _ = try DIContainerMacro.expansion(of: attr, providingMembersOf: decl, in: context)
+
+        let expectedID = MessageID(
+            domain: "InnoDI.validation",
+            id: "provide.lazy-aliased"
+        )
+        #expect(context.diagnostics.contains { $0.diagnosticID == expectedID })
+    }
+
+    @Test("Closure parameter using a Provider typealias emits the provider-aliased warning")
+    func providerAliasedParameterWarns() throws {
+        let source = """
+        typealias SomeProvider<T> = InnoDI.Provider<T>
+
+        @DIContainer
+        struct AppContainer {
+            @Provide(.transient, factory: { (config: Config) in
+                Request(config: config)
+            })
+            var request: Request
+
+            @Provide(.shared, factory: { (p: SomeProvider<Request>) in
+                RequestLogger(provider: p)
+            })
+            var logger: RequestLogger
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let decl = parsed.statements.first(where: { $0.item.is(StructDeclSyntax.self) })?
+                .item.as(StructDeclSyntax.self),
+              let attr = decl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse AppContainer with sibling typealias")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        _ = try DIContainerMacro.expansion(of: attr, providingMembersOf: decl, in: context)
+
+        let expectedID = MessageID(
+            domain: "InnoDI.validation",
+            id: "provide.provider-aliased"
+        )
+        #expect(context.diagnostics.contains {
+            $0.diagnosticID == expectedID
+        })
+    }
+
+    @Test("Unrelated typealiases do not trigger the aliased warning")
+    func unrelatedTypealiasDoesNotWarn() throws {
+        let source = """
+        typealias UserID = Int
+
+        @DIContainer
+        struct AppContainer {
+            @Provide(.input) var config: AppConfig
+            @Provide(.shared, factory: { (config: AppConfig) in Service(config: config) })
+            var service: Service
+        }
+        """
+
+        let parsed = Parser.parse(source: source)
+        guard let decl = parsed.statements.first(where: { $0.item.is(StructDeclSyntax.self) })?
+                .item.as(StructDeclSyntax.self),
+              let attr = decl.attributes.first?.as(AttributeSyntax.self) else {
+            Issue.record("Should parse AppContainer with unrelated typealias")
+            return
+        }
+
+        let context = TestMacroExpansionContext()
+        _ = try DIContainerMacro.expansion(of: attr, providingMembersOf: decl, in: context)
+
+        let lazyID = MessageID(domain: "InnoDI.validation", id: "provide.lazy-aliased")
+        let providerID = MessageID(domain: "InnoDI.validation", id: "provide.provider-aliased")
+        #expect(!context.diagnostics.contains { $0.diagnosticID == lazyID })
+        #expect(!context.diagnostics.contains { $0.diagnosticID == providerID })
+    }
+
     @Test("Sub-container targeting a child with at least one shared member does not warn")
     func subContainerTargetingChildWithSharedMemberDoesNotWarn() throws {
         let source = """


### PR DESCRIPTION
## Summary

Phase N-4 — introduce \`provide.lazy-aliased\` and \`provide.provider-aliased\` **warnings**. The macro resolves deferred-wrapper kinds from written syntax, so a factory parameter spelled \`SomeLazy<Foo>\` where \`typealias SomeLazy<T> = Lazy<T>\` silently falls through to the \`.hard\` edge classification. Cycle detection then kicks in and the \`Provider<T>\`-specific \`.transient\`-target rule is bypassed — surprising to authors who think they wrote \`Lazy<Foo>\`.

## 설계 결정

- **Severity = warning, not error**: the surrounding code still compiles. The warning highlights the silent fall-through without breaking users who intentionally want a hard edge named through a typealias.
- **Same-file best-effort**: we only collect typealiases from the parent's source file. Cross-file \`typealias L = Lazy\` stays invisible, matching the existing Lazy/Provider detection contract documented at the public type declarations.
- **Both alias shapes supported**: generic alias (\`typealias L<T> = Lazy<T>\` used as \`L<Foo>\`) and non-generic alias (\`typealias FooLazy = Lazy<Foo>\` used as \`FooLazy\`) both emit the warning. The alias's RHS just has to reduce to \`Lazy<...>\` or \`Provider<...>\`.
- **Does not change edge classification**: the warning is purely informational. Downstream cycle detection and scope validation continue to treat the parameter as \`.hard\`.

## 영향 파일 요약

| 파일 | 변경 |
|---|---|
| \`Sources/InnoDIMacros/Diagnostics.swift\` | \`provideLazyAliased\` / \`provideProviderAliased\` codes + message constructors (warning severity) |
| \`Sources/InnoDIMacros/DILazyProviderAliasCheck.swift\` (NEW) | Source-file walk for \`TypeAliasDeclSyntax\` with Lazy/Provider RHS; \`aliasedDeferredWrapperKind\` lookup |
| \`Sources/InnoDIMacros/DIContainerValidator.swift\` | Computes the alias set once per expansion and scans member closure references after the existing validation loop |
| \`Tests/InnoDIMacrosTests/DIContainerMacroTests.swift\` | Three new direct-expansion tests (lazy alias warn, provider alias warn, unrelated typealias silence) |

## 검증 체크리스트

- [x] \`swift test\` 354 tests green (+3 new)
- [x] \`swift test --filter InnoDIMacrosTests\` 149 macro tests green
- [x] 기존 매크로 스냅샷 byte-identical
- [x] 경고만 발행, 엣지 분류/사이클 검출 동작 불변

## Phase N 스택 다음 단계

- **N-5** docs/phase-n-hardening — README root/validateDAG 섹션, MIGRATION Phase N 엔트리, bindings 엣지 케이스 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)