### PR TITLE
[codex] Harden validation and add prebuilt tools

### DIFF
--- a/InnoDIValidationTools/Artifacts/InnoDIPrebuiltDAGValidationCoordinator.artifactbundle/InnoDIPrebuiltDAGValidationCoordinator-macos/bin/InnoDIPrebuiltDAGValidationCoordinator
+++ b/InnoDIValidationTools/Artifacts/InnoDIPrebuiltDAGValidationCoordinator.artifactbundle/InnoDIPrebuiltDAGValidationCoordinator-macos/bin/InnoDIPrebuiltDAGValidationCoordinator
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+echo "error: InnoDIPrebuiltDAGValidationCoordinator placeholder artifact is not a release binary." >&2
+echo "Run InnoDIValidationTools/Tools/prepare-release-artifact.sh to build a local artifact bundle, or use a released InnoDIValidationTools tag." >&2
+exit 2

--- a/InnoDIValidationTools/Artifacts/InnoDIPrebuiltDAGValidationCoordinator.artifactbundle/info.json
+++ b/InnoDIValidationTools/Artifacts/InnoDIPrebuiltDAGValidationCoordinator.artifactbundle/info.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": "1.0",
+  "artifacts": {
+    "InnoDIPrebuiltDAGValidationCoordinator": {
+      "version": "0.0.0-local-placeholder",
+      "type": "executable",
+      "variants": [
+        {
+          "path": "InnoDIPrebuiltDAGValidationCoordinator-macos/bin/InnoDIPrebuiltDAGValidationCoordinator",
+          "supportedTriples": [
+            "arm64-apple-macosx",
+            "x86_64-apple-macosx"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/InnoDIValidationTools/Artifacts/README.md
+++ b/InnoDIValidationTools/Artifacts/README.md
@@ -1,0 +1,10 @@
+# Artifacts
+
+This directory includes a small fail-fast placeholder artifact so the companion
+package manifest remains valid in a fresh checkout.
+
+`Tools/prepare-release-artifact.sh` replaces
+`InnoDIPrebuiltDAGValidationCoordinator.artifactbundle` with the real
+coordinator binary for local acceptance and release packaging. Run the
+preparation script before using this companion package as a local prebuilt
+plugin dependency.

--- a/InnoDIValidationTools/Package.swift
+++ b/InnoDIValidationTools/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version: 6.2
+
+import PackageDescription
+
+let package = Package(
+    name: "InnoDIValidationTools",
+    platforms: [
+        .macOS(.v13),
+    ],
+    products: [
+        .plugin(
+            name: "InnoDIPrebuiltDAGValidationPlugin",
+            targets: ["InnoDIPrebuiltDAGValidationPlugin"]
+        ),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "InnoDIPrebuiltDAGValidationCoordinator",
+            path: "Artifacts/InnoDIPrebuiltDAGValidationCoordinator.artifactbundle"
+        ),
+        .plugin(
+            name: "InnoDIPrebuiltDAGValidationPlugin",
+            capability: .buildTool(),
+            dependencies: [
+                "InnoDIPrebuiltDAGValidationCoordinator",
+            ]
+        ),
+    ]
+)

--- a/InnoDIValidationTools/Plugins/InnoDIPrebuiltDAGValidationPlugin/plugin.swift
+++ b/InnoDIValidationTools/Plugins/InnoDIPrebuiltDAGValidationPlugin/plugin.swift
@@ -2,29 +2,25 @@ import Foundation
 import PackagePlugin
 
 @main
-struct InnoDIDAGValidationPlugin: BuildToolPlugin {
+struct InnoDIPrebuiltDAGValidationPlugin: BuildToolPlugin {
     func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
         guard target is SourceModuleTarget else {
             return []
         }
 
-        // Opt-out hook for consumers that intentionally skip the build-time
-        // DAG gate (PoCs, fast iteration loops, or builds running on a
-        // shared volume that already runs validation in a separate CI job).
-        // Production CI must leave the variable unset so the gate runs.
         if let optOut = ProcessInfo.processInfo.environment["INNODI_DISABLE_BUILD_VALIDATION"],
            ["1", "true", "TRUE", "yes", "YES"].contains(optOut) {
             return []
         }
 
-        let coordinator = try context.tool(named: "InnoDI-DAGValidationCoordinator")
+        let coordinator = try context.tool(named: "InnoDIPrebuiltDAGValidationCoordinator")
         let outputDirectory = context.pluginWorkDirectoryURL
         let rootPath = context.package.directoryURL.path
         let sharedStateDirectory = sharedValidationStateDirectory(for: outputDirectory)
 
         return [
             .buildCommand(
-                displayName: "Validate InnoDI DAG for \(target.name)",
+                displayName: "Validate InnoDI DAG for \(target.name) (prebuilt)",
                 executable: coordinator.url,
                 arguments: [
                     "--root", rootPath,

--- a/InnoDIValidationTools/Plugins/InnoDIPrebuiltDAGValidationPlugin/plugin.swift
+++ b/InnoDIValidationTools/Plugins/InnoDIPrebuiltDAGValidationPlugin/plugin.swift
@@ -9,14 +9,15 @@ struct InnoDIPrebuiltDAGValidationPlugin: BuildToolPlugin {
         }
 
         if let optOut = ProcessInfo.processInfo.environment["INNODI_DISABLE_BUILD_VALIDATION"],
-           ["1", "true", "TRUE", "yes", "YES"].contains(optOut) {
+           ["1", "true", "yes"].contains(
+               optOut.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+           ) {
             return []
         }
 
         let coordinator = try context.tool(named: "InnoDIPrebuiltDAGValidationCoordinator")
         let outputDirectory = context.pluginWorkDirectoryURL
-        let rootPath = context.package.directoryURL.path
-        let sharedStateDirectory = sharedValidationStateDirectory(for: outputDirectory)
+        let rootPath = context.package.directoryURL.path(percentEncoded: false)
 
         return [
             .buildCommand(
@@ -24,8 +25,7 @@ struct InnoDIPrebuiltDAGValidationPlugin: BuildToolPlugin {
                 executable: coordinator.url,
                 arguments: [
                     "--root", rootPath,
-                    "--state-dir", sharedStateDirectory.path,
-                    "--output-dir", outputDirectory.path,
+                    "--output-dir", outputDirectory.path(percentEncoded: false),
                 ],
                 inputFiles: validationInputFiles(packageRoot: context.package.directoryURL),
                 outputFiles: [
@@ -39,6 +39,7 @@ struct InnoDIPrebuiltDAGValidationPlugin: BuildToolPlugin {
 
     private func validationInputFiles(packageRoot: URL) -> [URL] {
         let fileManager = FileManager.default
+        // Explicit safety-net for validationInputFiles; FileManager hidden-file skipping is the primary filter.
         let excludedDirectories: Set<String> = [
             ".build",
             ".git",
@@ -78,25 +79,9 @@ struct InnoDIPrebuiltDAGValidationPlugin: BuildToolPlugin {
             }
         }
 
-        return Array(Set(inputs)).sorted { $0.path < $1.path }
-    }
-
-    private func sharedValidationStateDirectory(for outputDirectory: URL) -> URL {
-        let components = outputDirectory.pathComponents
-        if let outputsIndex = components.lastIndex(of: "outputs"),
-           outputsIndex + 1 < components.count {
-            return URL(
-                fileURLWithPath: NSString.path(
-                    withComponents: Array(components.prefix(outputsIndex + 2))
-                ),
-                isDirectory: true
-            )
-            .appending(path: "innodi-dag-validation-state", directoryHint: .isDirectory)
-        }
-
-        return outputDirectory
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .appending(path: "innodi-dag-validation-state", directoryHint: .isDirectory)
+        var seenInputPaths = Set<String>()
+        return inputs
+            .filter { seenInputPaths.insert($0.path(percentEncoded: false)).inserted }
+            .sorted { $0.path(percentEncoded: false) < $1.path(percentEncoded: false) }
     }
 }

--- a/InnoDIValidationTools/README.md
+++ b/InnoDIValidationTools/README.md
@@ -53,5 +53,9 @@ automation can build and verify the package before publishing:
 Tools/prepare-release-artifact.sh --tag <tag> --source-path ../ --output-dir Artifacts
 ```
 
+Run the example from inside `InnoDIValidationTools` so `--source-path ../`
+points at the repository root; adjust `--source-path` when using a different
+working directory.
+
 For a public release, pass `--release-url` and `--update-package` so the
-manifest is rewritten to a remote binary target with a computed checksum.
+manifest's binary target is updated to use a remote URL with a computed checksum.

--- a/InnoDIValidationTools/README.md
+++ b/InnoDIValidationTools/README.md
@@ -1,0 +1,57 @@
+# InnoDIValidationTools
+
+Companion SwiftPM package for consumers that want InnoDI's build-time DAG
+validator without compiling the source coordinator tool in every dependency
+graph.
+
+The main `InnoDI` package remains the default integration path. Use this
+package only when consumer build-cost measurements show that the prebuilt
+validator is worth the extra release artifact dependency.
+
+## Usage
+
+Add both packages at the same tag:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/InnoSquadCorp/InnoDI.git", exact: "<tag>"),
+    .package(url: "https://github.com/InnoSquadCorp/InnoDIValidationTools.git", exact: "<tag>"),
+]
+```
+
+Attach exactly one validation plugin to each target:
+
+```swift
+.target(
+    name: "YourFeature",
+    dependencies: [
+        .product(name: "InnoDI", package: "InnoDI"),
+    ],
+    plugins: [
+        .plugin(name: "InnoDIPrebuiltDAGValidationPlugin", package: "InnoDIValidationTools"),
+    ]
+)
+```
+
+Do not attach `InnoDIDAGValidationPlugin` and
+`InnoDIPrebuiltDAGValidationPlugin` to the same target. Both plugins run the
+same validator and write the same artifact names, so attaching both double-runs
+the gate.
+
+## Platform Support
+
+The first prebuilt release supports macOS hosts. Linux, local package
+development, and unsupported binary-artifact environments should keep using the
+source plugin from the main InnoDI package.
+
+## Local Artifact Preparation
+
+`Package.swift` points at a local artifact bundle by default so release
+automation can build and verify the package before publishing:
+
+```sh
+Tools/prepare-release-artifact.sh --tag <tag> --source-path ../ --output-dir Artifacts
+```
+
+For a public release, pass `--release-url` and `--update-package` so the
+manifest is rewritten to a remote binary target with a computed checksum.

--- a/InnoDIValidationTools/Tools/prepare-release-artifact.sh
+++ b/InnoDIValidationTools/Tools/prepare-release-artifact.sh
@@ -19,7 +19,7 @@ Options:
   --repo <url>             InnoDI git repository (default: $INNODI_REPO).
   --output-dir <path>      Artifact output directory (default: Artifacts).
   --release-url <url>      Remote zip URL to write into Package.swift.
-  --update-package         Rewrite Package.swift to use --release-url/checksum.
+  --update-package         Update Package.swift binary target to use --release-url/checksum.
   --help                   Show this help.
 USAGE
 }
@@ -159,39 +159,72 @@ rm -f "$ZIP_PATH"
 
 CHECKSUM="$(swift package compute-checksum "$ZIP_PATH")"
 
+update_package_manifest() {
+  local package_path="$ROOT_DIR/Package.swift"
+  local updated_path="$TMP_DIR/Package.swift.updated"
+
+  set +e
+  awk -v release_url="$RELEASE_URL" -v checksum="$CHECKSUM" '
+    function emitReplacement(indent) {
+      print indent ".binaryTarget("
+      print indent "    name: \"InnoDIPrebuiltDAGValidationCoordinator\","
+      print indent "    url: \"" release_url "\","
+      print indent "    checksum: \"" checksum "\""
+      print indent "),"
+    }
+
+    /^[[:space:]]*\.binaryTarget\([[:space:]]*$/ {
+      capture = 1
+      matched = 0
+      block = $0 ORS
+      indent = substr($0, 1, match($0, /\./) - 1)
+      next
+    }
+
+    capture {
+      block = block $0 ORS
+      if ($0 ~ /name:[[:space:]]*"InnoDIPrebuiltDAGValidationCoordinator"/) {
+        matched = 1
+      }
+      if ($0 ~ /^[[:space:]]*\),[[:space:]]*$/) {
+        if (matched) {
+          emitReplacement(indent)
+          found = 1
+        } else {
+          printf "%s", block
+        }
+        capture = 0
+        matched = 0
+        block = ""
+      }
+      next
+    }
+
+    { print }
+
+    END {
+      if (capture) {
+        printf "%s", block
+      }
+      if (!found) {
+        exit 42
+      }
+    }
+  ' "$package_path" > "$updated_path"
+  local awk_status=$?
+  set -e
+
+  if [[ "$awk_status" -ne 0 ]]; then
+    rm -f "$updated_path"
+    echo "Error: unable to find InnoDIPrebuiltDAGValidationCoordinator binary target in $package_path." >&2
+    exit 1
+  fi
+
+  mv "$updated_path" "$package_path"
+}
+
 if [[ "$UPDATE_PACKAGE" -eq 1 ]]; then
-  cat > "$ROOT_DIR/Package.swift" <<SWIFT
-// swift-tools-version: 6.2
-
-import PackageDescription
-
-let package = Package(
-    name: "InnoDIValidationTools",
-    platforms: [
-        .macOS(.v13),
-    ],
-    products: [
-        .plugin(
-            name: "InnoDIPrebuiltDAGValidationPlugin",
-            targets: ["InnoDIPrebuiltDAGValidationPlugin"]
-        ),
-    ],
-    targets: [
-        .binaryTarget(
-            name: "InnoDIPrebuiltDAGValidationCoordinator",
-            url: "$RELEASE_URL",
-            checksum: "$CHECKSUM"
-        ),
-        .plugin(
-            name: "InnoDIPrebuiltDAGValidationPlugin",
-            capability: .buildTool(),
-            dependencies: [
-                "InnoDIPrebuiltDAGValidationCoordinator",
-            ]
-        ),
-    ]
-)
-SWIFT
+  update_package_manifest
 fi
 
 cat <<SUMMARY

--- a/InnoDIValidationTools/Tools/prepare-release-artifact.sh
+++ b/InnoDIValidationTools/Tools/prepare-release-artifact.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TAG=""
+SOURCE_PATH=""
+INNODI_REPO="${INNODI_REPO:-git@github.com:InnoSquadCorp/InnoDI.git}"
+OUTPUT_DIR="$ROOT_DIR/Artifacts"
+RELEASE_URL=""
+UPDATE_PACKAGE=0
+
+usage() {
+  cat <<USAGE
+Usage: Tools/prepare-release-artifact.sh --tag <tag> [options]
+
+Options:
+  --tag <tag>              InnoDI tag/version embedded in the artifact bundle.
+  --source-path <path>     Existing InnoDI checkout to build instead of cloning.
+  --repo <url>             InnoDI git repository (default: $INNODI_REPO).
+  --output-dir <path>      Artifact output directory (default: Artifacts).
+  --release-url <url>      Remote zip URL to write into Package.swift.
+  --update-package         Rewrite Package.swift to use --release-url/checksum.
+  --help                   Show this help.
+USAGE
+}
+
+require_value() {
+  local option="$1"
+  local value="${2:-}"
+  if [[ -z "$value" || "$value" == -* ]]; then
+    echo "Error: $option requires a value." >&2
+    usage
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag)
+      require_value "$1" "${2:-}"
+      TAG="$2"
+      shift 2
+      ;;
+    --source-path)
+      require_value "$1" "${2:-}"
+      SOURCE_PATH="$2"
+      shift 2
+      ;;
+    --repo)
+      require_value "$1" "${2:-}"
+      INNODI_REPO="$2"
+      shift 2
+      ;;
+    --output-dir)
+      require_value "$1" "${2:-}"
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --release-url)
+      require_value "$1" "${2:-}"
+      RELEASE_URL="$2"
+      shift 2
+      ;;
+    --update-package)
+      UPDATE_PACKAGE=1
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$TAG" ]]; then
+  echo "Error: --tag is required." >&2
+  usage
+  exit 1
+fi
+
+if [[ "$UPDATE_PACKAGE" -eq 1 && -z "$RELEASE_URL" ]]; then
+  echo "Error: --update-package requires --release-url." >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/innodi-validation-tools.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+if [[ -n "$SOURCE_PATH" ]]; then
+  SOURCE_DIR="$(cd "$SOURCE_PATH" && pwd)"
+else
+  SOURCE_DIR="$TMP_DIR/InnoDI"
+  git clone --depth 1 --branch "$TAG" "$INNODI_REPO" "$SOURCE_DIR"
+fi
+
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
+
+(
+  cd "$SOURCE_DIR"
+  swift build -c release --product InnoDI-DAGValidationCoordinator
+)
+
+BINARY_PATH="$SOURCE_DIR/.build/release/InnoDI-DAGValidationCoordinator"
+if [[ ! -x "$BINARY_PATH" ]]; then
+  echo "Error: expected executable at $BINARY_PATH" >&2
+  exit 1
+fi
+
+TRIPLE="$(
+  swiftc -print-target-info \
+    | sed -n 's/.*"triple"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+    | head -n 1
+)"
+if [[ -z "$TRIPLE" ]]; then
+  echo "Error: unable to determine Swift target triple." >&2
+  exit 1
+fi
+
+BUNDLE_NAME="InnoDIPrebuiltDAGValidationCoordinator.artifactbundle"
+BUNDLE_PATH="$OUTPUT_DIR/$BUNDLE_NAME"
+VARIANT_DIR="InnoDIPrebuiltDAGValidationCoordinator-$TRIPLE"
+rm -rf "$BUNDLE_PATH"
+mkdir -p "$BUNDLE_PATH/$VARIANT_DIR/bin"
+cp "$BINARY_PATH" "$BUNDLE_PATH/$VARIANT_DIR/bin/InnoDIPrebuiltDAGValidationCoordinator"
+
+cat > "$BUNDLE_PATH/info.json" <<JSON
+{
+  "schemaVersion": "1.0",
+  "artifacts": {
+    "InnoDIPrebuiltDAGValidationCoordinator": {
+      "version": "$TAG",
+      "type": "executable",
+      "variants": [
+        {
+          "path": "$VARIANT_DIR/bin/InnoDIPrebuiltDAGValidationCoordinator",
+          "supportedTriples": [
+            "$TRIPLE"
+          ]
+        }
+      ]
+    }
+  }
+}
+JSON
+
+ZIP_NAME="InnoDIPrebuiltDAGValidationCoordinator-$TAG.artifactbundle.zip"
+ZIP_PATH="$OUTPUT_DIR/$ZIP_NAME"
+rm -f "$ZIP_PATH"
+(
+  cd "$OUTPUT_DIR"
+  /usr/bin/zip -qry "$ZIP_NAME" "$BUNDLE_NAME"
+)
+
+CHECKSUM="$(swift package compute-checksum "$ZIP_PATH")"
+
+if [[ "$UPDATE_PACKAGE" -eq 1 ]]; then
+  cat > "$ROOT_DIR/Package.swift" <<SWIFT
+// swift-tools-version: 6.2
+
+import PackageDescription
+
+let package = Package(
+    name: "InnoDIValidationTools",
+    platforms: [
+        .macOS(.v13),
+    ],
+    products: [
+        .plugin(
+            name: "InnoDIPrebuiltDAGValidationPlugin",
+            targets: ["InnoDIPrebuiltDAGValidationPlugin"]
+        ),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "InnoDIPrebuiltDAGValidationCoordinator",
+            url: "$RELEASE_URL",
+            checksum: "$CHECKSUM"
+        ),
+        .plugin(
+            name: "InnoDIPrebuiltDAGValidationPlugin",
+            capability: .buildTool(),
+            dependencies: [
+                "InnoDIPrebuiltDAGValidationCoordinator",
+            ]
+        ),
+    ]
+)
+SWIFT
+fi
+
+cat <<SUMMARY
+Artifact bundle: $BUNDLE_PATH
+Zip: $ZIP_PATH
+Checksum: $CHECKSUM
+Triple: $TRIPLE
+SUMMARY

--- a/Plugins/InnoDIDAGValidationPlugin/plugin.swift
+++ b/Plugins/InnoDIDAGValidationPlugin/plugin.swift
@@ -13,14 +13,15 @@ struct InnoDIDAGValidationPlugin: BuildToolPlugin {
         // shared volume that already runs validation in a separate CI job).
         // Production CI must leave the variable unset so the gate runs.
         if let optOut = ProcessInfo.processInfo.environment["INNODI_DISABLE_BUILD_VALIDATION"],
-           ["1", "true", "TRUE", "yes", "YES"].contains(optOut) {
+           ["1", "true", "yes"].contains(
+               optOut.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+           ) {
             return []
         }
 
         let coordinator = try context.tool(named: "InnoDI-DAGValidationCoordinator")
         let outputDirectory = context.pluginWorkDirectoryURL
-        let rootPath = context.package.directoryURL.path
-        let sharedStateDirectory = sharedValidationStateDirectory(for: outputDirectory)
+        let rootPath = context.package.directoryURL.path(percentEncoded: false)
 
         return [
             .buildCommand(
@@ -28,8 +29,7 @@ struct InnoDIDAGValidationPlugin: BuildToolPlugin {
                 executable: coordinator.url,
                 arguments: [
                     "--root", rootPath,
-                    "--state-dir", sharedStateDirectory.path,
-                    "--output-dir", outputDirectory.path,
+                    "--output-dir", outputDirectory.path(percentEncoded: false),
                 ],
                 inputFiles: validationInputFiles(packageRoot: context.package.directoryURL),
                 outputFiles: [
@@ -43,6 +43,7 @@ struct InnoDIDAGValidationPlugin: BuildToolPlugin {
 
     private func validationInputFiles(packageRoot: URL) -> [URL] {
         let fileManager = FileManager.default
+        // Explicit safety-net for validationInputFiles; FileManager hidden-file skipping is the primary filter.
         let excludedDirectories: Set<String> = [
             ".build",
             ".git",
@@ -82,25 +83,9 @@ struct InnoDIDAGValidationPlugin: BuildToolPlugin {
             }
         }
 
-        return Array(Set(inputs)).sorted { $0.path < $1.path }
-    }
-
-    private func sharedValidationStateDirectory(for outputDirectory: URL) -> URL {
-        let components = outputDirectory.pathComponents
-        if let outputsIndex = components.lastIndex(of: "outputs"),
-           outputsIndex + 1 < components.count {
-            return URL(
-                fileURLWithPath: NSString.path(
-                    withComponents: Array(components.prefix(outputsIndex + 2))
-                ),
-                isDirectory: true
-            )
-            .appending(path: "innodi-dag-validation-state", directoryHint: .isDirectory)
-        }
-
-        return outputDirectory
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .appending(path: "innodi-dag-validation-state", directoryHint: .isDirectory)
+        var seenInputPaths = Set<String>()
+        return inputs
+            .filter { seenInputPaths.insert($0.path(percentEncoded: false)).inserted }
+            .sorted { $0.path(percentEncoded: false) < $1.path(percentEncoded: false) }
     }
 }

--- a/README.de.md
+++ b/README.de.md
@@ -181,6 +181,12 @@ hangst, das InnoDI-Container deklariert:
 )
 ```
 
+Wenn Teams gemessen haben, dass das Kompilieren des Source-Tools der dominante
+Einfuehrungsaufwand ist, stellt das Companion-Paket `InnoDIValidationTools` ein
+optionales prebuilt macOS validation plugin bereit. Haenge entweder das source
+plugin oben oder das prebuilt plugin an, niemals beide; unsupported hosts und
+lokale Paketentwicklung sollten weiter das source plugin verwenden.
+
 ## Schnellstart
 
 <!-- innodi:compile -->

--- a/README.es.md
+++ b/README.es.md
@@ -181,6 +181,12 @@ declara contenedores InnoDI:
 )
 ```
 
+Para equipos que hayan medido que compilar la herramienta fuente es el costo
+dominante de adopcion, el paquete complementario `InnoDIValidationTools`
+proporciona un plugin de validacion macOS prebuilt opcional. Adjunta el source
+plugin anterior o el prebuilt plugin, nunca ambos; los hosts no soportados y el
+desarrollo local de paquetes deben seguir usando el source plugin.
+
 ## Inicio rapido
 
 <!-- innodi:compile -->

--- a/README.ja.md
+++ b/README.ja.md
@@ -176,6 +176,12 @@ build-time DAG validator を有効にするには、InnoDI container を宣言�
 )
 ```
 
+source-tool のコンパイルが導入コストの大部分を占めると計測済みのチーム向けに、
+companion package の `InnoDIValidationTools` は任意の prebuilt macOS
+validation plugin を提供します。上記の source plugin か prebuilt plugin の
+どちらか一方だけを attach し、両方は attach しないでください。unsupported
+hosts と local package development では source plugin を使い続けてください。
+
 ## クイックスタート
 
 <!-- innodi:compile -->

--- a/README.ko.md
+++ b/README.ko.md
@@ -168,6 +168,12 @@ InnoDI 컨테이너를 선언하는 타깃에는 build-time DAG validator 플러
 )
 ```
 
+소스 도구 컴파일이 도입 비용의 대부분이라고 측정한 팀은 동반
+`InnoDIValidationTools` 패키지의 선택적 prebuilt macOS validation plugin을
+사용할 수 있습니다. 위의 source plugin 또는 prebuilt plugin 중 하나만
+연결하고, 둘 다 연결하지 마세요. unsupported hosts와 local package
+development에서는 source plugin을 계속 사용해야 합니다.
+
 ## 빠른 시작
 
 <!-- innodi:compile -->

--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ declares InnoDI containers:
 )
 ```
 
+For teams that have measured source-tool compilation as the dominant adoption
+cost, the companion `InnoDIValidationTools` package provides an optional
+prebuilt macOS validation plugin. Attach either the source plugin above or the
+prebuilt plugin, never both; unsupported hosts and local package development
+should keep using the source plugin.
+
 ## Quick Start
 
 <!-- innodi:compile -->

--- a/README.ru.md
+++ b/README.ru.md
@@ -179,6 +179,12 @@ dependencies: [
 )
 ```
 
+Для команд, которые измерили, что компиляция source tool является основной
+стоимостью внедрения, сопутствующий package `InnoDIValidationTools`
+предоставляет optional prebuilt macOS validation plugin. Подключайте либо
+source plugin выше, либо prebuilt plugin, но никогда оба; unsupported hosts и
+local package development должны продолжать использовать source plugin.
+
 ## Быстрый старт
 
 <!-- innodi:compile -->

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -163,6 +163,11 @@ dependencies: [
 )
 ```
 
+如果团队已经确认 source-tool 编译是主要采用成本，配套的
+`InnoDIValidationTools` package 提供可选的 prebuilt macOS validation
+plugin。只挂载上面的 source plugin 或 prebuilt plugin 之一，不能同时挂载；
+unsupported hosts 和 local package development 应继续使用 source plugin。
+
 ## 快速开始
 
 <!-- innodi:compile -->

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,7 +33,12 @@ Before tagging a release:
    - `Tools/generate-docc.sh`
 10. Decide whether any artifact or schema contract changed and update the contract notes below.
 11. Confirm the GitHub Actions `Release Gate` workflow is using the intended tag and toolchain.
-12. For public-discovery releases, confirm Swift Package Index readiness:
+12. If publishing the optional prebuilt validation plugin, prepare and verify
+    the companion package artifact:
+    - `(cd InnoDIValidationTools && Tools/prepare-release-artifact.sh --tag <tag> --source-path ../ --output-dir Artifacts)`
+    - verify a synthetic consumer can build with `InnoDIPrebuiltDAGValidationPlugin`
+    - publish `InnoDIValidationTools` with the same tag as this repository
+13. For public-discovery releases, confirm Swift Package Index readiness:
     - repository is public
     - `Package.swift` is at the root
     - a semantic-version tag exists
@@ -41,7 +46,7 @@ Before tagging a release:
     - package URL submitted to SPI includes `https://` and `.git`
     - after the package appears on SPI, use the maintainer badge markdown from
       the package page and add it to `README.md`
-13. After tagging, evaluate external discovery PRs:
+14. After tagging, evaluate external discovery PRs:
     - `matteocrippa/awesome-swift` for the compile-time DI category
     - the current leading SwiftUI awesome list only if the submitted entry
       focuses on `InnoDISwiftUI` helpers rather than core DI
@@ -126,6 +131,15 @@ standalone release assets.
 - **Documentation snippet compile gate.** `Tools/check-docs-code-blocks.sh`
   compiles Swift code fences marked with `<!-- innodi:compile -->`, and both PR
   and release gates run it.
+- **Lazy eager-call validation.** Direct `Lazy<T>` invocation inside `.shared`
+  factories now emits `provide.lazy-eager-call`, matching the Provider guard and
+  preventing soft edges from silently becoming eager initialization traps.
+- **CLI unknown options are hard errors.** `InnoDI-DependencyGraph` now fails
+  unknown flags instead of warning and continuing, so typoed validation flags
+  cannot silently skip release checks.
+- **Optional prebuilt validation tools scaffold.** `InnoDIValidationTools`
+  contains the companion prebuilt macOS validation plugin package and artifact
+  preparation script. The source plugin remains the default compatibility path.
 - **`@GenerateMock` consumer compile hardening.** The experimental mock macro
   now declares a deterministic `Mock` suffix, supports top-level protocols,
   qualifies helper names for overloaded methods, and handles generic method

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,13 +45,22 @@ surface:
 - `@SubContainer(withNames:)` has been removed from the public macro
   signature, parser, diagnostics, build-support hierarchy validation, examples,
   and runtime tests. Supported explicit wiring is now `with:` or `bindings:`.
+- Direct `Lazy<T>` calls during `.shared` construction now produce
+  `provide.lazy-eager-call`, matching the Provider eager-call guard and keeping
+  soft edges from silently becoming eager runtime traps.
 - SwiftUI stacked helper examples that previously needed the string escape
   hatch now split root helper construction into ordinary extension methods.
 - The DAG validation plugin stores lock/cache state below SwiftPM's plugin work
   directory instead of `<package>/.build/innodi-dag-validation`, keeping the
   documented `--scratch-path` recovery route valid on unsafe package roots.
+- The validation plugin now uses a package-level shared state directory across
+  target-level plugin work directories, and the repository includes a
+  multi-target SwiftPM integration fixture that verifies cache reuse.
 - `Tools/check-docs-code-blocks.sh` now compiles marked Swift documentation
   snippets, and CI/release gates run it.
+- `InnoDIValidationTools` scaffolds the optional prebuilt macOS validation
+  plugin package and release artifact tooling for consumers that have measured
+  source-tool compilation as their main build-cost bottleneck.
 
 ## Post-4.1.0 Priorities
 
@@ -154,6 +163,9 @@ ordered by user-facing trust risk first.
    - Evaluate whether `Lazy<T>` needs a lighter-weight surface such as a property-wrapper form, and whether the three built-in scopes need finer-grained lifetime variants for server-side or multi-window workloads.
 3. CLI and validation polish
    - Add stronger `--help` coverage, more usage tests, and sharper diagnostics around graph collection, fix-its, and release artifacts.
+   - Promote the prebuilt validation-tools package from scaffold to published
+     companion release after the first tagged artifact is produced and measured
+     against the source plugin in a synthetic consumer.
 4. Toolchain compatibility hardening
    - Keep SwiftSyntax, DocC, and build-plugin behavior stable across new Swift
      and Xcode toolchains without weakening the documented validation contract.

--- a/Sources/InnoDI-DAGValidationCoordinator/main.swift
+++ b/Sources/InnoDI-DAGValidationCoordinator/main.swift
@@ -4,7 +4,7 @@ import InnoDIBuildSupport
 struct CoordinatorArguments {
     let rootPath: String
     let toolPath: String?
-    let stateDirectoryPath: String
+    let stateDirectoryPath: String?
     let outputDirectoryPath: String
 }
 
@@ -17,10 +17,13 @@ do {
     let lockPolicy = ValidationCoordinatorLockPolicy(
         environment: ProcessInfo.processInfo.environment
     )
+    let stateDirectoryPath = arguments.stateDirectoryPath ?? sharedValidationStateDirectory(
+        forPluginOutputDirectory: URL(fileURLWithPath: arguments.outputDirectoryPath, isDirectory: true)
+    ).path(percentEncoded: false)
     let outcome = try await ValidationCoordinator.coordinate(
         rootPath: arguments.rootPath,
         toolPath: arguments.toolPath,
-        stateDirectoryPath: arguments.stateDirectoryPath,
+        stateDirectoryPath: stateDirectoryPath,
         outputDirectoryPath: arguments.outputDirectoryPath,
         lockPolicy: lockPolicy
     )
@@ -82,7 +85,7 @@ private func parseArguments() throws -> CoordinatorArguments {
         }
     }
 
-    guard let rootPath, let stateDirectoryPath, let outputDirectoryPath else {
+    guard let rootPath, let outputDirectoryPath else {
         throw CoordinatorArgumentError.missingRequiredArguments
     }
 
@@ -106,7 +109,7 @@ enum CoordinatorArgumentError: LocalizedError {
         case let .unknownOption(option):
             return "Unknown option \(option)."
         case .missingRequiredArguments:
-            return "Required options: --root, --state-dir, --output-dir. Optional compatibility input: --tool <path>."
+            return "Required options: --root, --output-dir. Optional compatibility inputs: --state-dir <path>, --tool <path>."
         }
     }
 }

--- a/Sources/InnoDI/InnoDI.docc/DiagnosticsGuide.md
+++ b/Sources/InnoDI/InnoDI.docc/DiagnosticsGuide.md
@@ -71,6 +71,8 @@ Most frequently-hit codes:
   a container member.
 - `provide.lazy-unsupported-target` — `Lazy<T>` parameter pointing at a type
   not declared as a container member.
+- `provide.lazy-eager-call` — `Lazy<T>` invoked during `.shared`
+  construction, which turns the soft edge back into an eager edge.
 - `provide.provider-non-transient-target` — `Provider<T>` resolved to a
   `.shared` or `.input`; providers require `.transient` targets.
 - `provide.provider-unsupported-target` — `Provider<T>` parameter with no

--- a/Sources/InnoDI/InnoDI.docc/PluginOptOut.md
+++ b/Sources/InnoDI/InnoDI.docc/PluginOptOut.md
@@ -40,11 +40,11 @@ Set the environment variable at build invocation:
 INNODI_DISABLE_BUILD_VALIDATION=1 swift build
 ```
 
-Accepted values are `1`, `true`, `TRUE`, `yes`, `YES`. Anything else (or
-the variable being unset) leaves the plugin enabled. The variable is read
-once per invocation when the plugin schedules its commands; it does not
-persist across builds, and Xcode's Build Settings sheet resets it when the
-process restarts.
+Accepted values are `1`, `true`, and `yes`, compared after trimming whitespace
+and lowercasing. Anything else (or the variable being unset) leaves the plugin
+enabled. The variable is read once per invocation when the plugin schedules its
+commands; it does not persist across builds, and Xcode's Build Settings sheet
+resets it when the process restarts.
 
 `INNODI_DISABLE_BUILD_VALIDATION=1` is independent from
 `INNODI_ALLOW_UNSAFE_LOCK=1`. The latter still runs the validator but on

--- a/Sources/InnoDI/InnoDI.docc/PluginOptOut.md
+++ b/Sources/InnoDI/InnoDI.docc/PluginOptOut.md
@@ -1,11 +1,12 @@
 # Build Plugin Opt-Out
 
-`InnoDIDAGValidationPlugin` attaches automatically to every target that
-declares an InnoDI container, runs the validation coordinator, and serializes
-graph artifacts under SwiftPM's plugin work directory. The coordinator is
-incremental and cached, but the plugin still adds a per-target build step
-and a swift-syntax invocation. Two narrow situations make opting out
-defensible.
+When a target attaches `InnoDIDAGValidationPlugin`, the plugin runs the
+validation coordinator for that target and serializes graph artifacts under
+SwiftPM's plugin work directory. SwiftPM does not automatically attach the
+plugin just because a target declares an InnoDI container; consumers opt in by
+listing the plugin in the target manifest. The coordinator is incremental and
+cached, but the plugin still adds a per-target build step and a swift-syntax
+invocation. Two narrow situations make opting out defensible.
 
 ## When Opt-Out Is Reasonable
 

--- a/Sources/InnoDI/InnoDI.docc/PolicyBoundaries.md
+++ b/Sources/InnoDI/InnoDI.docc/PolicyBoundaries.md
@@ -55,11 +55,84 @@ InnoDI keeps validation deterministic by choosing a few explicit boundaries.
 
 - `Lazy<T>` and `Provider<T>` defer container-member access after init-time
   wiring, so those edges are rendered but excluded from hard cycle detection.
-- The deferral is only effective when the factory receives and stores/calls the
-  wrapper itself. If a factory immediately calls the wrapper while constructing
-  the dependency, the dependency is effectively eager again.
+- The deferral is only effective when the factory receives the wrapper and
+  stores or forwards it. If a factory immediately calls the wrapper while constructing
+  the dependency, the dependency is effectively eager again. InnoDI diagnoses
+  direct `lazy()` / `provider()` calls and their direct `callAsFunction()` /
+  `resolver()` spellings inside `.shared` construction.
 - Indirect eager calls through helper functions are not type-checked by InnoDI;
   review those factories manually when breaking cycles with deferred wrappers.
+
+<!-- innodi:compile -->
+```swift
+import InnoDI
+
+struct Config {}
+struct Service { init(config: Config) {} }
+struct Request { init(config: Config) {} }
+struct Consumer {
+    let service: Lazy<Service>
+    let requests: Provider<Request>
+}
+
+@DIContainer
+struct AppContainer {
+    @Provide(.input)
+    var config: Config
+
+    @Provide(.shared, factory: { (config: Config) in
+        Service(config: config)
+    }, concrete: true)
+    var service: Service
+
+    @Provide(.transient, factory: { (config: Config) in
+        Request(config: config)
+    }, concrete: true)
+    var request: Request
+
+    @Provide(.shared, factory: { (service: Lazy<Service>, request: Provider<Request>) in
+        Consumer(service: service, requests: request)
+    }, concrete: true)
+    var consumer: Consumer
+}
+
+let container = AppContainer(config: Config())
+_ = container.consumer
+```
+
+<!-- innodi:compile -->
+```swift
+import InnoDI
+
+struct Config {}
+struct FeatureService { init(config: Config) {} }
+
+@DIContainer
+struct FeatureContainer {
+    @Provide(.input)
+    var featureConfig: Config
+
+    @Provide(.shared, factory: { (featureConfig: Config) in
+        FeatureService(config: featureConfig)
+    }, concrete: true)
+    var service: FeatureService
+}
+
+@DIContainer
+struct AppContainer {
+    @Provide(.input)
+    var config: Config
+
+    @SubContainer(
+        scope: .shared,
+        bindings: [(child: \FeatureContainer.featureConfig, parent: \AppContainer.config)]
+    )
+    var feature: FeatureContainer
+}
+
+let container = AppContainer(config: Config())
+_ = container.feature
+```
 
 ## Concrete Opt-In
 

--- a/Sources/InnoDI/InnoDI.docc/ko.lproj/DiagnosticsGuide.md
+++ b/Sources/InnoDI/InnoDI.docc/ko.lproj/DiagnosticsGuide.md
@@ -75,6 +75,8 @@ InnoDI 매크로가 만드는 모든 error/warning/note는
   멤버를 가리키지 않습니다.
 - `provide.lazy-unsupported-target` — `Lazy<T>` 파라미터가 컨테이너
   멤버로 선언되지 않은 타입을 가리킵니다.
+- `provide.lazy-eager-call` — `Lazy<T>`가 `.shared` construction 시점에
+  호출되어 soft edge가 다시 eager edge가 됐습니다.
 - `provide.provider-non-transient-target` — `Provider<T>`가 `.shared`
   또는 `.input`로 해소됐습니다. provider는 `.transient` target이 필요합니다.
 - `provide.provider-unsupported-target` — `Provider<T>` 파라미터에

--- a/Sources/InnoDI/InnoDI.swift
+++ b/Sources/InnoDI/InnoDI.swift
@@ -86,7 +86,10 @@ public macro Provide(
 /// the container's own `.shared` / `.transient` semantics continue to govern
 /// the target's lifecycle. Do not call the wrapper inside the factory body
 /// itself; only store it for later use, or the backing cell will not yet be
-/// populated. `Lazy<T>` remains synchronous, so it cannot target `.shared`
+/// populated. InnoDI diagnoses direct `lazy()` / `lazy.callAsFunction()` /
+/// `lazy.resolver()` calls inside `.shared` construction; indirect eager calls
+/// routed through helper APIs remain a policy boundary you should review
+/// manually. `Lazy<T>` remains synchronous, so it cannot target `.shared`
 /// members provided by `asyncFactory`.
 ///
 /// `Lazy<T>` is intentionally a non-`Sendable` deferred handle. The wrapper

--- a/Sources/InnoDIBuildSupport/PluginSharedStateDirectory.swift
+++ b/Sources/InnoDIBuildSupport/PluginSharedStateDirectory.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+package func sharedValidationStateDirectory(forPluginOutputDirectory outputDirectory: URL) -> URL {
+    let components = outputDirectory.pathComponents
+
+    // sharedValidationStateDirectory(forPluginOutputDirectory:) depends on SwiftPM's
+    // plugin work-directory shape: .../plugins/outputs/<package>/<target>/<plugin>.
+    // It extracts through outputs/<package> so every target/plugin in one package
+    // reuses state; revisit this if SwiftPM changes the plugin output layout.
+    if let outputsIndex = components.indices.reversed().first(where: { index in
+        components[index] == "outputs"
+            && index > 0
+            && components[index - 1] == "plugins"
+            && index + 1 < components.count
+    }) {
+        return URL(
+            fileURLWithPath: NSString.path(
+                withComponents: Array(components.prefix(outputsIndex + 2))
+            ),
+            isDirectory: true
+        )
+        .appending(path: "innodi-dag-validation-state", directoryHint: .isDirectory)
+    }
+
+    var fallback = outputDirectory
+    for _ in 0..<2 {
+        let parent = fallback.deletingLastPathComponent()
+        guard parent.path != fallback.path else { break }
+        fallback = parent
+    }
+    return fallback.appending(path: "innodi-dag-validation-state", directoryHint: .isDirectory)
+}

--- a/Sources/InnoDIBuildSupport/WorkspaceHierarchyValidation.swift
+++ b/Sources/InnoDIBuildSupport/WorkspaceHierarchyValidation.swift
@@ -121,6 +121,14 @@ func makeChildContainerOutOfWorkspaceIssue(edge: ResolvedHierarchyEdge) -> Valid
             )
         )
     }
+    if let parentModule = edge.parentModule {
+        notes.append(
+            ValidationIssueNote(
+                message: "parent module '\(parentModule.displayName)' is declared at '\(parentModule.manifestPath)'. Confirm this manifest or project file declares a dependency on the child target/product.",
+                location: edge.parentLocation
+            )
+        )
+    }
     notes.append(contentsOf: hierarchyModuleDisambiguationNotes(for: edge))
 
     var metadata: [String: String] = [
@@ -132,9 +140,11 @@ func makeChildContainerOutOfWorkspaceIssue(edge: ResolvedHierarchyEdge) -> Valid
     ]
     if let parentModule = edge.parentModule {
         metadata["parentModuleID"] = parentModule.moduleID
+        metadata["parentManifestPath"] = parentModule.manifestPath
     }
     if let childModule = edge.childModule {
         metadata["childModuleID"] = childModule.moduleID
+        metadata["childManifestPath"] = childModule.manifestPath
     }
 
     return ValidationIssue(
@@ -143,7 +153,7 @@ func makeChildContainerOutOfWorkspaceIssue(edge: ResolvedHierarchyEdge) -> Valid
         message: "@SubContainer '\(edge.subContainer.memberName)' on '\(edge.parentPath)' (module '\(parentModuleName)') references child container '\(edge.childPath)', but the workspace validator could not find a container record for it. Cross-module checks (component marker, module dependency edge, dependency satisfaction) are skipped for this edge.",
         location: edge.subContainer.location,
         notes: notes,
-        remediation: "Confirm the child target ships @DIComponent and that the parent module's manifest depends on the child module, then re-run validation. If the child intentionally lives outside the validated workspace, treat this warning as the contract you are accepting.",
+        remediation: "Confirm the child target ships @DIComponent, add the child target/product to the parent module's manifest dependencies, and re-run validation. If the child intentionally lives outside the validated workspace, treat this warning as the contract you are accepting.",
         metadata: metadata
     )
 }

--- a/Sources/InnoDIDependencyGraphCLI/CLI/Arguments.swift
+++ b/Sources/InnoDIDependencyGraphCLI/CLI/Arguments.swift
@@ -58,7 +58,6 @@ func parseArguments(_ rawArguments: [String] = Array(CommandLine.arguments.dropF
     var validateDAG = false
     var diagnoseLockPath: String?
     var cacheStatsPath: String?
-    let warnings: [String] = []
 
     let args = rawArguments
     var index = 0
@@ -152,8 +151,7 @@ func parseArguments(_ rawArguments: [String] = Array(CommandLine.arguments.dropF
             validateDAG: validateDAG,
             diagnoseLockPath: diagnoseLockPath,
             cacheStatsPath: cacheStatsPath
-        ),
-        warnings: warnings
+        )
     )
 }
 
@@ -192,7 +190,7 @@ extension ArgumentsError {
         case .invalidFormat(let value):
             return "Error: Invalid --format value '\(value)'"
         case .unknownOption(let option):
-            return "Error: Unknown option \(option)"
+            return "Error: Unknown option '\(option)'"
         }
     }
 }

--- a/Sources/InnoDIDependencyGraphCLI/CLI/Arguments.swift
+++ b/Sources/InnoDIDependencyGraphCLI/CLI/Arguments.swift
@@ -44,6 +44,7 @@ enum ArgumentParseResult: Equatable {
 enum ArgumentsError: Error, Equatable {
     case missingOptionValue(option: String)
     case invalidFormat(value: String)
+    case unknownOption(option: String)
 }
 
 /// Pure-function argument parser. No process exit, no stderr writes — the
@@ -57,7 +58,7 @@ func parseArguments(_ rawArguments: [String] = Array(CommandLine.arguments.dropF
     var validateDAG = false
     var diagnoseLockPath: String?
     var cacheStatsPath: String?
-    var warnings: [String] = []
+    let warnings: [String] = []
 
     let args = rawArguments
     var index = 0
@@ -137,7 +138,7 @@ func parseArguments(_ rawArguments: [String] = Array(CommandLine.arguments.dropF
         } else if arg == "--help" || arg == "-h" {
             return .helpRequested
         } else if arg.hasPrefix("-") {
-            warnings.append("Warning: unrecognized option '\(arg)'")
+            return .failed(.unknownOption(option: arg))
         }
 
         index += 1
@@ -190,6 +191,8 @@ extension ArgumentsError {
             return "Error: Option \(option) requires a value"
         case .invalidFormat(let value):
             return "Error: Invalid --format value '\(value)'"
+        case .unknownOption(let option):
+            return "Error: Unknown option \(option)"
         }
     }
 }

--- a/Sources/InnoDIMacros/DIContainerValidator.swift
+++ b/Sources/InnoDIMacros/DIContainerValidator.swift
@@ -103,17 +103,35 @@ struct DIContainerValidator {
             let providerClosureReferences = Dictionary(uniqueKeysWithValues: member.providerClosureParameterReferences.map { ($0.name, $0) })
 
             if member.scope == .shared {
+                let sharedClosures = [member.factory, member.asyncFactory].compactMap { $0?.as(ClosureExprSyntax.self) }
+                let lazyNames = Set(softClosureReferences.keys)
+                if !lazyNames.isEmpty {
+                    for closure in sharedClosures {
+                        for callSite in collectDirectDeferredEagerCalls(in: closure, dependencyNames: lazyNames) {
+                            context.diagnose(
+                                Diagnostic(
+                                    node: callSite.node,
+                                    message: SimpleDiagnostic.provideLazyEagerCall(
+                                        memberName: member.name,
+                                        dependencyName: callSite.dependencyName
+                                    )
+                                )
+                            )
+                            hadErrors = true
+                        }
+                    }
+                }
+
                 let providerNames = Set(providerClosureReferences.keys)
                 if !providerNames.isEmpty {
-                    let sharedClosures = [member.factory, member.asyncFactory].compactMap { $0?.as(ClosureExprSyntax.self) }
                     for closure in sharedClosures {
-                        for callSite in collectDirectProviderEagerCalls(in: closure, providerNames: providerNames) {
+                        for callSite in collectDirectDeferredEagerCalls(in: closure, dependencyNames: providerNames) {
                             context.diagnose(
                                 Diagnostic(
                                     node: callSite.node,
                                     message: SimpleDiagnostic.provideProviderEagerCall(
                                         memberName: member.name,
-                                        dependencyName: callSite.providerName
+                                        dependencyName: callSite.dependencyName
                                     )
                                 )
                             )

--- a/Sources/InnoDIMacros/DIProvideValidationDiagnostics.swift
+++ b/Sources/InnoDIMacros/DIProvideValidationDiagnostics.swift
@@ -88,18 +88,18 @@ internal func makeUnresolvedFactoryParameterDiagnostic(
     )
 }
 
-internal struct DirectProviderEagerCallSite {
-    let providerName: String
+internal struct DirectDeferredEagerCallSite {
+    let dependencyName: String
     let node: Syntax
 }
 
-internal func collectDirectProviderEagerCalls(
+internal func collectDirectDeferredEagerCalls(
     in closure: ClosureExprSyntax,
-    providerNames: Set<String>
-) -> [DirectProviderEagerCallSite] {
-    guard !providerNames.isEmpty else { return [] }
+    dependencyNames: Set<String>
+) -> [DirectDeferredEagerCallSite] {
+    guard !dependencyNames.isEmpty else { return [] }
 
-    var callSites: [DirectProviderEagerCallSite] = []
+    var callSites: [DirectDeferredEagerCallSite] = []
 
     func walk(node: Syntax) {
         if node.is(ClosureExprSyntax.self)
@@ -109,7 +109,7 @@ internal func collectDirectProviderEagerCalls(
         }
 
         if let functionCall = node.as(FunctionCallExprSyntax.self),
-           let callSite = directProviderEagerCallSite(in: functionCall, providerNames: providerNames) {
+           let callSite = directDeferredEagerCallSite(in: functionCall, dependencyNames: dependencyNames) {
             callSites.append(callSite)
         }
 
@@ -125,26 +125,26 @@ internal func collectDirectProviderEagerCalls(
     return callSites
 }
 
-private func directProviderEagerCallSite(
+private func directDeferredEagerCallSite(
     in functionCall: FunctionCallExprSyntax,
-    providerNames: Set<String>
-) -> DirectProviderEagerCallSite? {
-    let calledExpression = unwrapProviderCallExpression(functionCall.calledExpression)
+    dependencyNames: Set<String>
+) -> DirectDeferredEagerCallSite? {
+    let calledExpression = unwrapDeferredCallExpression(functionCall.calledExpression)
 
     if let reference = calledExpression.as(DeclReferenceExprSyntax.self),
-       providerNames.contains(reference.baseName.text) {
-        return DirectProviderEagerCallSite(
-            providerName: reference.baseName.text,
+       dependencyNames.contains(reference.baseName.text) {
+        return DirectDeferredEagerCallSite(
+            dependencyName: reference.baseName.text,
             node: Syntax(reference)
         )
     }
 
     if let memberAccess = calledExpression.as(MemberAccessExprSyntax.self),
-       let base = unwrapProviderCallBase(memberAccess.base),
-       providerNames.contains(base.baseName.text),
+       let base = unwrapDeferredCallBase(memberAccess.base),
+       dependencyNames.contains(base.baseName.text),
        ["callAsFunction", "resolver"].contains(memberAccess.declName.baseName.text) {
-        return DirectProviderEagerCallSite(
-            providerName: base.baseName.text,
+        return DirectDeferredEagerCallSite(
+            dependencyName: base.baseName.text,
             node: Syntax(memberAccess)
         )
     }
@@ -152,21 +152,21 @@ private func directProviderEagerCallSite(
     return nil
 }
 
-private func unwrapProviderCallExpression(_ expression: ExprSyntax) -> ExprSyntax {
+private func unwrapDeferredCallExpression(_ expression: ExprSyntax) -> ExprSyntax {
     if let tuple = expression.as(TupleExprSyntax.self),
        tuple.elements.count == 1,
        let first = tuple.elements.first,
        first.label == nil {
-        return unwrapProviderCallExpression(first.expression)
+        return unwrapDeferredCallExpression(first.expression)
     }
 
     return expression
 }
 
-private func unwrapProviderCallBase(_ expression: ExprSyntax?) -> DeclReferenceExprSyntax? {
+private func unwrapDeferredCallBase(_ expression: ExprSyntax?) -> DeclReferenceExprSyntax? {
     guard let expression else { return nil }
 
-    let unwrapped = unwrapProviderCallExpression(expression)
+    let unwrapped = unwrapDeferredCallExpression(expression)
     return unwrapped.as(DeclReferenceExprSyntax.self)
 }
 

--- a/Sources/InnoDIMacros/Diagnostics.swift
+++ b/Sources/InnoDIMacros/Diagnostics.swift
@@ -38,6 +38,7 @@ enum InnoDIDiagnosticCode: String, CaseIterable {
     case provideBoolLiteralRequired = "provide.bool-literal-required"
     case provideInvalidWithDependencies = "provide.invalid-with-dependencies"
     case provideLazyUnsupportedTarget = "provide.lazy-unsupported-target"
+    case provideLazyEagerCall = "provide.lazy-eager-call"
     case provideProviderNonTransientTarget = "provide.provider-non-transient-target"
     case provideProviderUnsupportedTarget = "provide.provider-unsupported-target"
     case provideProviderEagerCall = "provide.provider-eager-call"
@@ -98,8 +99,8 @@ enum InnoDIDiagnosticCode: String, CaseIterable {
                 .provideFactoryConflict, .provideAsyncFactoryInvalidScope, .provideAsyncFactoryMustBeAsync,
                 .provideFactoryMustBeSync, .provideFactoryMustNotThrow,
                 .provideBoolLiteralRequired, .provideInvalidWithDependencies,
-                .provideLazyUnsupportedTarget, .provideProviderNonTransientTarget, .provideProviderUnsupportedTarget,
-                .provideProviderEagerCall,
+                .provideLazyUnsupportedTarget, .provideLazyEagerCall,
+                .provideProviderNonTransientTarget, .provideProviderUnsupportedTarget, .provideProviderEagerCall,
                 .provideUnresolvedFactoryParameter, .provideUnavailableDependencyReference, .provideUnresolvedWithDependency,
                 .containerUnknownDependency, .containerDependencyCycle, .containerMainActorConflict,
                 .containerBoolLiteralRequired,
@@ -284,6 +285,13 @@ extension SimpleDiagnostic {
         Self(
             "Factory parameter '\(dependencyName)' for '\(memberName)' cannot use Lazy<T> because '\(dependencyName)' is provided by asyncFactory and Lazy resolvers are synchronous.",
             code: .provideLazyUnsupportedTarget
+        )
+    }
+
+    static func provideLazyEagerCall(memberName: String, dependencyName: String) -> Self {
+        Self(
+            "Factory parameter '\(dependencyName)' for '\(memberName)' cannot call Lazy<T> during .shared construction. Store or forward the lazy handle and invoke it only after the container has finished initializing.",
+            code: .provideLazyEagerCall
         )
     }
 

--- a/Tests/InnoDIBuildSupportTests/CrossModuleChildDiagnosticsTests.swift
+++ b/Tests/InnoDIBuildSupportTests/CrossModuleChildDiagnosticsTests.swift
@@ -70,7 +70,7 @@ struct CrossModuleChildDiagnosticsTests {
         let childRecord = WorkspaceModuleRecord(
             moduleID: "Child",
             name: "FeatureModule",
-            manifestPath: "/tmp/Package.swift",
+            manifestPath: "/tmp/ChildPackage.swift",
             packageDisplayName: nil,
             packageIdentity: nil,
             sourcePatterns: [],
@@ -93,7 +93,7 @@ struct CrossModuleChildDiagnosticsTests {
         #expect(issue.metadata["parentManifestPath"] == "/tmp/Package.swift")
         #expect(issue.metadata["childModule"] == "FeatureModule")
         #expect(issue.metadata["childModuleID"] == "Child")
-        #expect(issue.metadata["childManifestPath"] == "/tmp/Package.swift")
+        #expect(issue.metadata["childManifestPath"] == "/tmp/ChildPackage.swift")
         // The note set must include the workspace-not-loaded explanation.
         #expect(issue.notes.contains { $0.message.contains("not visible to this validation pass") })
         #expect(issue.notes.contains { $0.message.contains("declares a dependency on the child target/product") })

--- a/Tests/InnoDIBuildSupportTests/CrossModuleChildDiagnosticsTests.swift
+++ b/Tests/InnoDIBuildSupportTests/CrossModuleChildDiagnosticsTests.swift
@@ -90,10 +90,14 @@ struct CrossModuleChildDiagnosticsTests {
         #expect(issue.severity == .warning)
         #expect(issue.metadata["parentModule"] == "AppFeature")
         #expect(issue.metadata["parentModuleID"] == "Parent")
+        #expect(issue.metadata["parentManifestPath"] == "/tmp/Package.swift")
         #expect(issue.metadata["childModule"] == "FeatureModule")
         #expect(issue.metadata["childModuleID"] == "Child")
+        #expect(issue.metadata["childManifestPath"] == "/tmp/Package.swift")
         // The note set must include the workspace-not-loaded explanation.
         #expect(issue.notes.contains { $0.message.contains("not visible to this validation pass") })
+        #expect(issue.notes.contains { $0.message.contains("declares a dependency on the child target/product") })
+        #expect(issue.remediation?.contains("child target/product") == true)
     }
 
     @Test("validateResolvedEdges surfaces the warning instead of skipping silently")

--- a/Tests/InnoDIBuildSupportTests/StrictConcurrencyBuildTests.swift
+++ b/Tests/InnoDIBuildSupportTests/StrictConcurrencyBuildTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Dispatch
 import Darwin
 import Testing
+import InnoDIBuildSupport
 import InnoDITestSupport
 
 @Suite("Strict concurrency build integration", .serialized, .tags(.slow))
@@ -328,6 +329,43 @@ struct StrictConcurrencyBuildTests {
         )
     }
 
+    @Test("DAG validation plugin shares state across multiple plugin-attached targets", .tags(.slow))
+    func dagValidationPluginSharesStateAcrossTargets() throws {
+        let fixture = try makeMultiTargetPluginFixture()
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent("InnoDI-MultiTargetPlugin-\(UUID().uuidString)", isDirectory: true)
+        defer {
+            try? FileManager.default.removeItem(at: fixture)
+            try? FileManager.default.removeItem(at: scratch)
+        }
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+
+        let result = try runStrictConcurrencyBuild(packageURL: fixture, scratchPath: scratch)
+
+        if result.timedOut || result.exitCode != 0 {
+            Issue.record("swift build failed:\n\(result.stdout)\n\(result.stderr)")
+        }
+        #expect(!result.timedOut)
+        #expect(result.exitCode == 0)
+
+        let stampURLs = try findFiles(named: "dag-validation-stamp.txt", under: scratch)
+        let metricsURLs = try findFiles(named: "dag-validation-metrics.json", under: scratch)
+        let sharedStateDirectories = try findDirectories(named: "innodi-dag-validation-state", under: scratch)
+        let metrics = try metricsURLs.map { url in
+            let data = try Data(contentsOf: url)
+            return try JSONDecoder().decode(ValidationMetricsArtifact.self, from: data)
+        }
+
+        #expect(stampURLs.count >= 2)
+        #expect(metrics.count >= 2)
+        #expect(sharedStateDirectories.count == 1)
+        #expect(metrics.contains { $0.wasCached })
+        if let sharedStateDirectory = sharedStateDirectories.first {
+            let sharedRunResults = try findFiles(named: "result.json", under: sharedStateDirectory)
+            #expect(sharedRunResults.count == 1)
+        }
+    }
+
     @Test("Deferred wrappers remain non-Sendable even when the payload is Sendable")
     func deferredWrappersStillFailInSendableHolders() throws {
         let fixture = try makeStrictConcurrencyFixture(
@@ -585,6 +623,98 @@ private func makeStrictConcurrencyFixture(
     return rootURL
 }
 
+private func makeMultiTargetPluginFixture() throws -> URL {
+    let rootURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("InnoDI-MultiTargetPluginFixture-\(UUID().uuidString)", isDirectory: true)
+    let featureAURL = rootURL.appendingPathComponent("Sources/FeatureA", isDirectory: true)
+    let featureBURL = rootURL.appendingPathComponent("Sources/FeatureB", isDirectory: true)
+
+    try FileManager.default.createDirectory(at: featureAURL, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: featureBURL, withIntermediateDirectories: true)
+
+    let escapedRepoPath = packageRootURL()
+        .path(percentEncoded: false)
+        .replacingOccurrences(of: "\\", with: "\\\\")
+    let dependencyPackageIdentity: String = {
+        var identity = packageRootURL().lastPathComponent.lowercased()
+        if identity.hasSuffix(".git") {
+            identity.removeLast(".git".count)
+        }
+        return identity
+    }()
+
+    let manifest = """
+    // swift-tools-version: 6.2
+    import PackageDescription
+
+    let package = Package(
+        name: "MultiTargetPluginFixture",
+        platforms: [
+            .macOS(.v14),
+            .iOS(.v17)
+        ],
+        dependencies: [
+            .package(path: "\(escapedRepoPath)")
+        ],
+        targets: [
+            .executableTarget(
+                name: "FeatureA",
+                dependencies: [
+                    .product(name: "InnoDI", package: "\(dependencyPackageIdentity)")
+                ],
+                plugins: [
+                    .plugin(name: "InnoDIDAGValidationPlugin", package: "\(dependencyPackageIdentity)")
+                ]
+            ),
+            .executableTarget(
+                name: "FeatureB",
+                dependencies: [
+                    .product(name: "InnoDI", package: "\(dependencyPackageIdentity)")
+                ],
+                plugins: [
+                    .plugin(name: "InnoDIDAGValidationPlugin", package: "\(dependencyPackageIdentity)")
+                ]
+            )
+        ]
+    )
+    """
+
+    try manifest.write(
+        to: rootURL.appendingPathComponent("Package.swift"),
+        atomically: true,
+        encoding: .utf8
+    )
+    try multiTargetFeatureSource(containerName: "FeatureAContainer").write(
+        to: featureAURL.appendingPathComponent("main.swift"),
+        atomically: true,
+        encoding: .utf8
+    )
+    try multiTargetFeatureSource(containerName: "FeatureBContainer").write(
+        to: featureBURL.appendingPathComponent("main.swift"),
+        atomically: true,
+        encoding: .utf8
+    )
+
+    return rootURL
+}
+
+private func multiTargetFeatureSource(containerName: String) -> String {
+    """
+    import InnoDI
+
+    struct Service: Sendable {}
+
+    @DIContainer
+    struct \(containerName) {
+        @Provide(.shared, factory: Service(), concrete: true)
+        var service: Service
+    }
+
+    let container = \(containerName)()
+    _ = container.service
+    """
+}
+
 private func packageRootURL() -> URL {
     if let override = ProcessInfo.processInfo.environment["PACKAGE_ROOT"],
        !override.isEmpty {
@@ -608,6 +738,34 @@ private func packageRootURL() -> URL {
 private let strictConcurrencyBuildTimeoutSeconds: TimeInterval = 180
 private let strictConcurrencyTerminationGracePeriodSeconds: TimeInterval = 5
 private let strictConcurrencyHardKillGracePeriodSeconds: TimeInterval = 2
+
+private func findFiles(named name: String, under rootURL: URL) throws -> [URL] {
+    try findFileSystemEntries(named: name, under: rootURL, isDirectory: false)
+}
+
+private func findDirectories(named name: String, under rootURL: URL) throws -> [URL] {
+    try findFileSystemEntries(named: name, under: rootURL, isDirectory: true)
+}
+
+private func findFileSystemEntries(named name: String, under rootURL: URL, isDirectory: Bool) throws -> [URL] {
+    guard let enumerator = FileManager.default.enumerator(
+        at: rootURL,
+        includingPropertiesForKeys: [.isDirectoryKey],
+        options: [.skipsHiddenFiles]
+    ) else {
+        return []
+    }
+
+    var matches: [URL] = []
+    for case let url as URL in enumerator {
+        guard url.lastPathComponent == name else { continue }
+        let values = try url.resourceValues(forKeys: [.isDirectoryKey])
+        if values.isDirectory == isDirectory {
+            matches.append(url)
+        }
+    }
+    return matches.sorted { $0.path < $1.path }
+}
 
 private func installStrictConcurrencyReadHandler(
     on handle: FileHandle,

--- a/Tests/InnoDIBuildSupportTests/StrictConcurrencyBuildTests.swift
+++ b/Tests/InnoDIBuildSupportTests/StrictConcurrencyBuildTests.swift
@@ -564,20 +564,9 @@ private func makeStrictConcurrencyFixture(
 
     try FileManager.default.createDirectory(at: sourcesURL, withIntermediateDirectories: true)
 
-    let escapedRepoPath = packageRootURL()
-        .path(percentEncoded: false)
-        .replacingOccurrences(of: "\\", with: "\\\\")
-    // Mirror SwiftPM's package-identity normalization (`.git` suffix stripped +
-    // lowercased) used by `normalizePackageIdentity` in InnoDIBuildSupport so
-    // path-identity CI passes when the checkout directory is `InnoDI.git` or
-    // any other case-mixed name.
-    let dependencyPackageIdentity: String = {
-        var identity = packageRootURL().lastPathComponent.lowercased()
-        if identity.hasSuffix(".git") {
-            identity.removeLast(".git".count)
-        }
-        return identity
-    }()
+    let packageIdentity = packageIdentityInfo(packageRootURL: packageRootURL())
+    let escapedRepoPath = packageIdentity.escapedRepoPath
+    let dependencyPackageIdentity = packageIdentity.dependencyPackageIdentity
 
     let dependencyList = dependencies
         .map { ".product(name: \"\($0)\", package: \"\(dependencyPackageIdentity)\")" }
@@ -632,16 +621,9 @@ private func makeMultiTargetPluginFixture() throws -> URL {
     try FileManager.default.createDirectory(at: featureAURL, withIntermediateDirectories: true)
     try FileManager.default.createDirectory(at: featureBURL, withIntermediateDirectories: true)
 
-    let escapedRepoPath = packageRootURL()
-        .path(percentEncoded: false)
-        .replacingOccurrences(of: "\\", with: "\\\\")
-    let dependencyPackageIdentity: String = {
-        var identity = packageRootURL().lastPathComponent.lowercased()
-        if identity.hasSuffix(".git") {
-            identity.removeLast(".git".count)
-        }
-        return identity
-    }()
+    let packageIdentity = packageIdentityInfo(packageRootURL: packageRootURL())
+    let escapedRepoPath = packageIdentity.escapedRepoPath
+    let dependencyPackageIdentity = packageIdentity.dependencyPackageIdentity
 
     let manifest = """
     // swift-tools-version: 6.2
@@ -733,6 +715,21 @@ private func packageRootURL() -> URL {
     }
 
     fatalError("Unable to locate Package.swift from \(#filePath).")
+}
+
+private func packageIdentityInfo(packageRootURL: URL) -> (escapedRepoPath: String, dependencyPackageIdentity: String) {
+    let escapedRepoPath = packageRootURL
+        .path(percentEncoded: false)
+        .replacingOccurrences(of: "\\", with: "\\\\")
+    // Mirror SwiftPM's package-identity normalization (`.git` suffix stripped +
+    // lowercased) used by `normalizePackageIdentity` in InnoDIBuildSupport so
+    // path-identity CI passes when the checkout directory is `InnoDI.git` or
+    // any other case-mixed name.
+    var identity = packageRootURL.lastPathComponent.lowercased()
+    if identity.hasSuffix(".git") {
+        identity.removeLast(".git".count)
+    }
+    return (escapedRepoPath, identity)
 }
 
 private let strictConcurrencyBuildTimeoutSeconds: TimeInterval = 180

--- a/Tests/InnoDIBuildSupportTests/ValidationCoordinatorTests.swift
+++ b/Tests/InnoDIBuildSupportTests/ValidationCoordinatorTests.swift
@@ -10,6 +10,35 @@ import Dispatch
 
 @Suite("ValidationCoordinator")
 struct ValidationCoordinatorTests {
+    @Test("Shared validation state directory anchors at the SwiftPM plugin package output")
+    func sharedValidationStateDirectoryAnchorsAtPluginPackageOutput() {
+        let sourcePluginOutput = URL(
+            fileURLWithPath: "/tmp/build/plugins/outputs/Consumer/FeatureA/InnoDIDAGValidationPlugin",
+            isDirectory: true
+        )
+        let prebuiltPluginOutput = URL(
+            fileURLWithPath: "/tmp/build/plugins/outputs/Consumer/FeatureA/InnoDIPrebuiltDAGValidationPlugin",
+            isDirectory: true
+        )
+        let outputsNamedTargetOutput = URL(
+            fileURLWithPath: "/tmp/build/plugins/outputs/Consumer/outputs/InnoDIDAGValidationPlugin",
+            isDirectory: true
+        )
+        let nestedPluginOutput = URL(
+            fileURLWithPath: "/tmp/build/plugins/outputs/Consumer/FeatureA/InnoDIDAGValidationPlugin/work",
+            isDirectory: true
+        )
+        let expected = URL(
+            fileURLWithPath: "/tmp/build/plugins/outputs/Consumer/innodi-dag-validation-state",
+            isDirectory: true
+        )
+
+        #expect(sharedValidationStateDirectory(forPluginOutputDirectory: sourcePluginOutput).path == expected.path)
+        #expect(sharedValidationStateDirectory(forPluginOutputDirectory: prebuiltPluginOutput).path == expected.path)
+        #expect(sharedValidationStateDirectory(forPluginOutputDirectory: outputsNamedTargetOutput).path == expected.path)
+        #expect(sharedValidationStateDirectory(forPluginOutputDirectory: nestedPluginOutput).path == expected.path)
+    }
+
     @Test("Whitespace and comments do not change the AST signature")
     func whitespaceAndCommentsDoNotChangeASTSignature() throws {
         let fixture = try makeFixture()

--- a/Tests/InnoDIDependencyGraphCLITests/ArgumentsParsingTests.swift
+++ b/Tests/InnoDIDependencyGraphCLITests/ArgumentsParsingTests.swift
@@ -62,14 +62,10 @@ struct ArgumentsParsingTests {
         #expect(warnings.isEmpty)
     }
 
-    @Test("Unknown options are returned as warnings")
-    func unknownOptionsAreWarnings() {
-        guard case let .parsed(args, warnings) = parseArguments(["--ignored", "value"]) else {
-            Issue.record("Expected parsed result")
-            return
-        }
-        #expect(args.format == nil)
-        #expect(warnings == ["Warning: unrecognized option '--ignored'"])
+    @Test("Unknown options fail parsing")
+    func unknownOptionsFailParsing() {
+        let result = parseArguments(["--ignored", "value"])
+        #expect(result == .failed(.unknownOption(option: "--ignored")))
     }
 
     @Test("--help short-circuits parsing")

--- a/Tests/InnoDIDependencyGraphCLITests/DependencyGraphCLITests.swift
+++ b/Tests/InnoDIDependencyGraphCLITests/DependencyGraphCLITests.swift
@@ -195,7 +195,7 @@ struct DependencyGraphCLITests {
         ])
 
         #expect(result.exitCode == 1)
-        #expect(result.stderr.contains("Error: Unknown option --unknown"))
+        #expect(result.stderr.contains("Error: Unknown option '--unknown'"))
         #expect(result.stdout.contains("Usage: InnoDI-DependencyGraph"))
         #expect(!result.stdout.contains("InnoDI Dependency Graph"))
     }

--- a/Tests/InnoDIDependencyGraphCLITests/DependencyGraphCLITests.swift
+++ b/Tests/InnoDIDependencyGraphCLITests/DependencyGraphCLITests.swift
@@ -183,8 +183,8 @@ struct DependencyGraphCLITests {
         #expect(result.stderr.contains("DAG validation failed."))
     }
 
-    @Test("Unknown option emits warning but continues")
-    func unknownOptionWarnsAndContinues() throws {
+    @Test("Unknown option fails with usage and no graph output")
+    func unknownOptionFailsWithUsage() throws {
         let fixtureURL = try makeFixtureProject()
         defer { try? FileManager.default.removeItem(at: fixtureURL) }
 
@@ -194,9 +194,10 @@ struct DependencyGraphCLITests {
             "--format", "ascii"
         ])
 
-        #expect(result.exitCode == 0)
-        #expect(result.stderr.contains("Warning: unrecognized option '--unknown'"))
-        #expect(result.stdout.contains("InnoDI Dependency Graph"))
+        #expect(result.exitCode == 1)
+        #expect(result.stderr.contains("Error: Unknown option --unknown"))
+        #expect(result.stdout.contains("Usage: InnoDI-DependencyGraph"))
+        #expect(!result.stdout.contains("InnoDI Dependency Graph"))
     }
 
     @Test("Missing value for --root fails with usage")

--- a/Tests/InnoDIMacrosTests/DIContainerMacroTests.swift
+++ b/Tests/InnoDIMacrosTests/DIContainerMacroTests.swift
@@ -707,6 +707,136 @@ struct DIContainerMacroTests {
         )
     }
 
+    @Test("Lazy<T> cannot be called directly inside a shared factory body")
+    func lazyDirectCallInsideSharedFactoryFails() {
+        assertMacroExpansionDiagnosticCodes(
+            """
+            @DIContainer
+            struct AppContainer {
+                @Provide(.shared, factory: Service(), concrete: true)
+                var service: Service
+
+                @Provide(.shared, factory: { (service: Lazy<Service>) in
+                    ServiceHolder(service: service())
+                }, concrete: true)
+                var holder: ServiceHolder
+            }
+            """,
+            expectedCodes: [
+                MessageID(domain: "InnoDI.validation", id: "provide.lazy-eager-call")
+            ],
+            macros: Self.macros
+        )
+    }
+
+    @Test("Lazy<T>.callAsFunction() is also rejected inside a shared factory body")
+    func lazyCallAsFunctionInsideSharedFactoryFails() {
+        assertMacroExpansionDiagnosticCodes(
+            """
+            @DIContainer
+            struct AppContainer {
+                @Provide(.shared, factory: Service(), concrete: true)
+                var service: Service
+
+                @Provide(.shared, factory: { (service: Lazy<Service>) in
+                    ServiceHolder(service: service.callAsFunction())
+                }, concrete: true)
+                var holder: ServiceHolder
+            }
+            """,
+            expectedCodes: [
+                MessageID(domain: "InnoDI.validation", id: "provide.lazy-eager-call")
+            ],
+            macros: Self.macros
+        )
+    }
+
+    @Test("Parenthesized Lazy<T> calls are rejected inside a shared factory body")
+    func lazyParenthesizedCallInsideSharedFactoryFails() {
+        assertMacroExpansionDiagnosticCodes(
+            """
+            @DIContainer
+            struct AppContainer {
+                @Provide(.shared, factory: Service(), concrete: true)
+                var service: Service
+
+                @Provide(.shared, factory: { (service: Lazy<Service>) in
+                    ServiceHolder(service: (service)())
+                }, concrete: true)
+                var holder: ServiceHolder
+            }
+            """,
+            expectedCodes: [
+                MessageID(domain: "InnoDI.validation", id: "provide.lazy-eager-call")
+            ],
+            macros: Self.macros
+        )
+    }
+
+    @Test("Resolver-style Lazy<T> calls are rejected inside a shared factory body")
+    func lazyResolverCallInsideSharedFactoryFails() {
+        assertMacroExpansionDiagnosticCodes(
+            """
+            @DIContainer
+            struct AppContainer {
+                @Provide(.shared, factory: Service(), concrete: true)
+                var service: Service
+
+                @Provide(.shared, factory: { (service: Lazy<Service>) in
+                    ServiceHolder(service: service.resolver())
+                }, concrete: true)
+                var holder: ServiceHolder
+            }
+            """,
+            expectedCodes: [
+                MessageID(domain: "InnoDI.validation", id: "provide.lazy-eager-call")
+            ],
+            macros: Self.macros
+        )
+    }
+
+    @Test("Lazy<T> cannot be called directly inside an async shared factory body")
+    func lazyDirectCallInsideAsyncSharedFactoryFails() {
+        assertMacroExpansionDiagnosticCodes(
+            """
+            @DIContainer
+            struct AppContainer {
+                @Provide(.shared, factory: Service(), concrete: true)
+                var service: Service
+
+                @Provide(.shared, asyncFactory: { (service: Lazy<Service>) async in
+                    AsyncHolder(service: service())
+                }, concrete: true)
+                var holder: AsyncHolder
+            }
+            """,
+            expectedCodes: [
+                MessageID(domain: "InnoDI.validation", id: "provide.lazy-eager-call")
+            ],
+            macros: Self.macros
+        )
+    }
+
+    @Test("Lazy<T> direct calls remain allowed in transient factories")
+    func lazyDirectCallInsideTransientFactoryRemainsAllowed() {
+        assertMacroExpansionDiagnosticCodes(
+            """
+            @DIContainer
+            struct AppContainer {
+                @Provide(.shared, factory: Service(), concrete: true)
+                var service: Service
+
+                @Provide(.transient, factory: { (service: Lazy<Service>) in
+                    ServiceHolder(service: service())
+                }, concrete: true)
+                var holder: ServiceHolder
+            }
+            """,
+            expectedCodes: [],
+            macros: Self.macros
+        )
+    }
+
     @Test("Provider<T> cannot be called directly inside a shared factory body")
     func providerDirectCallInsideSharedFactoryFails() {
         assertMacroExpansionDiagnosticCodes(


### PR DESCRIPTION
## Summary

- Add `provide.lazy-eager-call` diagnostics for direct `Lazy<T>` calls inside `.shared` factory and asyncFactory bodies.
- Treat unknown `InnoDI-DependencyGraph` flags as parse failures so validation typos fail CI instead of silently rendering a graph.
- Move DAG validation plugin shared state to a package-level plugin output sibling and cover cache reuse with a multi-target SwiftPM integration test.
- Add the `InnoDIValidationTools` companion package scaffold for the optional prebuilt macOS validation plugin, including release artifact tooling and a fail-fast placeholder artifact.
- Clarify plugin attachment/opt-out docs, deferred-wrapper policy boundaries, cross-module sub-container diagnostics, release notes, and adoption guidance.

## Validation

- `swift test`
- `swift test -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- `swift run InnoDI-DependencyGraph --root . --validate-dag`
- `Tools/check-docs-code-blocks.sh`
- `Tools/check-localized-readme-sync.sh`
- `Tools/check-no-fatalerror-in-macros.sh`
- `Tools/measure-macro-performance.sh --report-only` exited 0; regression gate skipped because baseline Swift 6.3 differs from current Swift 6.3.1.
- Synthetic source/prebuilt consumer acceptance: source and prebuilt plugin paths both wrote DAG metrics/stamps, and the prebuilt path did not compile the source coordinator tool.
- `swift package describe --package-path InnoDIValidationTools`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 선택적 InnoDIValidationTools 동반 패키지로 사전 빌드된 macOS 검증 플러그인 제공
  * 플러그인이 대상별로 실행될 때 공유 상태 디렉터리의 재사용 지원

* **버그 수정**
  * 자식 컨테이너 경고에 부모/자식 매니페스트 경로 및 개선된 안내 추가
  * 미지정/알 수 없는 CLI 옵션이 경고 대신 오류로 처리되도록 변경

* **문서**
  * lazy/provider 호출 규칙 및 사용 가이드(다국어) 보강
  * 릴리스 아티팩트 준비 및 사용 안내 추가

* **잡무(Chores)**
  * 아티팩트 번들용 자리표시자와 릴리스 준비 스크립트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->